### PR TITLE
feat(codegen): suffix exception names where appropriate

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.kotlin.codegen.core
 
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.lang.isValidKotlinIdentifier
+import software.amazon.smithy.kotlin.codegen.model.isError
 import software.amazon.smithy.kotlin.codegen.utils.splitOnWordBoundaries
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
 import software.amazon.smithy.kotlin.codegen.utils.toPascalCase
@@ -19,11 +20,26 @@ import java.util.logging.Logger
 
 // (somewhat) centralized naming rules
 
+private const val defaultErrorSuffix = "Exception"
+private val allowableErrorSuffixes = listOf(
+    defaultErrorSuffix,
+    "Fault",
+    "Error",
+)
+
 /**
  * Get the default name for a shape (for code generation).  Delegates to
  * Smithy to rename shapes when configured to do so in the model.
  */
-fun Shape.defaultName(serviceShape: ServiceShape): String = id.getName(serviceShape).toPascalCase()
+fun Shape.defaultName(serviceShape: ServiceShape): String {
+    val name = id.getName(serviceShape).toPascalCase()
+
+    return if (this.isError && allowableErrorSuffixes.none(name::endsWith)) {
+        name + defaultErrorSuffix
+    } else {
+        name
+    }
+}
 
 /**
  * Get the default name for a member shape (for code generation)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -113,6 +113,12 @@ val Shape.isEnum: Boolean
     get() = isStringShape && hasTrait<EnumTrait>()
 
 /**
+ * Test if a shape is an error.
+ */
+val Shape.isError: Boolean
+    get() = hasTrait<ErrorTrait>()
+
+/**
  * Test if a shape represents an Kotlin number type
  */
 val Shape.isNumberShape: Boolean

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
 import software.amazon.smithy.kotlin.codegen.model.isBoxed
+import software.amazon.smithy.kotlin.codegen.model.isError
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ShapeType
@@ -38,7 +39,7 @@ class StructureGenerator(
 
         writer.renderDocumentation(shape)
         writer.renderAnnotations(shape)
-        if (!shape.hasTrait<ErrorTrait>()) {
+        if (!shape.isError) {
             renderStructure()
         } else {
             renderError()
@@ -77,7 +78,7 @@ class StructureGenerator(
             val (memberName, memberSymbol) = memberNameSymbolIndex[it]!!
             writer.renderMemberDocumentation(model, it)
             writer.renderAnnotations(it)
-            if (shape.hasTrait<ErrorTrait>() && "message" == memberName) {
+            if (shape.isError && "message" == memberName) {
                 val targetShape = model.expectShape(it.target)
                 if (!targetShape.isStringShape) {
                     throw CodegenException("Message is a reserved name for exception types and cannot be used for any other property")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -347,6 +347,39 @@ class SymbolProviderTest {
     }
 
     @Test
+    fun `suffixes error shape names when necessary`() {
+        assertEquals("SomethingWentWrongException", getExceptionName("SomethingWentWrong"))
+    }
+
+    @Test
+    fun `does not suffix error shape names that already end in "Exception"`() {
+        assertEquals("ThereCanBeNoException", getExceptionName("ThereCanBeNoException"))
+    }
+
+    @Test
+    fun `does not suffix error shape names that already end in "Error"`() {
+        assertEquals("HumanError", getExceptionName("HumanError"))
+    }
+
+    @Test
+    fun `does not suffix error shape names that already end in "Fault"`() {
+        assertEquals("SanAndreasFault", getExceptionName("SanAndreasFault"))
+    }
+
+    private fun getExceptionName(forShapeName: String): String {
+        val model = """
+            @error("client")
+            structure $forShapeName {
+                message: String
+            }
+        """.prependNamespaceAndService().toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
+        val member = model.expectShape<StructureShape>("com.test#$forShapeName")
+        return provider.toSymbol(member).name
+    }
+
+    @Test
     fun `creates documents`() {
         val document = DocumentShape.builder().id("foo.bar#MyDocument").build()
         val model = """


### PR DESCRIPTION
*Issue #, if available:* Closes #288

*Description of changes:* Suffix the names of generated exception structures with the name "Exception" unless the shape already ends in one of "Exception", "Error", or "Fault".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
