### PR TITLE
Do not escape null w backticks

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.lang.isValidKotlinIdentifier
 import software.amazon.smithy.kotlin.codegen.model.isError
 import software.amazon.smithy.kotlin.codegen.utils.splitOnWordBoundaries
@@ -95,4 +94,4 @@ fun EnumDefinition.variantName(): String {
  * Generate the union variant name from a union member shape
  * e.g. `VariantName`
  */
-fun MemberShape.unionVariantName(symbolProvider: SymbolProvider): String = this.memberName.toPascalCase()
+fun MemberShape.unionVariantName(): String = this.memberName.toPascalCase()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
@@ -36,7 +36,7 @@ class UnionGenerator(
         shape.allMembers.values.sortedBy { it.memberName }.forEach {
             writer.renderMemberDocumentation(model, it)
             writer.renderAnnotations(it)
-            val variantName = it.unionVariantName(symbolProvider)
+            val variantName = it.unionVariantName()
             val targetType = model.expectShape(it.target).type
             writer.writeInline("data class #L(val value: #Q) : #Q()", variantName, symbolProvider.toSymbol(it), symbol)
             when (targetType) {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGenerator.kt
@@ -142,6 +142,6 @@ class SerializeUnionGenerator(
 internal fun MemberShape.unionTypeName(ctx: ProtocolGenerator.GenerationContext): String {
     val unionShape = ctx.model.expectShape(id.withoutMember())
     val unionSymbol = ctx.symbolProvider.toSymbol(unionShape)
-    val variantName = unionVariantName(ctx.symbolProvider)
+    val variantName = unionVariantName()
     return "${unionSymbol.name}.$variantName"
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
@@ -7,7 +7,6 @@ package software.amazon.smithy.kotlin.codegen.core
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.kotlin.codegen.model.expectShape
-import software.amazon.smithy.kotlin.codegen.test.defaultSettings
 import software.amazon.smithy.kotlin.codegen.test.prependNamespaceAndService
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.shapes.MemberShape
@@ -135,9 +134,8 @@ class NamingTest {
                 }
             """.prependNamespaceAndService().toSmithyModel()
 
-            val symbolProvider = KotlinSymbolProvider(model, model.defaultSettings())
             val shape = model.expectShape<MemberShape>("com.test#TestStruct\$$input")
-            assertEquals(expected, shape.unionVariantName(symbolProvider), "input: $input")
+            assertEquals(expected, shape.unionVariantName(), "input: $input")
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* The simplest change that I can think of to allow `null` to be codegened as `Null`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
