### PR TITLE
Implement reading of sdkId from smithy-build.json and using that to g…

### DIFF
--- a/smithy-kotlin-codegen-test/build.gradle.kts
+++ b/smithy-kotlin-codegen-test/build.gradle.kts
@@ -9,7 +9,7 @@ extra["moduleName"] = "software.amazon.smithy.kotlin.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.1")
+    id("software.amazon.smithy").version("0.5.2")
 }
 
 val smithyVersion: String by project

--- a/smithy-kotlin-codegen-test/smithy-build.json
+++ b/smithy-kotlin-codegen-test/smithy-build.json
@@ -5,6 +5,7 @@
             "service": "example.weather#Weather",
             "module": "weather",
             "moduleVersion": "0.0.1",
+            "sdkId": "Weather",
             "build": {
                 "rootProject": true
             }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
@@ -52,7 +52,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
 
         service = settings.getService(model)
         symbolProvider = integrations.fold(
-            KotlinCodegenPlugin.createSymbolProvider(model, settings.moduleName)
+            KotlinCodegenPlugin.createSymbolProvider(model, settings.moduleName, settings.sdkId)
         ) { provider, integration ->
             integration.decorateSymbolProvider(settings, model, provider)
         }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinCodegenPlugin.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinCodegenPlugin.kt
