### PR TITLE
fix interpolated string encoding error in url path builder

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/Utils.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/Utils.kt
@@ -88,8 +88,3 @@ inline fun <reified T : Trait> Shape.expectTrait(): T = expectTrait(T::class.jav
  * Kotlin sugar for getTrait() check. e.g. shape.getTrait<EnumTrait>() instead of shape.getTrait(EnumTrait::class.java)
  */
 inline fun <reified T : Trait> Shape.getTrait(): T? = getTrait(T::class.java).getOrNull()
-
-/**
- * Escape characters in strings to ensure they are treated as pure literals.
- */
-fun String.kotlinStringLiteral(): String = replace("\$", "\\$")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.*
+import software.amazon.smithy.kotlin.codegen.lang.toEscapedLiteral
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.neighbor.RelationshipType
 import software.amazon.smithy.model.neighbor.Walker
@@ -378,7 +379,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                     }
                 } else {
                     // literal
-                    segment.content.kotlinStringLiteral()
+                    segment.content.toEscapedLiteral()
                 }
             }
         )

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -84,3 +84,8 @@ fun isValidKotlinIdentifier(s: String): Boolean {
  */
 val Symbol.isBuiltIn: Boolean
     get() = namespace == "kotlin"
+
+/**
+ * Escape characters in strings to ensure they are treated as pure literals.
+ */
+fun String.toEscapedLiteral(): String = replace("\$", "\\$")


### PR DESCRIPTION
Escape '$' character when generating string literals to codegen for URI paths.  Minor cleanup

*Issue #, if available:*  /story/show/176972455

*Description of changes:*
* Escape `$` character only when emitting string literal path segments

## Testing Done

Services documented in ticket compile w/out error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
