### PR TITLE
fix: turn off default ktor response validation

### DIFF
--- a/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/software/aws/clientrt/http/engine/ktor/KtorEngine.kt
+++ b/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/software/aws/clientrt/http/engine/ktor/KtorEngine.kt
@@ -31,6 +31,9 @@ import software.aws.clientrt.http.response.HttpResponse as SdkHttpResponse
 class KtorEngine(val config: HttpClientEngineConfig) : HttpClientEngine {
     val client: HttpClient = HttpClient(OkHttp) {
         // TODO - propagate applicable client engine config to OkHttp engine
+
+        // do not throw exceptions if status code < 300, error handling is expected by generated clients
+        expectSuccess = false
     }
     private val logger = Logger.getLogger<KtorEngine>()
 


### PR DESCRIPTION
*Description of changes:*
Turn off ktor's response validation that throws exceptions for HTTP status code < 300 by default. This allows generated error response middleware to intercept the raw response without catching a ktor specific exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
