### PR TITLE
Removing spaces from test method names so it plays nicely with JS

### DIFF
--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/DocumentBuilderTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/DocumentBuilderTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 
 class DocumentBuilderTest {
     @Test
-    fun `builds an object`() {
+    fun buildsAnObject() {
         val doc = document {
             "foo" to 1
             "baz" to documentArray {

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/config/IdempotencyTokenTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/config/IdempotencyTokenTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class IdempotencyTokenTest {
 
     @Test
-    fun `default idempotencyTokenProvider implementation returns a different token with each call`() {
+    fun defaultIdempotencyTokenProviderImplementationReturnsADifferentTokenWithEachCall() {
         val token1 = IdempotencyTokenProvider.Default.generateToken()
         val token2 = IdempotencyTokenProvider.Default.generateToken()
 
@@ -15,6 +15,6 @@ class IdempotencyTokenTest {
     }
 
     @Test
-    fun `default idempotencyTokenProvider implementation returns non empty token`() =
+    fun defaultIdempotencyTokenProviderImplementationReturnsNonEmptyToken() =
         assertTrue(IdempotencyTokenProvider.Default.generateToken().isNotEmpty())
 }

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/content/ByteArrayContentTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/content/ByteArrayContentTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 class ByteArrayContentTest {
     @Test
-    fun `it can be consumed as ByteStream`() {
+    fun itCanBeConsumedAsByteStream() {
         val actual = byteArrayOf(0x01, 0x02, 0x03)
         val content = ByteArrayContent(actual)
         assertEquals(3, content.contentLength)

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/content/StringContentTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/content/StringContentTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 class StringContentTest {
     @Test
-    fun `it can be consumed as ByteStream`() {
+    fun itCanBeConsumedAsByteStream() {
         val content = StringContent("testing")
         assertEquals(7, content.contentLength)
         val expected = byteArrayOf(0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67)
@@ -25,7 +25,7 @@ class StringContentTest {
     }
 
     @Test
-    fun `it handles UTF-8`() {
+    fun itHandlesUTF8() {
         val content = StringContent("你好")
         content.bytes().forEach { print("$it ") }
         assertEquals(6, content.contentLength)

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/InstantTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/InstantTest.kt
@@ -44,7 +44,7 @@ class InstantTest {
     )
 
     @Test
-    fun `test fromIso8601`() {
+    fun testFromIso8601() {
         for ((idx, test) in iso8601Tests.withIndex()) {
             val actual = Instant.fromIso8601(test.input)
             assertEquals(test.expectedSec, actual.epochSeconds, "test[$idx]: failed to correctly parse ${test.input}")
@@ -62,7 +62,7 @@ class InstantTest {
         FmtTest(1604650057, 0, "2020-11-06T08:07:37Z")
     )
     @Test
-    fun `test format as iso8601`() {
+    fun testFormatAsIso8601() {
         for ((idx, test) in iso8601FmtTests.withIndex()) {
             val actual = Instant
                 .fromEpochSeconds(test.sec, test.ns)
@@ -81,7 +81,7 @@ class InstantTest {
         FromTest("Thu, 05 Nov 2020 19:22:37 -1245", 1604650057, 0)
     )
     @Test
-    fun `test fromRfc5322`() {
+    fun testFromRfc5322() {
         for ((idx, test) in rfc5322Tests.withIndex()) {
             val actual = Instant.fromRfc5322(test.input)
             assertEquals(test.expectedSec, actual.epochSeconds, "test[$idx]: failed to correctly parse ${test.input}")
@@ -97,7 +97,7 @@ class InstantTest {
         FmtTest(1604650057, 0, "Fri, 06 Nov 2020 08:07:37 GMT")
     )
     @Test
-    fun `test format as rfc5322`() {
+    fun testFormatAsRfc5322() {
         for ((idx, test) in rfc5322FmtTests.withIndex()) {
             val actual = Instant
                 .fromEpochSeconds(test.sec, test.ns)
@@ -115,7 +115,7 @@ class InstantTest {
     )
 
     @Test
-    fun `test format as epoch seconds`() {
+    fun testFormatAsEpochSeconds() {
         for ((idx, test) in epochFmtTests.withIndex()) {
             val actual = Instant
                 .fromEpochSeconds(test.sec, test.ns)
@@ -125,7 +125,7 @@ class InstantTest {
     }
 
     @Test
-    fun `test toEpochDouble`() {
+    fun testToEpochDouble() {
         val sec = 1604604157L
         val ns = 12_345_000
         val actual = Instant.fromEpochSeconds(sec, ns).toEpochDouble()
@@ -135,7 +135,7 @@ class InstantTest {
     }
 
     @Test
-    fun `test get current time`() {
+    fun testGetCurrentTime() {
         val currentTime = Instant.now()
 
         val pastInstant = 1602099269 // 2020-10-07T19:34:29+00:00
@@ -144,7 +144,7 @@ class InstantTest {
     }
 
     @Test
-    fun `test get epoch milliseconds`() {
+    fun testGetEpochMilliseconds() {
         val instant = Instant.fromEpochSeconds(1602878160, 2_000_00)
         val expected = 1602878160000L
         assertEquals(expected, instant.epochMilliseconds)
@@ -158,7 +158,7 @@ class InstantTest {
     // Always good to learn from others...
     class V2JavaSdkTests {
         @Test
-        fun `v2 java sdk tt0031561767`() {
+        fun v2JavaSdkTt0031561767() {
             val input = "Fri, 16 May 2014 23:56:46 GMT"
             val instant: Instant = Instant.fromRfc5322(input)
             assertEquals(input, instant.format(TimestampFormat.RFC_5322))
@@ -169,7 +169,7 @@ class InstantTest {
          * same before and after marshalling/unmarshalling
          */
         @Test
-        fun `v2 java sdk UnixTimestampRoundtrip`() {
+        fun v2JavaSdkUnixTimestampRoundtrip() {
             // v2 sdk used currentTimeMillis(), instead we just hard code a value here
             // otherwise that would be a JVM specific test since since we do not (yet) have
             // a Kotlin MPP way of getting current timestamp. Also obviously not using epoch mill

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseEpochTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseEpochTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 
 class ParseEpochTest {
     @Test
-    fun `it parses epoch timestamps`() {
+    fun itParsesEpochTimestamps() {
         val tests = listOf(
             Triple("0", 0L, 0),
             Triple("1200", 1200L, 0),

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseIso8601Test.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseIso8601Test.kt
@@ -39,7 +39,7 @@ class ParseIso8601Test {
     )
 
     @Test
-    fun `it parses extended format timestamps`() {
+    fun itParsesExtendedFormatTimestamps() {
         for ((idx, test) in extendedFmtTests.withIndex()) {
             val actual = parseIso8601(test.input)
             assertEquals(test.expected, actual, "test[$idx]: failed to correctly parse ${test.input}")
@@ -60,7 +60,7 @@ class ParseIso8601Test {
     )
 
     @Test
-    fun `it parses basic format timestamps`() {
+    fun itParsesBasicFormatTimestamps() {
         for ((idx, test) in basicFmtTests.withIndex()) {
             val actual = parseIso8601(test.input)
             assertEquals(test.expected, actual, "test[$idx]: failed to correctly parse ${test.input}")
@@ -94,7 +94,7 @@ class ParseIso8601Test {
     )
 
     @Test
-    fun `it rejects invalid extended timestamps`() {
+    fun itRejectsInvalidExtendedTimestamps() {
         for ((idx, test) in invalidTimestamps.withIndex()) {
             val ex = assertFailsWith<ParseException>("test[$idx]: expected exception parsing ${test.input}") {
                 parseIso8601(test.input)

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseRfc5322Test.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParseRfc5322Test.kt
@@ -37,7 +37,7 @@ class ParseRfc5322Test {
     )
 
     @Test
-    fun `it parses rfc5322 timestamps`() {
+    fun itParsesRfc5322Timestamps() {
         for ((idx, test) in validTests.withIndex()) {
             val actual = parseRfc5322(test.input)
             assertEquals(test.expected, actual, "test[$idx]: failed to correctly parse ${test.input}")
@@ -45,7 +45,7 @@ class ParseRfc5322Test {
     }
 
     @Test
-    fun `it parses all valid day names`() {
+    fun itParsesAllValidDayNames() {
         val validDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
         for (day in validDays) {
             val input = "$day, 06 Nov 1994 08:49:37 GMT"
@@ -56,7 +56,7 @@ class ParseRfc5322Test {
     }
 
     @Test
-    fun `it parses all valid month names`() {
+    fun itParsesAllValidMonthNames() {
         val validMonths = listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
         for ((idx, month) in validMonths.withIndex()) {
             val input = "Mon, 06 $month 1994 08:49:37 GMT"
@@ -90,7 +90,7 @@ class ParseRfc5322Test {
     )
 
     @Test
-    fun `it rejects invalid timestamps`() {
+    fun itRejectsInvalidTimestamps() {
         for ((idx, test) in invalidTimestamps.withIndex()) {
             val ex = assertFailsWith<ParseException>("test[$idx]: expected exception parsing ${test.input}") {
                 parseRfc5322(test.input)

--- a/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParserCombinatorsTest.kt
+++ b/client-runtime/client-rt-core/common/test/software/aws/clientrt/time/ParserCombinatorsTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 class ParsersTest {
 
     @Test
-    fun `test takeWhileMN`() {
+    fun testTakeWhileMN() {
         assertEquals(ParseResult(5, IntRange(0, 4)), takeWhileMN(5, 5, ::isDigit)("12345abcde", 0))
         assertEquals(ParseResult(2, IntRange(0, 1)), takeWhileMN(1, 2, ::isDigit)("12345abcde", 0))
 
@@ -35,7 +35,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test takeMNDigits`() {
+    fun testTakeMNDigits() {
         assertEquals(ParseResult(2, 22), takeNDigits(2)("22", 0))
         assertEquals(ParseResult(8, 227), takeMNDigitsInt(2, 3)("abcde22759fge", 5))
         assertEquals(ParseResult(14, 123456789), takeMNDigitsInt(1, 9)("abcde123456789fge", 5))
@@ -50,7 +50,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test mnDigitsInRange`() {
+    fun testMnDigitsInRange() {
         assertEquals(ParseResult(2, 22), nDigitsInRange(2, IntRange(0, 30))("22", 0))
         // boundary of range
         assertEquals(ParseResult(8, 227), mnDigitsInRange(2, 3, IntRange(227, 227))("abcde22759fge", 5))
@@ -65,7 +65,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test chars`() {
+    fun testChars() {
         assertEquals('x', char('x')("abcxyz", 3).result)
 
         val ex = assertFailsWith<ParseException> { char('x')("abcxyz", 2) }
@@ -73,7 +73,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test tag`() {
+    fun testTag() {
         assertEquals(ParseResult(5, "xy"), tag("xy")("abcxyz", 3))
 
         val ex = assertFailsWith<ParseException> { tag("bcxz")("abcxyz", 1) }
@@ -84,7 +84,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test oneOf`() {
+    fun testOneOf() {
         assertEquals('x', oneOf("yzxa")("abcxyz", 3).result)
 
         var ex = assertFailsWith<ParseException> { oneOf("yzxa")("abcxyz", 2) }
@@ -92,7 +92,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test fraction`() {
+    fun testFraction() {
         assertEquals(ParseResult(1, 3), fraction(1, 1, 1)("345", 0))
 
         assertEquals(ParseResult(3, 345), fraction(1, 3, 3)("345", 0))
@@ -105,7 +105,7 @@ class ParsersTest {
     }
 
     @Test
-    fun `test takeTill`() {
+    fun testTakeTill() {
         assertEquals(ParseResult(5, IntRange(0, 4)), takeTill(::isDigit)("abcde12345", 0))
         assertEquals(ParseResult(5, IntRange(2, 4)), takeTill(::isDigit)("abcde1", 2))
 
@@ -119,14 +119,14 @@ class ParsersTest {
 
 class CombinatorTest {
     @Test
-    fun `test optional`() {
+    fun testOptional() {
         assertEquals(ParseResult(0, null), optional(char('x'))("abc", 0))
         // should consume a character
         assertEquals(ParseResult(1, 'x'), optional(char('x'))("xyz", 0))
     }
 
     @Test
-    fun `test alt`() {
+    fun testAlt() {
         assertEquals(ParseResult(1, 'y'), alt(char('x'), char('y'))("yup", 0))
 
         val ex = assertFails {
@@ -136,7 +136,7 @@ class CombinatorTest {
     }
 
     @Test
-    fun `test preceded`() {
+    fun testPreceded() {
         assertEquals(ParseResult(2, 'y'), preceded(char('x'), char('y'))("xyz", 0))
 
         // with optional
@@ -145,7 +145,7 @@ class CombinatorTest {
     }
 
     @Test
-    fun `test map`() {
+    fun testMap() {
         val result = map(alt(char('+'), char('-'))) {
             when (it) {
                 '-' -> -1
@@ -156,14 +156,14 @@ class CombinatorTest {
     }
 
     @Test
-    fun `test cond`() {
+    fun testCond() {
         assertEquals(ParseResult(0, null), cond(false, char('x'))("abc", 0))
         // should consume a character
         assertEquals(ParseResult(1, 'x'), cond(true, char('x'))("xyz", 0))
     }
 
     @Test
-    fun `test then`() {
+    fun testThen() {
         assertEquals(ParseResult(2, Pair('x', 'y')), char('x').then(char('y'))("xyz", 0))
     }
 }

--- a/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/software/aws/clientrt/http/engine/ktor/KtorRequestAdapterTest.kt
+++ b/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/software/aws/clientrt/http/engine/ktor/KtorRequestAdapterTest.kt
@@ -22,7 +22,7 @@ import io.ktor.content.ByteArrayContent as KtorByteArrayContent
 
 class KtorRequestAdapterTest {
     @Test
-    fun `it strips Content-Type header`() = runBlocking {
+    fun itStripsContentTypeHeader() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/json")
@@ -31,7 +31,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it converts HttpBody variant Bytes`() = runBlocking {
+    fun itConvertsHttpBodyVariantBytes() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/json")
@@ -45,7 +45,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it converts HttpBody variant Streaming`() = runBlocking {
+    fun itConvertsHttpBodyVariantStreaming() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")
@@ -59,7 +59,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it transfers a Streaming body`() = runBlocking {
+    fun itTransfersAStreamingBody() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")
@@ -78,7 +78,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it handles partial Stream reads`() = runBlocking {
+    fun itHandlesPartialStreamReads() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")
@@ -97,7 +97,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it handles Stream backpressure`() = runBlocking {
+    fun itHandlesStreamBackpressure() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")
@@ -137,7 +137,7 @@ class KtorRequestAdapterTest {
     }
 
     @Test
-    fun `it handles Stream cancellation`() = runBlocking {
+    fun itHandlesStreamCancellation() = runBlocking {
         val sdkBuilder = HttpRequestBuilder()
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")

--- a/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/software/aws/clientrt/http/engine/ktor/KtorUtilsTest.kt
+++ b/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/software/aws/clientrt/http/engine/ktor/KtorUtilsTest.kt
@@ -43,7 +43,7 @@ class MockHttpResponse : HttpResponse() {
 class KtorUtilsTest {
 
     @Test
-    fun `it converts request builders`() {
+    fun itConvertsRequestBuilders() {
         val builder = HttpRequestBuilder()
         builder.method = software.aws.clientrt.http.HttpMethod.POST
         builder.url {
@@ -73,7 +73,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `it converts responses`() {
+    fun itConvertsResponses() {
         val builder = HttpRequestBuilder()
         builder.method = software.aws.clientrt.http.HttpMethod.POST
         builder.url {
@@ -89,7 +89,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `ktor headers are wrapped`() {
+    fun ktorHeadersAreWrapped() {
         val respHeaders = Headers.build {
             append("foo", "bar")
             append("baz", "quux")
@@ -107,7 +107,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `ktor headers are copied`() {
+    fun ktorHeadersAreCopied() {
         val respHeaders = Headers.build {
             append("foo", "bar")
             append("baz", "quux")
@@ -126,7 +126,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `KtorContentStream notifies on readAll`() = runBlocking {
+    fun KtorContentStreamNotifiesOnReadAll() = runBlocking {
         val channel = ByteChannel(true)
         var called = false
         val notify = {
@@ -144,7 +144,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `KtorContentStream notifies on readAvailable`() = runBlocking {
+    fun KtorContentStreamNotifiesOnReadAvailable() = runBlocking {
         val channel = ByteChannel(true)
         var called = false
         val notify = {
@@ -166,7 +166,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `KtorContentStream notifies on readFully`() = runBlocking {
+    fun KtorContentStreamNotifiesOnReadFully() = runBlocking {
         val channel = ByteChannel(true)
         var called = false
         val notify = {
@@ -186,7 +186,7 @@ class KtorUtilsTest {
     }
 
     @Test
-    fun `KtorContentStream notifies on cancel`() = runBlocking {
+    fun KtorContentStreamNotifiesOnCancel() = runBlocking {
         val channel = ByteChannel(true)
         var called = false
         val notify = {

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HeadersTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HeadersTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 class HeadersTest {
 
     @Test
-    fun `it builds`() {
+    fun itBuilds() {
         val actual = Headers {
             append("key1", "v1")
             appendAll("key2", listOf("v2", "v3"))

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpClientConfigTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpClientConfigTest.kt
@@ -35,7 +35,7 @@ class TestFeature(val name: String) : Feature {
 
 class HttpClientConfigTest {
     @Test
-    fun `it configures features on install`() {
+    fun itConfiguresFeaturesOnInstall() {
         val config = HttpClientConfig()
         var called = false
         config.install(TestFeature) {
@@ -46,7 +46,7 @@ class HttpClientConfigTest {
     }
 
     @Test
-    fun `it allows features to install on client`() {
+    fun itAllowsFeaturesToInstallOnClient() {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse {
                 TODO("test engine")

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpMethodTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpMethodTest.kt
@@ -10,13 +10,13 @@ import kotlin.test.assertFails
 
 class HttpMethodTest {
     @Test
-    fun `string representation`() {
+    fun stringRepresentation() {
         assertEquals("GET", HttpMethod.GET.name)
         assertEquals("POST", HttpMethod.POST.toString())
     }
 
     @Test
-    fun `it parses`() {
+    fun itParses() {
         assertEquals(
             HttpMethod.GET,
             HttpMethod.parse("get")

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpRequestBuilderTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpRequestBuilderTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 
 class HttpRequestBuilderTest {
     @Test
-    fun `it builds`() {
+    fun itBuilds() {
         val builder = HttpRequestBuilder()
         builder.headers {
             append("x-foo", "bar")

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpStatusCodeTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/HttpStatusCodeTest.kt
@@ -8,26 +8,26 @@ import kotlin.test.*
 
 class HttpStatusCodeTest {
     @Test
-    fun `is success`() {
+    fun isSuccess() {
         assertTrue(HttpStatusCode.OK.isSuccess())
         assertTrue(HttpStatusCode(299, "").isSuccess())
         assertFalse(HttpStatusCode(300, "").isSuccess())
     }
 
     @Test
-    fun `from value`() {
+    fun fromValue() {
         assertEquals(HttpStatusCode.OK, HttpStatusCode.fromValue(200))
         assertEquals(HttpStatusCode(3001, "").value, HttpStatusCode.fromValue(3001).value)
     }
 
     @Test
-    fun `it can match categories`() {
+    fun itCanMatchCategories() {
         assertEquals(HttpStatusCode.OK.category(), HttpStatusCode.Accepted.category())
         assertNotEquals(HttpStatusCode.NotFound.category(), HttpStatusCode.BadGateway.category())
     }
 
     @Test
-    fun `it fails with invalid http codes`() {
+    fun itFailsWithInvalidHttpCodes() {
         assertFailsWith<IllegalStateException>("Invalid HTTP code 999") {
             HttpStatusCode.Category.fromCode(999)
         }

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/PipelineTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/PipelineTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertEquals
 class PipelineTest {
 
     @Test
-    fun `request pipeline runs`() = runSuspendTest {
+    fun requestPipelineRuns() = runSuspendTest {
         val pipeline = HttpRequestPipeline()
         pipeline.intercept(HttpRequestPipeline.Initialize) { subject.headers.append("key", "1") }
         pipeline.intercept(HttpRequestPipeline.Transform) { subject.headers.append("key", "2") }
@@ -33,7 +33,7 @@ class PipelineTest {
     }
 
     @Test
-    fun `response pipeline runs`() = runSuspendTest {
+    fun responsePipelineRuns() = runSuspendTest {
         val pipeline = HttpResponsePipeline()
         pipeline.intercept(HttpResponsePipeline.Receive) { proceedWith((subject as Int) + 1) }
         pipeline.intercept(HttpResponsePipeline.Transform) { proceedWith((subject as Int) + 1) }
@@ -49,7 +49,7 @@ class PipelineTest {
     }
 
     @Test
-    fun `functions can be used`() = runSuspendTest {
+    fun functionsCanBeUsed() = runSuspendTest {
         val pipeline = HttpResponsePipeline()
 
         suspend fun freeFunc(ctx: PipelineContext<Any, HttpResponseContext>) {

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/PreparedHttpRequestTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/PreparedHttpRequestTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.Test
 class PreparedHttpRequestTest {
 
     @Test
-    fun `it runs the pipelines`() = runSuspendTest {
+    fun itRunsThePipelines() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse {
                 val req = requestBuilder.build()
@@ -56,7 +56,7 @@ class PreparedHttpRequestTest {
     }
 
     @Test
-    fun `it throws transform failed`(): Unit = runSuspendTest {
+    fun itThrowsTransformFailed(): Unit = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse {
                 val req = requestBuilder.build()

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/QueryParametersTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/QueryParametersTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 class QueryParametersTest {
 
     @Test
-    fun `it builds`() {
+    fun itBuilds() {
         val params = QueryParameters {
             append("foo", "baz")
             appendAll("foo", listOf("bar", "quux"))
@@ -30,7 +30,7 @@ class QueryParametersTest {
     }
 
     @Test
-    fun `it encodes to query string`() {
+    fun itEncodesToQueryString() {
         data class QueryParamTest(val params: QueryParameters, val expected: String)
         val tests: List<QueryParamTest> = listOf(
             QueryParamTest(

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/UrlTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/UrlTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFails
 
 class UrlTest {
     @Test
-    fun `basic to string`() {
+    fun basicToString() {
         val expected = "https://test.aws.com/kotlin"
         val url = Url(
             Protocol.HTTPS,
@@ -21,7 +21,7 @@ class UrlTest {
     }
 
     @Test
-    fun `force retain query`() {
+    fun forceRetainQuery() {
         val expected = "https://test.aws.com/kotlin?"
         val url = UrlBuilder {
             host = "test.aws.com"
@@ -32,7 +32,7 @@ class UrlTest {
     }
 
     @Test
-    fun `with parameters`() {
+    fun withParameters() {
         val expected = "https://test.aws.com/kotlin?baz=quux&baz=qux&foo=bar"
         val params = QueryParameters {
             append("foo", "bar")
@@ -49,7 +49,7 @@ class UrlTest {
     }
 
     @Test
-    fun `specific port`() {
+    fun specificPort() {
         val expected = "https://test.aws.com:8000"
         val url = Url(
             Protocol.HTTPS,
@@ -68,7 +68,7 @@ class UrlTest {
     }
 
     @Test
-    fun `port range`() {
+    fun portRange() {
         fun checkPort(n: Int) {
             assertEquals(
                 n,
@@ -88,7 +88,7 @@ class UrlTest {
     }
 
     @Test
-    fun `userinfo no password`() {
+    fun userinfoNoPassword() {
         val expected = "https://user@test.aws.com"
         val url = UrlBuilder {
             scheme = Protocol.HTTPS
@@ -99,7 +99,7 @@ class UrlTest {
     }
 
     @Test
-    fun `full userinfo`() {
+    fun fullUserinfo() {
         val expected = "https://user:password@test.aws.com"
         val url = UrlBuilder {
             scheme = Protocol.HTTPS
@@ -110,7 +110,7 @@ class UrlTest {
     }
 
     @Test
-    fun `it builds`() {
+    fun itBuilds() {
         val builder = UrlBuilder()
         builder.scheme = Protocol.HTTP
         builder.host = "test.aws.com"
@@ -126,7 +126,7 @@ class UrlTest {
     }
 
     @Test
-    fun `it builds with non default port`() {
+    fun itBuildsWithNonDefaultPort() {
         val url = UrlBuilder {
             scheme = Protocol.HTTP
             host = "test.aws.com"
@@ -138,7 +138,7 @@ class UrlTest {
     }
 
     @Test
-    fun `it builds with parameters`() {
+    fun itBuildsWithParameters() {
         val url = UrlBuilder {
             scheme = Protocol.HTTP
             host = "test.aws.com"
@@ -152,7 +152,7 @@ class UrlTest {
     }
 
     @Test
-    fun `it parses`() {
+    fun itParses() {
         val urls = listOf(
             "http://test.aws.com/kotlin?foo=baz",
             "http://test.aws.com:3000/kotlin",

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/DefaultRequestTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/DefaultRequestTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 
 class DefaultRequestTest {
     @Test
-    fun `it sets defaults`() = runSuspendTest {
+    fun itSetsDefaults() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }
@@ -38,7 +38,7 @@ class DefaultRequestTest {
     }
 
     @Test
-    fun `it does not override`() = runSuspendTest {
+    fun itDoesNotOverride() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/DefaultValidateResponseTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/DefaultValidateResponseTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertFailsWith
 
 class DefaultValidateResponseTest {
     @Test
-    fun `it throws exception on non-200 response`() = runSuspendTest {
+    fun itThrowsExceptionOnNon200Response() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }
@@ -42,7 +42,7 @@ class DefaultValidateResponseTest {
     }
 
     @Test
-    fun `it passes success responses`() = runSuspendTest {
+    fun itPassesSuccessResponses() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/HttpSerdeTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/feature/HttpSerdeTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertEquals
 
 class HttpSerdeTest {
     @Test
-    fun `it serializes`() = runSuspendTest {
+    fun itSerializes() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }
@@ -47,7 +47,7 @@ class HttpSerdeTest {
     }
 
     @Test
-    fun `it deserializes`() = runSuspendTest {
+    fun itDeserializes() = runSuspendTest {
         val mockEngine = object : HttpClientEngine {
             override suspend fun roundTrip(requestBuilder: HttpRequestBuilder): HttpResponse { throw NotImplementedError() }
         }

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/CaseInsensitiveMapTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/CaseInsensitiveMapTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 
 class CaseInsensitiveMapTest {
     @Test
-    fun `map operations ignore case`() {
+    fun mapOperationsIgnoreCase() {
         val map = CaseInsensitiveMap<String>()
 
         map["conTent-Type"] = "json"

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/HeaderListsTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/HeaderListsTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFails
 
 class HeaderListsTest {
     @Test
-    fun `it splits on comma`() {
+    fun itSplitsOnComma() {
         assertEquals(listOf("1"), splitHeaderListValues("1"))
         assertEquals(listOf("1", "2", "3"), splitHeaderListValues("1,2,3"))
         assertEquals(listOf("1", "2", "3"), splitHeaderListValues("1,  2,  3"))
@@ -19,7 +19,7 @@ class HeaderListsTest {
     }
 
     @Test
-    fun `it splits httpDate lists`() {
+    fun itSplitsHttpDateLists() {
         // input to expected
         val tests = listOf(
             // no split

--- a/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/TextTest.kt
+++ b/client-runtime/protocol/http/common/test/software/aws/clientrt/http/util/TextTest.kt
@@ -13,7 +13,7 @@ data class EscapeTest(val input: String, val expected: String, val formUrlEncode
 
 class TextTest {
     @Test
-    fun `url values encode correctly`() {
+    fun urlValuesEncodeCorrectly() {
         val nonEncodedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~"
         val encodedCharactersInput = "\t\n\r !\"#$%&'()*+,/:;<=>?@[\\]^`{|}"
         val encodedCharactersOutput =
@@ -36,7 +36,7 @@ class TextTest {
     }
 
     @Test
-    fun `form data values encode correctly`() {
+    fun formDataValuesEncodeCorrectly() {
         val nonEncodedCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
         val encodedCharactersInput = "\t\n\r !\"#$%&'()+,/:;<=>?@[\\]^`{|}"
         val encodedCharactersOutput =
@@ -56,14 +56,14 @@ class TextTest {
     }
 
     @Test
-    fun `url path values encode correctly`() {
+    fun urlPathValuesEncodeCorrectly() {
         val urlPath = "/wikipedia/en/6/61/Purdue_University_\u2013seal.svg"
         assertEquals("/wikipedia/en/6/61/Purdue_University_%E2%80%93seal.svg", urlPath.encodeUrlPath())
         assertEquals("/kotlin/Tue,%2029%20Apr%202014%2018:30:38%20GMT", "/kotlin/Tue, 29 Apr 2014 18:30:38 GMT".encodeUrlPath())
     }
 
     @Test
-    fun `utf8 url path values encode correctly`() {
+    fun utf8UrlPathValuesEncodeCorrectly() {
         val swissAndGerman = "\u0047\u0072\u00fc\u0065\u007a\u0069\u005f\u007a\u00e4\u006d\u00e4"
         val russian = "\u0412\u0441\u0435\u043c\u005f\u043f\u0440\u0438\u0432\u0435\u0442"
         val japanese = "\u3053\u3093\u306b\u3061\u306f"
@@ -73,7 +73,7 @@ class TextTest {
     }
 
     @Test
-    fun `split query string into parts`() {
+    fun splitQueryStringIntoParts() {
         val query = "foo=baz&bar=quux&foo=qux&a="
         val actual = query.splitAsQueryParameters()
         val expected = QueryParameters {

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonDeserializerTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonDeserializerTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.*
 @OptIn(ExperimentalStdlibApi::class)
 class JsonDeserializerTest {
     @Test
-    fun `it handles doubles`() {
+    fun itHandlesDoubles() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeDouble()
@@ -23,7 +23,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles floats`() {
+    fun itHandlesFloats() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeFloat()
@@ -33,7 +33,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles int`() {
+    fun itHandlesInt() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeInt()
@@ -42,7 +42,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles byte as number`() {
+    fun itHandlesByteAsNumber() {
         val payload = "1".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeByte()
@@ -51,7 +51,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles short`() {
+    fun itHandlesShort() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeShort()
@@ -60,7 +60,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles long`() {
+    fun itHandlesLong() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeLong()
@@ -69,7 +69,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles bool`() {
+    fun itHandlesBool() {
         val payload = "true".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeBool()
@@ -78,7 +78,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles string`() {
+    fun itHandlesString() {
         // allow deserializeString() to consume tokens other than JsonToken.String as raw string values
         // this supports custom deserialization (e.g. timestamps) of the raw value
         val tests = listOf(
@@ -98,7 +98,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles null`() {
+    fun itHandlesNull() {
         val payload = "null".encodeToByteArray()
         val stringDeserializer = JsonDeserializer(payload)
         stringDeserializer.deserializeNull()
@@ -108,7 +108,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles lists`() {
+    fun itHandlesLists() {
         val payload = "[1,2,3]".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeList(SdkFieldDescriptor("", SerialKind.List)) {
@@ -123,7 +123,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles sparse lists`() {
+    fun itHandlesSparseLists() {
         val payload = "[1,null,3]".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeList(SdkFieldDescriptor("", SerialKind.List)) {
@@ -139,7 +139,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles maps`() {
+    fun itHandlesMaps() {
         val payload = """
             {
                 "key1": 1,
@@ -159,7 +159,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it checks null values of non-sparse maps`() {
+    fun itChecksNullValuesOfNonSparseMaps() {
         val payload = """
             {
                 "key1": 1,
@@ -213,7 +213,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles basic structs`() {
+    fun itHandlesBasicStructs() {
         val payload = """
         {
             "x": 1,
@@ -238,7 +238,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles list of objects`() {
+    fun itHandlesListOfObjects() {
         val payload = """
         [
             {
@@ -267,7 +267,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it enumerates unknown struct fields`() {
+    fun itEnumeratesUnknownStructFields() {
         val payload = """
         {
             "x": 1,
@@ -400,7 +400,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it handles kitchen sink`() {
+    fun itHandlesKitchenSink() {
         val payload = """
         {
             "int": 1,
@@ -488,7 +488,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun `it skips explicit nulls`() {
+    fun itSkipsExplicitNulls() {
         val payload = """
          {
              "x": 1,

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerdeProviderTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerdeProviderTest.kt
@@ -12,14 +12,14 @@ import kotlin.test.assertNotNull
 class JsonSerdeProviderTest {
 
     @Test
-    fun `it instantiates a serializer`() {
+    fun itInstantiatesASerializer() {
         val unit = JsonSerdeProvider()
 
         assertNotNull(unit.serializer())
     }
 
     @Test
-    fun `it instantiates a deserializer`() {
+    fun itInstantiatesADeserializer() {
         val unit = JsonSerdeProvider()
 
         assertNotNull(unit.deserializer("{}".encodeToByteArray()))

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonSerializerTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
 class JsonSerializerTest {
 
     @Test
-    fun `can serialize class with class field`() {
+    fun canSerializeClassWithClassField() {
         val a = A(
             B(2)
         )
@@ -47,7 +47,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize list of classes`() {
+    fun canSerializeListOfClasses() {
         val obj = listOf(
             B(1),
             B(2),
@@ -63,7 +63,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize map`() {
+    fun canSerializeMap() {
         val objs = mapOf(
             "A1" to A(
                 B(1)
@@ -89,7 +89,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize map of lists`() {
+    fun canSerializeMapOfLists() {
         val objs = mapOf(
             "A1" to listOf("a", "b", "c"),
             "A2" to listOf("d", "e", "f"),
@@ -109,7 +109,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize list of lists`() {
+    fun canSerializeListOfLists() {
         val objs = listOf(
             listOf("a", "b", "c"),
             listOf("d", "e", "f"),
@@ -129,7 +129,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize list of maps`() {
+    fun canSerializeListOfMaps() {
         val objs = listOf(
             mapOf("a" to "b", "c" to "d"),
             mapOf("e" to "f", "g" to "h"),
@@ -149,7 +149,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize map of maps`() {
+    fun canSerializeMapOfMaps() {
         val objs = mapOf(
             "A1" to mapOf("a" to "b", "c" to "d"),
             "A2" to mapOf("e" to "f", "g" to "h"),
@@ -169,7 +169,7 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `can serialize all primitives`() {
+    fun canSerializeAllPrimitives() {
         val json = JsonSerializer()
         data.serialize(json)
 

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonStreamReaderTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonStreamReaderTest.kt
@@ -30,7 +30,7 @@ fun assertTokensAreEqual(expected: List<JsonToken>, actual: List<JsonToken>) {
 @OptIn(ExperimentalStdlibApi::class)
 class JsonStreamReaderTest {
     @Test
-    fun `it deserializes objects`() {
+    fun itDeserializesObjects() {
         val payload = """
             {
                 "x": 1,
@@ -52,7 +52,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun `kitchen sink`() {
+    fun kitchenSink() {
         val payload = """
         {
             "num": 1,
@@ -107,7 +107,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun `it skips values recursively`() {
+    fun itSkipsValuesRecursively() {
         val payload = """
         {
             "x": 1,
@@ -140,7 +140,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun `it skips simple values`() {
+    fun itSkipsSimpleValues() {
         val payload = """
         {
             "x": 1,

--- a/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonStreamWriterTest.kt
+++ b/client-runtime/serde/serde-json/common/test/software/aws/clientrt/serde/json/JsonStreamWriterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 class JsonStreamWriterTest {
 
     @Test
-    fun `check json serializes correctly with wrapper`() {
+    fun checkJsonSerializesCorrectlyWithWrapper() {
         val msg1 = Message(
             912345678901,
             "How do I stream JSON in Java?",
@@ -33,7 +33,7 @@ class JsonStreamWriterTest {
     }
 
     @Test
-    fun `check close is idempotent`() {
+    fun checkCloseIsIdempotent() {
         val writer = jsonStreamWriter(true)
         writer.beginObject()
         writer.writeName("id")
@@ -46,7 +46,7 @@ class JsonStreamWriterTest {
     }
 
     @Test
-    fun `check non human readable`() {
+    fun checkNonHumanReadable() {
         val writer = jsonStreamWriter()
         writer.beginObject()
         writer.writeName("id")
@@ -57,7 +57,7 @@ class JsonStreamWriterTest {
     }
 
     @Test
-    fun `it allows raw values`() {
+    fun itAllowsRawValues() {
         val writer = jsonStreamWriter()
         val expected = """{"foo":1234.5678}"""
         writer.writeRawValue(expected)

--- a/client-runtime/serde/serde-test/common/test/NullDeserializationParityTest.kt
+++ b/client-runtime/serde/serde-test/common/test/NullDeserializationParityTest.kt
@@ -94,7 +94,7 @@ class NullDeserializationParityTest {
      * Empty objects should deserialize into empty instances of their target type.
      */
     @Test
-    fun `it deserializes an empty document into an empty anonymous struct`() {
+    fun itDeserializesAnEmptyDocumentIntoAnEmptyAnonymousStruct() {
         val jsonPayload = "{}".encodeToByteArray()
         val xmlPayload = "<AnonStruct />".encodeToByteArray()
 
@@ -112,7 +112,7 @@ class NullDeserializationParityTest {
      * deserialize those children as null references.
      */
     @Test
-    fun `it deserializes a reference to a null object`() {
+    fun itDeserializesAReferenceToANullObject() {
         val jsonPayload = """
             { "ChildStruct" : null }
         """.trimIndent().encodeToByteArray()
@@ -133,7 +133,7 @@ class NullDeserializationParityTest {
      * those deserialized children exist but are empty.
      */
     @Test
-    fun `it deserializes a reference to an empty object`() {
+    fun itDeserializesAReferenceToAnEmptyObject() {
         val jsonPayload = """
             { "ChildStruct" : {}} }
         """.trimIndent().encodeToByteArray()

--- a/client-runtime/serde/serde-test/common/test/SemanticParityTest.kt
+++ b/client-runtime/serde/serde-test/common/test/SemanticParityTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 class SemanticParityTest {
 
     @Test
-    fun `xml deserializes into object form then deserializes to json then serializes to object form then deserializes to original xml`() {
+    fun xmlDeserializesIntoObjectFormThenDeserializesToJsonThenSerializesToObjectFormThenDeserializesToOriginalXml() {
         for (test in getTests()) {
             // xml
             val xmlPayload = test.xmlSerialization
@@ -46,7 +46,7 @@ class SemanticParityTest {
     }
 
     @Test
-    fun `json deserializes into object form then deserializes to xml then serializes to object form then deserializes to original json`() {
+    fun jsonDeserializesIntoObjectFormThenDeserializesToXmlThenSerializesToObjectFormThenDeserializesToOriginalJson() {
         for (test in getTests()) {
             // json
             val jsonPayload = test.jsonSerialization
@@ -76,7 +76,7 @@ class SemanticParityTest {
     }
 
     @Test
-    fun `object form serializes into equivalent representations in json and xml`() {
+    fun objectFormSerializesIntoEquivalentRepresentationsInJsonAndXml() {
         for (test in getTests()) {
             val bst = test.sdkSerializable
 
@@ -97,7 +97,7 @@ class SemanticParityTest {
     }
 
     @Test
-    fun `equivalent json and xml serial forms produce the same object form`() {
+    fun equivalentJsonAndXmlSerialFormsProduceTheSameObjectForm() {
         for (test in getTests()) {
             val jsonDeserializer = JsonDeserializer(test.jsonSerialization.encodeToByteArray())
             val jsonBst = test.deserialize(jsonDeserializer)
@@ -110,7 +110,7 @@ class SemanticParityTest {
     }
 
     @Test
-    fun `it deserializes from json and then serializes to xml`() {
+    fun itDeserializesFromJsonAndThenSerializesToXml() {
         for (test in getTests()) {
             val jsonDeserializer = JsonDeserializer(test.jsonSerialization.encodeToByteArray())
             val bst = test.deserialize(jsonDeserializer)

--- a/client-runtime/serde/serde-test/common/test/SparseMapDeserializationTest.kt
+++ b/client-runtime/serde/serde-test/common/test/SparseMapDeserializationTest.kt
@@ -222,7 +222,7 @@ class SparseMapDeserializationTest {
     }
 
     @Test
-    fun `it deserializes an empty document into an empty struct`() {
+    fun itDeserializesAnEmptyDocumentIntoAnEmptyStruct() {
         val jsonPayload = "{}".encodeToByteArray()
         val xmlPayload = "<GetFoo />".encodeToByteArray()
 
@@ -235,7 +235,7 @@ class SparseMapDeserializationTest {
     }
 
     @Test
-    fun `it deserializes an empty map into an struct with empty map`() {
+    fun itDeserializesAnEmptyMapIntoAnStructWithEmptyMap() {
         val jsonPayload = """
             {
                 "sparseStructMap": {}
@@ -257,7 +257,7 @@ class SparseMapDeserializationTest {
     }
 
     @Test
-    fun `it deserializes a map with null values into an struct with map containing keys with null values`() {
+    fun itDeserializesAMapWithNullValuesIntoAnStructWithMapContainingKeysWithNullValues() {
         val jsonPayload = """
             {
             	"sparseStructMap": {

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerAWSTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerAWSTest.kt
@@ -117,7 +117,7 @@ class XmlDeserializerAWSTest {
     }
 
     @Test
-    fun `it handles Route 53 XML`() {
+    fun itHandlesRoute53XML() {
         val testXml = """
                <?xml version="1.0" encoding="UTF-8"?><!--
                  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerKitchenSinkTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerKitchenSinkTest.kt
@@ -132,7 +132,7 @@ class XmlDeserializerKitchenSinkTest {
     }
 
     @Test
-    fun `it handles kitchen sink`() {
+    fun itHandlesKitchenSink() {
         val payload = """
            <?xml version="1.0" encoding="UTF-8" ?>
            <payload>

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerListTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerListTest.kt
@@ -61,7 +61,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles lists`() {
+    fun itHandlesLists() {
         val payload = """
             <object>
                 <list>
@@ -85,7 +85,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles flat lists`() {
+    fun itHandlesFlatLists() {
         val payload = """
             <object>
                 <element>1</element>
@@ -106,7 +106,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles list of objects`() {
+    fun itHandlesListOfObjects() {
         val payload = """
                <list>
                    <payload>
@@ -139,7 +139,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles list of objects with structs with empty values`() {
+    fun itHandlesListOfObjectsWithStructsWithEmptyValues() {
         val payload = """
                <list>
                    <payload>
@@ -172,7 +172,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles list of objects with empty values`() {
+    fun itHandlesListOfObjectsWithEmptyValues() {
         val payload = """
                <list>
                    <payload>
@@ -203,7 +203,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun `it handles empty lists`() {
+    fun itHandlesEmptyLists() {
         val payload = """
                <list></list>
            """.encodeToByteArray()

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerMapTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerMapTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.Test
 class XmlDeserializerMapTest {
 
     @Test
-    fun `it handles maps with default node names`() {
+    fun itHandlesMapsWithDefaultNodeNames() {
         val payload = """
             <values>
                 <entry>
@@ -45,7 +45,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun `it handles maps with custom node names`() {
+    fun itHandlesMapsWithCustomNodeNames() {
         val payload = """
             <mymap>
                 <myentry>
@@ -77,7 +77,7 @@ class XmlDeserializerMapTest {
 
     // https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html#flattened-map-serialization
     @Test
-    fun `it handles flat maps`() {
+    fun itHandlesFlatMaps() {
         val payload = """
             <Bar>
                 <flatMap>
@@ -109,7 +109,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun `it handles empty maps`() {
+    fun itHandlesEmptyMaps() {
         val payload = """
             <Map></Map>
         """.encodeToByteArray()
@@ -128,7 +128,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun `it handles sparse maps`() {
+    fun itHandlesSparseMaps() {
         val payload = """
             <values>
                 <entry>
@@ -162,7 +162,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun `it handles checking map values for null`() {
+    fun itHandlesCheckingMapValuesForNull() {
         val payload = """
             <values>
                 <entry>

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerPrimitiveTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerPrimitiveTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerPrimitiveTest {
     @Test
-    fun `it handles doubles`() {
+    fun itHandlesDoubles() {
         val payload = "<node>1.2</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -29,7 +29,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles floats`() {
+    fun itHandlesFloats() {
         val payload = "<node>1.2</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -41,7 +41,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles int`() {
+    fun itHandlesInt() {
         val payload = "<node>${Int.MAX_VALUE}</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -53,7 +53,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles byte as number`() {
+    fun itHandlesByteAsNumber() {
         val payload = "<node>1</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -65,7 +65,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles short`() {
+    fun itHandlesShort() {
         val payload = "<node>${Short.MAX_VALUE}</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -77,7 +77,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles long`() {
+    fun itHandlesLong() {
         val payload = "<node>${Long.MAX_VALUE}</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -89,7 +89,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it handles bool`() {
+    fun itHandlesBool() {
         val payload = "<node>true</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -100,7 +100,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun `it fails invalid type specification for int`() {
+    fun itFailsInvalidTypeSpecificationForInt() {
         val payload = "<node>1.2</node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -113,7 +113,7 @@ class XmlDeserializerPrimitiveTest {
 
     @Test
     // TODO: It's unclear if this test should result in an exception or null value.
-    fun `it fails missing type specification for int`() {
+    fun itFailsMissingTypeSpecificationForInt() {
         val payload = "<node></node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {
@@ -126,7 +126,7 @@ class XmlDeserializerPrimitiveTest {
 
     @Test
     // TODO: It's unclear if this test should result in an exception or null value.
-    fun `it fails whitespace type specification for int`() {
+    fun itFailsWhitespaceTypeSpecificationForInt() {
         val payload = "<node> </node>".encodeToByteArray()
         val deserializer = XmlDeserializer(payload)
         val objSerializer = SdkObjectDescriptor.build {

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerStructTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlDeserializerStructTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertTrue
 class XmlDeserializerStructTest {
 
     @Test
-    fun `it handles basic structs with attribs`() {
+    fun itHandlesBasicStructsWithAttribs() {
         val payload = """
             <payload>
                 <x value="1" />
@@ -29,7 +29,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun `it handles basic structs with attribs and text`() {
+    fun itHandlesBasicStructsWithAttribsAndText() {
         val payload = """
             <payload>
                 <x value="1">x1</x>
@@ -91,7 +91,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun `it handles basic structs`() {
+    fun itHandlesBasicStructs() {
         val payload = """
             <payload>
                 <x>1</x>
@@ -107,7 +107,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun `it handles basic structs with null values`() {
+    fun itHandlesBasicStructsWithNullValues() {
         val payload1 = """
             <payload>
                 <x>1</x>
@@ -136,7 +136,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun `it enumerates unknown struct fields`() {
+    fun itEnumeratesUnknownStructFields() {
         val payload = """
                <payload>
                    <x>1</x>

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerdeProviderTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerdeProviderTest.kt
@@ -12,14 +12,14 @@ import kotlin.test.assertNotNull
 class XmlSerdeProviderTest {
 
     @Test
-    fun `it instantiates a serializer`() {
+    fun itInstantiatesASerializer() {
         val unit = XmlSerdeProvider()
 
         assertNotNull(unit.serializer())
     }
 
     @Test
-    fun `it instantiates a deserializer`() {
+    fun itInstantiatesADeserializer() {
         val unit = XmlSerdeProvider()
 
         assertNotNull(unit.deserializer("<a>boo</a>".encodeToByteArray()))

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerializerTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerializerTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 class XmlSerializerTest {
 
     @Test
-    fun `can serialize class with class field`() {
+    fun canSerializeClassWithClassField() {
         val a = A(
             B(2)
         )
@@ -56,7 +56,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize list of classes`() {
+    fun canSerializeListOfClasses() {
         val obj = listOf(
             B(1),
             B(2),
@@ -73,7 +73,7 @@ class XmlSerializerTest {
 
     // See https://awslabs.github.io/smithy/spec/xml.html#wrapped-map-serialization
     @Test
-    fun `can serialize map`() {
+    fun canSerializeMap() {
         val foo = Foo(
             mapOf(
                 "example-key1" to "example1",
@@ -88,7 +88,7 @@ class XmlSerializerTest {
 
     // See https://awslabs.github.io/smithy/spec/xml.html#flattened-map-serialization
     @Test
-    fun `can serialize flattened map`() {
+    fun canSerializeFlattenedMap() {
         val bar = Bar(
             mapOf(
                 "example-key1" to "example1",
@@ -103,7 +103,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize map of lists`() {
+    fun canSerializeMapOfLists() {
         val objs = mapOf(
             "A1" to listOf("a", "b", "c"),
             "A2" to listOf("d", "e", "f"),
@@ -123,7 +123,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize list of lists`() {
+    fun canSerializeListOfLists() {
         val objs = listOf(
             listOf("a", "b", "c"),
             listOf("d", "e", "f"),
@@ -143,7 +143,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize list of maps`() {
+    fun canSerializeListOfMaps() {
         val objs = listOf(
             mapOf("a" to "b", "c" to "d"),
             mapOf("e" to "f", "g" to "h"),
@@ -163,7 +163,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize map of maps`() {
+    fun canSerializeMapOfMaps() {
         val objs = mapOf(
             "A1" to mapOf("a" to "b", "c" to "d"),
             "A2" to mapOf("e" to "f", "g" to "h"),
@@ -225,7 +225,7 @@ class XmlSerializerTest {
     }
 
     @Test
-    fun `can serialize all primitives`() {
+    fun canSerializeAllPrimitives() {
         val xml = XmlSerializer()
         val data = Primitives(
             true, 10, 20, 30, 40, 50f, 60.0, 'A', "Str0",

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlStreamReaderTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlStreamReaderTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalStdlibApi::class)
 class XmlStreamReaderTest {
     @Test
-    fun `it deserializes xml`() {
+    fun itDeserializesXml() {
         val payload = """<root><x>1</x><y>2</y></root>""".trimIndent().encodeToByteArray()
         val actual = xmlStreamReader(payload).allTokens()
 
@@ -31,7 +31,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun `it deserializes xml with attributes`() {
+    fun itDeserializesXmlWithAttributes() {
         val payload = """<batch><add id="tt0484562"><field name="title">The Seeker: The Dark Is Rising</field></add><delete id="tt0301199" /></batch>""".trimIndent().encodeToByteArray()
         val actual = xmlStreamReader(payload).allTokens()
 
@@ -52,13 +52,13 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun `garbage in garbage out`() {
+    fun garbageInGarbageOut() {
         val payload = """you try to parse me once, jokes on me..try twice jokes on you bucko.""".trimIndent().encodeToByteArray()
         assertFailsWith(XmlGenerationException::class) { xmlStreamReader(payload).allTokens() }
     }
 
     @Test
-    fun `it handles nil node values`() {
+    fun itHandlesNilNodeValues() {
         val payload = """<null xsi:nil="true"></null>""".encodeToByteArray()
         val actual = xmlStreamReader(payload).allTokens()
         val expected = listOf(
@@ -71,7 +71,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun `kitchen sink`() {
+    fun kitchenSink() {
         val payload = """
         <root>
           <num>1</num>    
@@ -139,7 +139,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun `it skips values recursively`() {
+    fun itSkipsValuesRecursively() {
         val payload = """
             <payload><x>1></x><unknown><a>a</a><b>b</b><c><list><element>d</element><element>e</element><element>f</element></list></c><g><h>h</h><i>i</i></g></unknown><y>2></y></payload>
         """.trimIndent().encodeToByteArray()
@@ -163,7 +163,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun `it skips simple values`() {
+    fun itSkipsSimpleValues() {
         val payload = """<payload><x>1</x><z>unknown</z><y>2</y></payload>""".trimIndent().encodeToByteArray()
         val reader = xmlStreamReader(payload)
         // skip x

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlStreamWriterTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlStreamWriterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 class XmlStreamWriterTest {
 
     @Test
-    fun `check xml serializes correctly with wrapper`() {
+    fun checkXmlSerializesCorrectlyWithWrapper() {
         val msg1 = Message(
             912345678901,
             "How do I stream XML in Java?",
@@ -33,7 +33,7 @@ class XmlStreamWriterTest {
     }
 
     @Test
-    fun `check close is idempotent`() {
+    fun checkCloseIsIdempotent() {
         val writer = generateSimpleDocument()
         assertEquals(expectedIdempotent, writer.bytes.decodeToString())
         assertEquals(expectedIdempotent, writer.bytes.decodeToString())
@@ -48,13 +48,13 @@ class XmlStreamWriterTest {
     }
 
     @Test
-    fun `check non human readable`() {
+    fun checkNonHumanReadable() {
         val writer = generateSimpleDocument()
         assertEquals(expectedNoIndent, writer.bytes.decodeToString())
     }
 
     @Test
-    fun `it writes XML with attributes`() {
+    fun itWritesXMLWithAttributes() {
         val writer = xmlStreamWriter(pretty = false)
 
         writer.startTag("batch")

--- a/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/HttpRequestTestBuilderTest.kt
+++ b/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/HttpRequestTestBuilderTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertFails
 class HttpRequestTestBuilderTest {
 
     @Test
-    fun `it asserts HttpMethod`() {
+    fun itAssertsHttpMethod() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -34,7 +34,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts uri`() {
+    fun itAssertsUri() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -54,7 +54,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it encodes uri in mock engine`() {
+    fun itEncodesUriInMockEngine() {
         httpRequestTest {
             expected {
                 method = HttpMethod.POST
@@ -74,7 +74,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts query parameters`() {
+    fun itAssertsQueryParameters() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -97,7 +97,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts forbidden query parameters`() {
+    fun itAssertsForbiddenQueryParameters() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -122,7 +122,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts required query parameters`() {
+    fun itAssertsRequiredQueryParameters() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -148,7 +148,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts headers`() {
+    fun itAssertsHeaders() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -183,7 +183,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts lists of headers`() {
+    fun itAssertsListsOfHeaders() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -211,7 +211,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts forbidden headers`() {
+    fun itAssertsForbiddenHeaders() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -249,7 +249,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it asserts required headers`() {
+    fun itAssertsRequiredHeaders() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -288,7 +288,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it fails when body assert function is missing`() {
+    fun itFailsWhenBodyAssertFunctionIsMissing() {
         val ex = assertFails {
             httpRequestTest {
                 expected {
@@ -307,7 +307,7 @@ class HttpRequestTestBuilderTest {
     }
 
     @Test
-    fun `it calls bodyAssert function`() {
+    fun itCallsBodyAssertFunction() {
         val ex = assertFails {
             httpRequestTest {
                 expected {

--- a/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/HttpResponseTestBuilderTest.kt
+++ b/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/HttpResponseTestBuilderTest.kt
@@ -15,7 +15,7 @@ class HttpResponseTestBuilderTest {
 
     @Test
     @OptIn(ExperimentalStdlibApi::class)
-    fun `it builds responses`() {
+    fun itBuildsResponses() {
         httpResponseTest<Foo> {
             expected {
                 statusCode = HttpStatusCode.OK

--- a/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/JsonAssertionsTest.kt
+++ b/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/JsonAssertionsTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFails
 // some basic sanity tests that Jetbrains kotlinx-serialization: JsonElement::equals() method works for our purposes
 class JsonAssertionsTest {
     @Test
-    fun `it ignores key order`() {
+    fun itIgnoresKeyOrder() {
         val expected = """
         {
             "string": "v1",
@@ -53,7 +53,7 @@ class JsonAssertionsTest {
     }
 
     @Test
-    fun `it asserts missing keys`() {
+    fun itAssertsMissingKeys() {
         val expected = """
         {
             "string": "v1",
@@ -78,7 +78,7 @@ class JsonAssertionsTest {
     }
 
     @Test
-    fun `it asserts kitchen sink`() {
+    fun itAssertsKitchenSink() {
         val expected = """
         {
             "string": "v1",

--- a/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/UtilsTest.kt
+++ b/client-runtime/smithy-test/common/test/software/aws/clientrt/smithy/test/UtilsTest.kt
@@ -17,7 +17,7 @@ class UtilsTest {
     private val testBody = ByteArrayContent(testBodyContents)
 
     @Test
-    fun `it compares empty bodies`() = runSuspendTest {
+    fun itComparesEmptyBodies() = runSuspendTest {
         val ex = assertFails {
             assertEmptyBody(null, testBody)
         }
@@ -27,7 +27,7 @@ class UtilsTest {
     }
 
     @Test
-    fun `it compares bytes`() = runSuspendTest {
+    fun itComparesBytes() = runSuspendTest {
         val ex = assertFails {
             assertBytesEqual(null, testBody)
         }

--- a/client-runtime/utils/common/test/software/aws/clientrt/util/Base64Test.kt
+++ b/client-runtime/utils/common/test/software/aws/clientrt/util/Base64Test.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFails
 
 class Base64Test {
     @Test
-    fun `it round trips`() {
+    fun itRoundTrips() {
         val tests = listOf(
             "ABC" to "QUJD",
             "Kotlin is awesome" to "S290bGluIGlzIGF3ZXNvbWU=",
@@ -32,20 +32,20 @@ class Base64Test {
     }
 
     @Test
-    fun `empty String test`() {
+    fun emptyStringTest() {
         assertEquals("", "".encodeBase64())
         assertEquals("", "".decodeBase64())
     }
 
     @Test
-    fun `empty ByteArray test`() {
+    fun emptyByteArrayTest() {
         val buf = ByteArray(0)
         assertEquals(0, buf.encodeBase64().size)
         assertEquals(0, buf.decodeBase64().size)
     }
 
     @Test
-    fun `it handles padding`() {
+    fun itHandlesPadding() {
         val cases = mapOf(
             "This" to "VGhpcw==",
             "Thi" to "VGhp",
@@ -61,14 +61,14 @@ class Base64Test {
     }
 
     @Test
-    fun `zeroes`() {
+    fun zeroes() {
         val input = ByteArray(6) { 0 }
         val actual = input.encodeBase64String()
         assertEquals("AAAAAAAA", actual)
     }
 
     @Test
-    fun `decode invalid base64 string`() {
+    fun decodeInvalidBase64String() {
         val ex = assertFails {
             // - is not in the base64 alphabet
             "Zm9v-y==".decodeBase64()
@@ -77,7 +77,7 @@ class Base64Test {
     }
 
     @Test
-    fun `decode non multiple of 4`() {
+    fun decodeNonMultipleOf4() {
         val ex = assertFails {
             "Zm9vY=".decodeBase64()
         }
@@ -85,7 +85,7 @@ class Base64Test {
     }
 
     @Test
-    fun `decode invalid padding`() {
+    fun decodeInvalidPadding() {
         val ex = assertFails {
             "Zm9vY===".decodeBase64()
         }
@@ -94,7 +94,7 @@ class Base64Test {
     }
 
     @Test
-    fun `encode longer text`() {
+    fun encodeLongerText() {
         val decoded = "Alas, eleventy-one years is far too short a time to live among such excellent and admirable hobbits. I don't know half of you half as well as I should like, and I like less than half of you half as well as you deserve."
         val encoded = "QWxhcywgZWxldmVudHktb25lIHllYXJzIGlzIGZhciB0b28gc2hvcnQgYSB0aW1lIHRvIGxpdmUgYW1vbmcgc3VjaCBleGNlbGxlbnQgYW5kIGFkbWlyYWJsZSBob2JiaXRzLiBJIGRvbid0IGtub3cgaGFsZiBvZiB5b3UgaGFsZiBhcyB3ZWxsIGFzIEkgc2hvdWxkIGxpa2UsIGFuZCBJIGxpa2UgbGVzcyB0aGFuIGhhbGYgb2YgeW91IGhhbGYgYXMgd2VsbCBhcyB5b3UgZGVzZXJ2ZS4="
         assertEquals(encoded, decoded.encodeBase64())
@@ -102,7 +102,7 @@ class Base64Test {
     }
 
     @Test
-    fun `it handles utf8`() {
+    fun itHandlesUtf8() {
         val decoded = "ユニコードとはか？"
         val encoded = "44Om44OL44Kz44O844OJ44Go44Gv44GL77yf"
         assertEquals(encoded, decoded.encodeBase64())
@@ -110,7 +110,7 @@ class Base64Test {
     }
 
     @Test
-    fun `it handles control chars`() {
+    fun itHandlesControlChars() {
         val decoded = "hello\tworld\n"
         val encoded = "aGVsbG8Jd29ybGQK"
         assertEquals(encoded, decoded.encodeBase64())


### PR DESCRIPTION
While I really like the nice method names for tests (and we use them extensively in the JetBrains toolkit codebase) they don't really work in an MPP project - the compiler isn't smart enough to fix them when converting to JavaScript.