### PR TITLE
fix: allow writing to file that doesn't exist yet

### DIFF
--- a/client-runtime/client-rt-core/jvm/src/software/aws/clientrt/content/ByteStreamJVM.kt
+++ b/client-runtime/client-rt-core/jvm/src/software/aws/clientrt/content/ByteStreamJVM.kt
@@ -28,7 +28,7 @@ fun File.asByteStream(): ByteStream = FileContent(this)
  */
 fun Path.asByteStream(): ByteStream {
     val f = toFile()
-    require(f.exists()) { "cannot create ByteStream, invalid file: $this" }
+    require(f.exists()) { "cannot create ByteStream, file does not exist: $this" }
     require(f.isFile) { "cannot create a ByteStream from a directory: $this" }
     return f.asByteStream()
 }


### PR DESCRIPTION
*Description of changes:*
* (fix): removes invalid input parameter validation that prevents writing to a file that does not exist yet. Let the OS/JVM validate the call instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
