### PR TITLE
use sdkId if available for service client generation

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/ServiceGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/ServiceGenerator.kt
@@ -125,7 +125,7 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.write("")
             .write("override val serviceName: String")
             .indent()
-            .write("get() = \"#L\"", ctx.settings.sdkId)
+            .write("get() = #S", ctx.settings.sdkId)
             .dedent()
     }
 


### PR DESCRIPTION
Use settings property to retrieve sdk id or service name.  Fixes https://github.com/awslabs/smithy-kotlin/issues/236.

*Issue #, if available:* https://github.com/awslabs/smithy-kotlin/issues/236

*Description of changes:*
* Use existing property to read sdkId and fall back to service name if unavailable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
