### PR TITLE
Cleanup serialization api relating to null values

### DIFF
--- a/client-runtime/serde/common/src/software/aws/clientrt/serde/Serializer.kt
+++ b/client-runtime/serde/common/src/software/aws/clientrt/serde/Serializer.kt
@@ -41,7 +41,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Boolean?)
+    fun field(descriptor: SdkFieldDescriptor, value: Boolean)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -50,7 +50,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Byte?)
+    fun field(descriptor: SdkFieldDescriptor, value: Byte)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -59,7 +59,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Short?)
+    fun field(descriptor: SdkFieldDescriptor, value: Short)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -68,7 +68,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Char?)
+    fun field(descriptor: SdkFieldDescriptor, value: Char)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -77,7 +77,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Int?)
+    fun field(descriptor: SdkFieldDescriptor, value: Int)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -86,7 +86,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Long?)
+    fun field(descriptor: SdkFieldDescriptor, value: Long)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -95,7 +95,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Float?)
+    fun field(descriptor: SdkFieldDescriptor, value: Float)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -104,7 +104,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Double?)
+    fun field(descriptor: SdkFieldDescriptor, value: Double)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -113,7 +113,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: String?)
+    fun field(descriptor: SdkFieldDescriptor, value: String)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -156,6 +156,12 @@ interface StructSerializer : PrimitiveSerializer {
      * the raw [value] without any additional escaping or formatting
      */
     fun rawField(descriptor: SdkFieldDescriptor, value: String)
+
+    /**
+     * Writes the field name given in the descriptor, and then
+     * serializes null.
+     */
+    fun nullField(descriptor: SdkFieldDescriptor)
 
     /**
      * Ends the struct that was started (i.e. in JSON this would be a '}').

--- a/client-runtime/serde/serde-json/common/src/software/aws/clientrt/serde/json/JsonSerializer.kt
+++ b/client-runtime/serde/serde-json/common/src/software/aws/clientrt/serde/json/JsonSerializer.kt
@@ -46,54 +46,59 @@ class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructSerializ
         value.serialize(this)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Int?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Int) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeInt(value) else serializeNull()
+        serializeInt(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Long?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Long) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeLong(value) else serializeNull()
+        serializeLong(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Float?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Float) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeFloat(value) else serializeNull()
+        serializeFloat(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: String?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: String) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeString(value) else serializeNull()
+        serializeString(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Double?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Double) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeDouble(value) else serializeNull()
+        serializeDouble(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Boolean?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Boolean) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeBoolean(value) else serializeNull()
+        serializeBoolean(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Byte?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Byte) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeByte(value) else serializeNull()
+        serializeByte(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Short?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Short) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeShort(value) else serializeNull()
+        serializeShort(value)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Char?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Char) {
         jsonWriter.writeName(descriptor.serialName)
-        if (value != null) serializeChar(value) else serializeNull()
+        serializeChar(value)
     }
 
     override fun rawField(descriptor: SdkFieldDescriptor, value: String) {
         jsonWriter.writeName(descriptor.serialName)
         serializeRaw(value)
+    }
+
+    override fun nullField(descriptor: SdkFieldDescriptor) {
+        jsonWriter.writeName(descriptor.serialName)
+        serializeNull()
     }
 
     override fun structField(descriptor: SdkFieldDescriptor, block: StructSerializer.() -> Unit) {

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
@@ -188,7 +188,6 @@ data class Primitives(
     val double: Double,
     val char: Char,
     val string: String,
-    val unitNullable: Unit?,
     val listInt: List<Int>
 ) : SdkSerializable {
     companion object {
@@ -207,7 +206,7 @@ data class Primitives(
     override fun serialize(serializer: Serializer) {
         serializer.serializeStruct(ANONYMOUS_DESCRIPTOR) {
             field(descriptorBoolean, boolean)
-            field(descriptorBoolean, null as Boolean?)
+            nullField(descriptorBoolean)
             field(descriptorByte, byte)
             field(descriptorShort, short)
             field(descriptorInt, int)
@@ -227,5 +226,5 @@ data class Primitives(
 
 val data = Primitives(
     Unit, true, 10, 20, 30, 40, 50f, 60.0, 'A', "Str0",
-    null, listOf(1, 2, 3)
+    listOf(1, 2, 3)
 )

--- a/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
+++ b/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
@@ -43,62 +43,68 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
 
     override fun field(descriptor: SdkFieldDescriptor, value: SdkSerializable) = value.serialize(this)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Int?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Int) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeInt(value) else serializeNull()
+        serializeInt(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Long?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Long) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeLong(value) else serializeNull()
+        serializeLong(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Float?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Float) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeFloat(value) else serializeNull()
+        serializeFloat(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: String?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: String) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeString(value) else serializeNull()
+        serializeString(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Double?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Double) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeDouble(value) else serializeNull()
+        serializeDouble(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Boolean?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Boolean) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeBoolean(value) else serializeNull()
+        serializeBoolean(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Byte?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Byte) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeByte(value) else serializeNull()
+        serializeByte(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Short?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Short) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeShort(value) else serializeNull()
+        serializeShort(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Char?) {
+    override fun field(descriptor: SdkFieldDescriptor, value: Char) {
         xmlWriter.startTag(descriptor.serialName)
-        if (value != null) serializeChar(value) else serializeNull()
+        serializeChar(value)
         xmlWriter.endTag(descriptor.serialName)
     }
 
     override fun rawField(descriptor: SdkFieldDescriptor, value: String) {
         TODO("Not yet implemented")
+    }
+
+    override fun nullField(descriptor: SdkFieldDescriptor) {
+        xmlWriter.startTag(descriptor.serialName)
+        serializeNull()
+        xmlWriter.endTag(descriptor.serialName)
     }
 
     override fun structField(descriptor: SdkFieldDescriptor, block: StructSerializer.() -> Unit) {
@@ -244,7 +250,7 @@ private class XmlMapSerializer(
         TODO("Not yet implemented")
     }
 
-    private fun serializePrimitive(value: Any?) {
+    private fun serializePrimitive(value: Any) {
         val nodeName = descriptor.expectTrait<XmlMap>().valueName
         xmlWriter.startTag(nodeName)
         xmlWriter.text(value?.toString() ?: "") // NOTE: this may not be the correct serialization format for `null`
@@ -290,7 +296,7 @@ private class XmlListSerializer(
         TODO("Not yet implemented")
     }
 
-    private fun serializePrimitive(value: Any?) {
+    private fun serializePrimitive(value: Any) {
         val nodeName = descriptor.expectTrait<XmlList>().elementName
         xmlWriter.startTag(nodeName)
         xmlWriter.text(value?.toString() ?: "") // NOTE: this may not be the correct serialization format for `null`


### PR DESCRIPTION
Refactor serialization interface and implementations to handle null values explicitly.

*Issue #, if available:* #176182268

## Description of changes
This is a follow up task to the sparse feature work and general refactoring of serde/codegen's treatement of null values in smithy-kotlin.  The change makes null handling explicit rather than allowing nullable values to be passed into serialization implementations.  This task seems relatively small in scope, the protocol tests pass without any changes in codegen.  [Looking around in the Java SDK](https://github.com/aws/aws-sdk-java-v2/blob/master/core/protocols/aws-json-protocol/src/main/java/software/amazon/awssdk/protocols/json/internal/marshall/SimpleTypeJsonMarshaller.java#L37-L45) to confirm behavior, it appears that our current strategy of only serializing non-null values of objects means that in practice we do not need to explicitly serialize null values of request types.

I'm not sure that the `nullField()` is required.  It's not currently used but I can't rule out that we will need to be explicitly serializing null values at some point so am leaving it for now.

## Testing done
* smithy-kotlin unit tests pass
* Protocol tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
