### PR TITLE
Remove non top-level restriction on namespace serialization

### DIFF
--- a/client-runtime/serde/serde-xml/common/src/software/aws/clientrt/serde/xml/XmlSerializer.kt
+++ b/client-runtime/serde/serde-xml/common/src/software/aws/clientrt/serde/xml/XmlSerializer.kt
@@ -29,7 +29,7 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
         val structDescriptor = parentDescriptorStack.peekOrNull() ?: descriptor
 
         // Serialize ns declarations
-        val ns = structDescriptor.findTrait<XmlNamespace>()
+        val ns = descriptor.findTrait<XmlNamespace>()
         if (ns != null) {
             xmlWriter.namespacePrefix(ns.uri, ns.prefix)
         }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/smithy-kotlin/issues/317

*Description of changes:*
* Remove restriction that only top level namespace or namespaces that specify a prefix are serialized.

## Testing Done
* Verified all protocol tests pass after change
* Verifed sample project calling operation that was broken completes succesfully:

```kotlin
suspend fun main() {
    val c = S3Client { region = "us-east-2" }

    c.putBucketAcl(PutBucketAclRequest {
        bucket = "s3-media-ingestion-example"
        acl = BucketCannedAcl.Private
    })

    c.close()
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
