### PR TITLE
Fix xml pull parser to handle escaped characters in deserialization. …

### DIFF
--- a/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
+++ b/client-runtime/serde/serde-xml/common/src/software.aws.clientrt.serde.xml/XmlSerializer.kt
@@ -104,9 +104,7 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
         xmlWriter.endTag(descriptor.serialName)
     }
 
-    override fun rawField(descriptor: SdkFieldDescriptor, value: String) {
-        TODO("Not yet implemented")
-    }
+    override fun rawField(descriptor: SdkFieldDescriptor, value: String) = field(descriptor, value)
 
     override fun nullField(descriptor: SdkFieldDescriptor) {
         xmlWriter.startTag(descriptor.serialName)
@@ -157,7 +155,7 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
     }
 
     override fun serializeRaw(value: String) {
-        TODO("Not yet implemented")
+        xmlWriter.text(value)
     }
 
     override fun serializeSdkSerializable(value: SdkSerializable) = value.serialize(this)
@@ -227,9 +225,8 @@ private class XmlMapSerializer(
         }
     }
 
-    override fun rawEntry(key: String, value: String) {
-        TODO("Not yet implemented")
-    }
+    override fun rawEntry(key: String, value: String) =
+        entry(key, value)
 
     override fun serializeBoolean(value: Boolean) = serializePrimitive(value)
 

--- a/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerializerTest.kt
+++ b/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlSerializerTest.kt
@@ -14,53 +14,29 @@ class XmlSerializerTest {
     @Test
     fun canSerializeClassWithClassField() {
         val a = A(
-            B(2)
+            B("2")
         )
         val xml = XmlSerializer()
         a.serialize(xml)
         assertEquals("""<a><b><v>2</v></b></a>""", xml.toByteArray().decodeToString())
     }
 
-    class A(private val b: B) : SdkSerializable {
-        companion object {
-            val descriptorB: SdkFieldDescriptor = SdkFieldDescriptor(SerialKind.Struct, XmlSerialName("b"))
-
-            val objectDescriptor: SdkObjectDescriptor = SdkObjectDescriptor.build {
-                trait(XmlSerialName("a"))
-                field(descriptorB)
-            }
-        }
-
-        override fun serialize(serializer: Serializer) {
-            serializer.serializeStruct(objectDescriptor) {
-                field(descriptorB, b)
-            }
-        }
-    }
-
-    data class B(private val value: Int) : SdkSerializable {
-        companion object {
-            val descriptorValue = SdkFieldDescriptor(SerialKind.Integer, XmlSerialName("v"))
-
-            val objectDescriptor: SdkObjectDescriptor = SdkObjectDescriptor.build {
-                trait(XmlSerialName("b"))
-                field(descriptorValue)
-            }
-        }
-
-        override fun serialize(serializer: Serializer) {
-            serializer.serializeStruct(objectDescriptor) {
-                field(descriptorValue, value)
-            }
-        }
+    @Test
+    fun canSerializeClassWithEscapedCharacter() {
+        val a = A(
+            B("&lt;string&gt;")
+        )
+        val xml = XmlSerializer()
+        a.serialize(xml)
+        assertEquals("""<a><b><v>&amp;lt;string&amp;gt;</v></b></a>""", xml.toByteArray().decodeToString())
     }
 
     @Test
     fun canSerializeListOfClasses() {
         val obj = listOf(
-            B(1),
-            B(2),
-            B(3)
+            B("1"),
+            B("2"),
+            B("3")
         )
         val xml = XmlSerializer()
         xml.serializeList(SdkFieldDescriptor(SerialKind.List, XmlSerialName("list"), XmlCollectionName("b"))) {
@@ -74,9 +50,9 @@ class XmlSerializerTest {
     @Test
     fun canSerializeFlatListOfClasses() {
         val obj = listOf(
-            B(1),
-            B(2),
-            B(3)
+            B("1"),
+            B("2"),
+            B("3")
         )
         val xml = XmlSerializer()
         xml.serializeList(SdkFieldDescriptor(SerialKind.List, XmlSerialName("list"), XmlCollectionName("b"), Flattened)) {
@@ -357,6 +333,40 @@ data class Primitives(
                     serializeInt(value)
                 }
             }
+        }
+    }
+}
+
+class A(private val b: B) : SdkSerializable {
+    companion object {
+        val descriptorB: SdkFieldDescriptor = SdkFieldDescriptor(SerialKind.Struct, XmlSerialName("b"))
+
+        val objectDescriptor: SdkObjectDescriptor = SdkObjectDescriptor.build {
+            trait(XmlSerialName("a"))
+            field(descriptorB)
+        }
+    }
+
+    override fun serialize(serializer: Serializer) {
+        serializer.serializeStruct(objectDescriptor) {
+            field(descriptorB, b)
+        }
+    }
+}
+
+data class B(private val value: String) : SdkSerializable {
+    companion object {
+        val descriptorValue = SdkFieldDescriptor(SerialKind.String, XmlSerialName("v"))
+
+        val objectDescriptor: SdkObjectDescriptor = SdkObjectDescriptor.build {
+            trait(XmlSerialName("b"))
+            field(descriptorValue)
+        }
+    }
+
+    override fun serialize(serializer: Serializer) {
+        serializer.serializeStruct(objectDescriptor) {
+            field(descriptorValue, value)
         }
     }
 }


### PR DESCRIPTION
… Add tests. Implement raw serialization in xml serializer to fix some protocol tests.

*Issue #, if available:* https://github.com/awslabs/smithy-kotlin/issues/240

*Description of changes:*
* Add a special case parse mode to XmlStreamReaderXmlPull to enable parsing escaped characters contained in text nodes.
* Add tests to exercise escaped text
* Based on some protocol test failures, implement the raw serialize method in Xml serializer, map it to string serialization.  

## Testing Done

* relevant restXml protocol tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
