### PR TITLE
Explicitly avoid jsTest and jvmTest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build
-        run: ./gradlew build -x test
+        run: ./gradlew build -x test -x jvmTest -x jsTest
       - name: Unit Tests
         run: ./gradlew test
       - name: Lint


### PR DESCRIPTION
...in build action to prevent spurious unit test failure.

Issue: /story/show/174804483

Now we have CI rules that prevent me from just pushing changes to master.  This is a small tweak to CI to fix an issue in which a test fails only when building without tests.

Verified issue locally and fix locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
