### PR TITLE
feat(codegen): change operation dsl methods to overloads from extensions

### DIFF
--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -150,11 +150,11 @@ class ServiceGeneratorTest {
     @Test
     fun `it adds DSL overloads for operations`() {
         val expectedSignatures = listOf(
-            "suspend fun TestClient.getFoo(block: GetFooRequest.DslBuilder.() -> Unit) = getFoo(GetFooRequest.builder().apply(block).build())",
-            "suspend fun TestClient.getFooNoInput(block: GetFooNoInputRequest.DslBuilder.() -> Unit) = getFooNoInput(GetFooNoInputRequest.builder().apply(block).build())",
-            "suspend fun TestClient.getFooNoOutput(block: GetFooNoOutputRequest.DslBuilder.() -> Unit) = getFooNoOutput(GetFooNoOutputRequest.builder().apply(block).build())",
-            "suspend fun TestClient.getFooStreamingInput(block: GetFooStreamingInputRequest.DslBuilder.() -> Unit) = getFooStreamingInput(GetFooStreamingInputRequest.builder().apply(block).build())",
-            "suspend fun TestClient.getFooStreamingInputNoOutput(block: GetFooStreamingInputNoOutputRequest.DslBuilder.() -> Unit) = getFooStreamingInputNoOutput(GetFooStreamingInputNoOutputRequest.builder().apply(block).build())",
+            "suspend fun getFoo(block: GetFooRequest.DslBuilder.() -> Unit) = getFoo(GetFooRequest.builder().apply(block).build())",
+            "suspend fun getFooNoInput(block: GetFooNoInputRequest.DslBuilder.() -> Unit) = getFooNoInput(GetFooNoInputRequest.builder().apply(block).build())",
+            "suspend fun getFooNoOutput(block: GetFooNoOutputRequest.DslBuilder.() -> Unit) = getFooNoOutput(GetFooNoOutputRequest.builder().apply(block).build())",
+            "suspend fun getFooStreamingInput(block: GetFooStreamingInputRequest.DslBuilder.() -> Unit) = getFooStreamingInput(GetFooStreamingInputRequest.builder().apply(block).build())",
+            "suspend fun getFooStreamingInputNoOutput(block: GetFooStreamingInputNoOutputRequest.DslBuilder.() -> Unit) = getFooStreamingInputNoOutput(GetFooStreamingInputNoOutputRequest.builder().apply(block).build())",
         )
         expectedSignatures.forEach {
             commonTestContents.shouldContainOnlyOnceWithDiff(it)


### PR DESCRIPTION
*Issue #, if available:* Closes #184

*Companion PR:* awslabs/aws-sdk-kotlin#132

*Description of changes:* PR #321 added operation DSL _extension methods_ and @aajtodd correctly wondered whether overloads would be better. After attempting to use the extension methods I have to agree. Switching extension methods to in-interface overloads.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
