### PR TITLE
Add caching to CI script

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Minor addition to enable caching of gradle data as recommended for gradle-based CI builds.  Taken from the rust-sdk CI workflow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
