### PR TITLE
fix: missed changing test result collection for some integration tests

### DIFF
--- a/smithy-kotlin-integration-test/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
+++ b/smithy-kotlin-integration-test/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
@@ -143,7 +143,9 @@ class ApiEvolutionTest {
             }
         """.trimIndent()
 
-        assertTrue(testModelChangeAgainstSource(modelV1, modelV2, customerCode).compileSuccess)
+        testModelChangeAgainstSource(modelV1, modelV2, customerCode, copyGeneratedSdksToTmp).let { result ->
+            assertTrue(result.compileSuccess, result.compileOutput)
+        }
     }
 
     // This currently failed because we do not generate model or transforms for operations without inputs or outputs, yet
@@ -210,7 +212,9 @@ class ApiEvolutionTest {
             }
         """.trimIndent()
 
-        assertTrue(testModelChangeAgainstSource(modelV1, modelV2, customerCode, copyGeneratedSdksToTmp).compileSuccess)
+        testModelChangeAgainstSource(modelV1, modelV2, customerCode, copyGeneratedSdksToTmp).let { result ->
+            assertTrue(result.compileSuccess, result.compileOutput)
+        }
     }
 
     @Test
@@ -274,6 +278,8 @@ class ApiEvolutionTest {
             
         """.trimIndent()
 
-        assertTrue(testModelChangeAgainstSource(modelV1, modelV2, customerCode, copyGeneratedSdksToTmp).compileSuccess)
+        testModelChangeAgainstSource(modelV1, modelV2, customerCode, copyGeneratedSdksToTmp).let { result ->
+            assertTrue(result.compileSuccess, result.compileOutput)
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I updated some code from feedback in last CR but forgot to apply to all tests.

## Testing Done

* Unit tests work as before, except log emissions from compiler are now part of each test run instead of just emitted to console.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
