### PR TITLE
Add serialization support for Maps with values of collection types

### DIFF
--- a/client-runtime/serde/common/src/software/aws/clientrt/serde/Serializer.kt
+++ b/client-runtime/serde/common/src/software/aws/clientrt/serde/Serializer.kt
@@ -270,6 +270,26 @@ interface MapSerializer : PrimitiveSerializer {
     fun entry(key: String, value: SdkSerializable?)
 
     /**
+     * Writes the field name given in the descriptor, and then
+     * serializes the list field using the given block.
+     *
+     * @param key
+     * @param listDescriptor
+     * @param block
+     */
+    fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit)
+
+    /**
+     * Writes the field name given in the descriptor, and then
+     * serializes the map field using the given block.
+     *
+     * @param key
+     * @param mapDescriptor
+     * @param block
+     */
+    fun mapEntry(key: String, mapDescriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit)
+
+    /**
      * Writes the key and then serializes the raw [value] without any additional escaping or formatting
      */
     fun rawEntry(key: String, value: String)

--- a/client-runtime/serde/serde-json/common/src/software/aws/clientrt/serde/json/JsonSerializer.kt
+++ b/client-runtime/serde/serde-json/common/src/software/aws/clientrt/serde/json/JsonSerializer.kt
@@ -161,6 +161,20 @@ class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructSerializ
         if (value != null) serializeChar(value) else jsonWriter.writeNull()
     }
 
+    override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
+        jsonWriter.writeName(key)
+        beginList(listDescriptor)
+        block.invoke(this)
+        endList()
+    }
+
+    override fun mapEntry(key: String, mapDescriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit) {
+        jsonWriter.writeName(key)
+        beginMap(mapDescriptor)
+        block.invoke(this)
+        endMap()
+    }
+
     override fun rawEntry(key: String, value: String) {
         jsonWriter.writeName(key)
         serializeRaw(value)

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
@@ -89,6 +89,86 @@ class JsonSerializerTest {
     }
 
     @Test
+    fun `can serialize map of lists`() {
+        val objs = mapOf(
+            "A1" to listOf("a", "b", "c"),
+            "A2" to listOf("d", "e", "f"),
+            "A3" to listOf("g", "h", "i")
+        )
+        val json = JsonSerializer()
+        json.serializeMap(ANONYMOUS_DESCRIPTOR) {
+            for (obj in objs) {
+                listEntry(obj.key, ANONYMOUS_DESCRIPTOR) {
+                    for (v in obj.value) {
+                        serializeString(v)
+                    }
+                }
+            }
+        }
+        assertEquals("""{"A1":["a","b","c"],"A2":["d","e","f"],"A3":["g","h","i"]}""", json.toByteArray().decodeToString())
+    }
+
+    @Test
+    fun `can serialize list of lists`() {
+        val objs = listOf(
+            listOf("a", "b", "c"),
+            listOf("d", "e", "f"),
+            listOf("g", "h", "i")
+        )
+        val json = JsonSerializer()
+        json.serializeList(ANONYMOUS_DESCRIPTOR) {
+            for (obj in objs) {
+                json.serializeList(ANONYMOUS_DESCRIPTOR) {
+                    for (v in obj) {
+                        serializeString(v)
+                    }
+                }
+            }
+        }
+        assertEquals("""[["a","b","c"],["d","e","f"],["g","h","i"]]""", json.toByteArray().decodeToString())
+    }
+
+    @Test
+    fun `can serialize list of maps`() {
+        val objs = listOf(
+            mapOf("a" to "b", "c" to "d"),
+            mapOf("e" to "f", "g" to "h"),
+            mapOf("i" to "j", "k" to "l"),
+        )
+        val json = JsonSerializer()
+        json.serializeList(ANONYMOUS_DESCRIPTOR) {
+            for (obj in objs) {
+                json.serializeMap(ANONYMOUS_DESCRIPTOR) {
+                    for (v in obj) {
+                        entry(v.key, v.value)
+                    }
+                }
+            }
+        }
+        assertEquals("""[{"a":"b","c":"d"},{"e":"f","g":"h"},{"i":"j","k":"l"}]""", json.toByteArray().decodeToString())
+    }
+
+    @Test
+    fun `can serialize map of maps`() {
+        val objs = mapOf(
+            "A1" to mapOf("a" to "b", "c" to "d"),
+            "A2" to mapOf("e" to "f", "g" to "h"),
+            "A3" to mapOf("i" to "j", "k" to "l"),
+        )
+        val json = JsonSerializer()
+        json.serializeMap(ANONYMOUS_DESCRIPTOR) {
+            for (obj in objs) {
+                mapEntry(obj.key, ANONYMOUS_DESCRIPTOR) {
+                    for (v in obj.value) {
+                        entry(v.key, v.value)
+                    }
+                }
+            }
+        }
+        assertEquals("""{"A1":{"a":"b","c":"d"},"A2":{"e":"f","g":"h"},"A3":{"i":"j","k":"l"}}""", json.toByteArray().decodeToString())
+    }
+
+    @Test
     fun `can serialize all primitives`() {
         val json = JsonSerializer()
         data.serialize(json)

--- a/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
+++ b/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
@@ -196,6 +196,22 @@ private class XmlMapSerializer(
 
     override fun entry(key: String, value: Char?) = generalEntry(key) { xmlWriter.text(value.toString()) }
 
+    override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
+        generalEntry(key) {
+            val ls = xmlSerializer.beginList(listDescriptor)
+            block.invoke(ls)
+            ls.endList()
+        }
+    }
+
+    override fun mapEntry(key: String, mapDescriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit) {
+        generalEntry(key) {
+            val ls = xmlSerializer.beginMap(mapDescriptor)
+            block.invoke(ls)
+            ls.endMap()
+        }
+    }
+
     override fun rawEntry(key: String, value: String) {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
*Issue #, if available:* /story/show/175665924

## Description of changes:

This PR add support of serializing nested Maps and Lists as values of outer Maps, by adding `listEntry()` and `mapEntry()` functions on the MapSerializer type.  For completeness, additional unit tests were added to exercise a couple other collection use cases.  A follow-up PR for codegen to use this new functionality from smithy-kotlin codegen.

## Testing Done:
* Unit tests pass
* Manually verify serialization output produces expected result


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