@@ -25,10 +25,12 @@ class KotlinCodegenPlugin : SmithyBuildPlugin {
         /**
          * Creates a Kotlin symbol provider.
          * @param model The model to generate symbols for
-         * @param namespace The root package name (e.g. com.foo.bar). All symbols will be generated as part of this
-         * package (or as a child of it)
+         * @param rootNamespace All symbols will be created under this namespace (package) or as a direct child of it.
+         * e.g. `com.foo` would create symbols under the `com.foo` package or `com.foo.model` package, etc.
+         * @param sdkId name to use to represent client type.  e.g. an sdkId of "foo" would produce a client type "FooClient".
          * @return Returns the created provider
          */
-        fun createSymbolProvider(model: Model, namespace: String): SymbolProvider = SymbolVisitor(model, namespace)
+        fun createSymbolProvider(model: Model, rootNamespace: String, sdkId: String): SymbolProvider =
+            SymbolVisitor(model, rootNamespace, sdkId)
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/EnumGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/EnumGeneratorTest.kt
@@ -36,7 +36,7 @@ class EnumGeneratorTest {
             
         """.asSmithyModel()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Baz")
         val shape = model.expectShape(ShapeId.from("com.test#Baz")).asStringShape().get()
         val symbol = provider.toSymbol(shape)
         val writer = KotlinWriter("com.test")
@@ -118,7 +118,7 @@ sealed class Baz {
             
         """.asSmithyModel()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Baz")
         val shape = model.expectShape(ShapeId.from("com.test#Baz")).asStringShape().get()
         val symbol = provider.toSymbol(shape)
         val writer = KotlinWriter("com.test")
@@ -208,7 +208,7 @@ sealed class Baz {
             .assemble()
             .unwrap()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Baz")
         val symbol = provider.toSymbol(shape)
         val writer = KotlinWriter("com.test")
         EnumGenerator(shape, symbol, writer).render()
@@ -248,7 +248,7 @@ sealed class Baz {
             .assemble()
             .unwrap()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Baz")
         val symbol = provider.toSymbol(shape)
         val writer = KotlinWriter("com.test")
         val ex = assertThrows<CodegenException> {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ServiceGeneratorTest.kt
@@ -73,7 +73,7 @@ class ServiceGeneratorTest {
         }
     }
 """
-        commonTestContents.shouldContainOnlyOnce(expected)
+        commonTestContents.shouldContainOnlyOnceWithDiff(expected)
     }
 
     @Test
@@ -96,7 +96,7 @@ class ServiceGeneratorTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Example")
         val writer = KotlinWriter("com.test")
         val service = model.getShape(ShapeId.from("com.test#Example")).get().asServiceShape().get()
         writer.onSection(SECTION_SERVICE_INTERFACE_COMPANION_OBJ) {
@@ -111,7 +111,7 @@ class ServiceGeneratorTest {
                 .closeBlock("}")
         }
 
-        val settings = KotlinSettings(service.id, "test", "0.0")
+        val settings = KotlinSettings(service.id, "test", "0.0", sdkId = service.id.name)
         val renderingCtx = RenderingContext(writer, service, model, provider, settings)
         val generator = ServiceGenerator(renderingCtx)
         generator.render()
@@ -136,10 +136,10 @@ class ServiceGeneratorTest {
     private fun generateService(modelResourceName: String): String {
         val model = javaClass.getResource(modelResourceName).asSmithy()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Example")
         val writer = KotlinWriter("test")
         val service = model.getShape(ShapeId.from("com.test#Example")).get().asServiceShape().get()
-        val settings = KotlinSettings(service.id, "test", "0.0")
+        val settings = KotlinSettings(service.id, "test", "0.0", sdkId = service.id.name)
         val renderingCtx = RenderingContext(writer, service, model, provider, settings)
         val generator = ServiceGenerator(renderingCtx)
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ShapeValueGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ShapeValueGeneratorTest.kt
@@ -40,7 +40,7 @@ class ShapeValueGeneratorTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "MyMap")
         val mapShape = model.expectShape(ShapeId.from("foo.bar#MyMap"))
         val writer = KotlinWriter("test")
 
@@ -77,7 +77,7 @@ mapOf<String, Int>(
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "MyList")
         val mapShape = model.expectShape(ShapeId.from("foo.bar#MyList"))
         val writer = KotlinWriter("test")
 
@@ -146,7 +146,7 @@ listOf<String>(
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "MyStruct")
 
         val structShape = model.expectShape(ShapeId.from("foo.bar#MyStruct"))
         val writer = KotlinWriter("test")
@@ -237,7 +237,7 @@ MyStruct {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "MyUnion")
 
         val unionShape = model.expectShape(ShapeId.from("foo.bar#MyUnion"))
         val writer = KotlinWriter("test")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/StructureGeneratorTest.kt
@@ -134,7 +134,7 @@ class StructureGeneratorTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
@@ -146,7 +146,7 @@ class StructureGeneratorTest {
             .assemble()
             .unwrap()
 
-        val errorProvider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(errorModel, "error.test")
+        val errorProvider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(errorModel, "error.test", "Test")
         val errorWriter = KotlinWriter("com.error.test")
         val clientErrorGenerator = StructureGenerator(errorModel, errorProvider, errorWriter, clientErrorShape)
         clientErrorGenerator.render()
@@ -359,7 +359,7 @@ class MyStruct private constructor(builder: BuilderImpl) {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         StructureGenerator(model, provider, writer, struct).render()
 
@@ -455,7 +455,7 @@ class MyStruct private constructor(builder: BuilderImpl) {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
@@ -484,7 +484,7 @@ class MyStruct private constructor(builder: BuilderImpl) {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
@@ -568,7 +568,7 @@ class InternalServerException private constructor(builder: BuilderImpl) : Servic
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, serverErrorShape)
 
@@ -597,7 +597,7 @@ class InternalServerException private constructor(builder: BuilderImpl) : Servic
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
@@ -672,7 +672,7 @@ class InternalServerException private constructor(builder: BuilderImpl) : Servic
         """.asSmithyModel()
         val struct = model.expectShape<StructureShape>("com.test#GetFooInput")
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()
@@ -728,7 +728,7 @@ class InternalServerException private constructor(builder: BuilderImpl) : Servic
         """.asSmithyModel()
         val struct = model.expectShape<StructureShape>("com.test#GetFooInput")
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = StructureGenerator(model, provider, writer, struct)
         generator.render()

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SymbolProviderTest.kt
@@ -30,7 +30,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val actual = provider.toMemberName(member)
         assertEquals("`class`", actual)
     }
@@ -47,7 +47,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val structSymbol = provider.toSymbol(struct)
         val memberSymbol = provider.toSymbol(member)
         assertEquals("test.model", structSymbol.namespace)
@@ -87,7 +87,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val memberSymbol = provider.toSymbol(member)
         // builtins should not have a namespace set
         assertEquals("", memberSymbol.namespace)
@@ -116,7 +116,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val memberSymbol = provider.toSymbol(member)
         // builtins should not have a namespace set
         assertEquals("", memberSymbol.namespace)
@@ -141,7 +141,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val memberSymbol = provider.toSymbol(member)
 
         assertEquals("software.aws.clientrt.content", memberSymbol.namespace)
@@ -169,7 +169,7 @@ class SymbolProviderTest {
             }
         """.asSmithyModel()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val listSymbol = provider.toSymbol(model.expectShape<ListShape>("foo.bar#Records"))
 
         assertEquals("List<Record>", listSymbol.name)
@@ -202,7 +202,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val setSymbol = provider.toSymbol(set)
 
         assertEquals("Set<Record>", setSymbol.name)
@@ -232,7 +232,7 @@ class SymbolProviderTest {
             }
         """.asSmithyModel()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
 
         val mapSymbol = provider.toSymbol(model.expectShape<MapShape>("foo.bar#MyMap"))
 
@@ -267,7 +267,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val bigSymbol = provider.toSymbol(member)
         assertEquals("java.math", bigSymbol.namespace)
         assertEquals("null", bigSymbol.defaultValue())
@@ -292,7 +292,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val symbol = provider.toSymbol(shape)
 
         assertEquals("test.model", symbol.namespace)
@@ -319,7 +319,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val symbol = provider.toSymbol(union)
 
         assertEquals("test.model", symbol.namespace)
@@ -341,7 +341,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val structSymbol = provider.toSymbol(struct)
         assertEquals("test.model", structSymbol.namespace)
         assertEquals("MyStruct", structSymbol.name)
@@ -359,7 +359,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val documentSymbol = provider.toSymbol(document)
         assertEquals("Document", documentSymbol.name)
         assertEquals("null", documentSymbol.defaultValue())
@@ -410,7 +410,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val structSymbol = provider.toSymbol(struct)
         // should get reference to List and Instant
         assertEquals(2, structSymbol.references.size)
@@ -425,7 +425,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val timestampSymbol = provider.toSymbol(tsShape)
         assertEquals("software.aws.clientrt.time", timestampSymbol.namespace)
         assertEquals("Instant", timestampSymbol.name)
@@ -467,7 +467,7 @@ class SymbolProviderTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
 
         val structSymbol = provider.toSymbol(struct1)
         assertEquals("test.model", structSymbol.namespace)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SymbolVisitorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SymbolVisitorTest.kt
@@ -1,0 +1,19 @@
+package software.amazon.smithy.kotlin.codegen
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SymbolVisitorTest {
+
+    // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-core.html#using-sdk-service-id-for-client-naming
+    @Test
+    fun `it produces the correct string transformation for client names`() {
+        assertEquals("ApiGateway", "API Gateway".clientName())
+        assertEquals("Lambda", "Lambda".clientName())
+        assertEquals("Elasticache", "ElastiCache".clientName())
+        assertEquals("Apigatewaymanagementapi", "ApiGatewayManagementApi".clientName())
+        assertEquals("MigrationhubConfig", "MigrationHub Config".clientName())
+        assertEquals("Iotfleethub", "IoTFleetHub".clientName())
+        assertEquals("Iot1clickProjects", "IoT 1Click Projects".clientName())
+    }
+}

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/UnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/UnionGeneratorTest.kt
@@ -41,7 +41,7 @@ class UnionGeneratorTest {
             .assemble()
             .unwrap()
 
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test")
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, "test", "Test")
         val writer = KotlinWriter("com.test")
         val generator = UnionGenerator(model, provider, writer, union)
         generator.render()


### PR DESCRIPTION
…enerate client name.

*Issue #, if available:* : /story/show/175850640

Companion PR: https://github.com/awslabs/aws-sdk-kotlin/pull/50

*Description of changes:*
* Generate SDK client name based on smithy spec
* Parse additional optional field in `smithy-build.json` file 
* misc cleanup

## Testing Done
* _contained in companion PR_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
