### PR TITLE
chore: add smithy-waiters dependency required by aws-models

### DIFF
--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -25,6 +25,7 @@ val kotestVersion: String by project
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
+    api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds `smithy-waiters` to API dependencies (required by aws-models updates)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
