### PR TITLE
fix: ensure ByteStream is completely consumed

### DIFF
--- a/client-runtime/client-rt-core/common/src/software/aws/clientrt/content/ByteStream.kt
+++ b/client-runtime/client-rt-core/common/src/software/aws/clientrt/content/ByteStream.kt
@@ -49,9 +49,23 @@ sealed class ByteStream {
     }
 }
 
+/**
+ * Consume the [ByteStream] and pull the entire contents into memory as a [ByteArray].
+ * Only do this if you are sure the contents fit in-memory as this will read the entire contents
+ * of a streaming variant.
+ */
 suspend fun ByteStream.toByteArray(): ByteArray = when (val stream = this) {
     is ByteStream.Buffer -> stream.bytes()
-    is ByteStream.Reader -> stream.readFrom().readRemaining()
+    is ByteStream.Reader -> {
+        val chan = stream.readFrom()
+        val bytes = chan.readRemaining()
+        // readRemaining will read up to `limit` bytes (which is defaulted to Int.MAX_VALUE) or until
+        // the stream is closed and no more bytes remain.
+        // This is usually sufficient to consume the stream but technically that's not what it's doing.
+        // Save us a painful debug session later in the very rare chance this were to occur...
+        check(chan.isClosedForRead) { "failed to read all bytes from ByteStream.Reader, more data still expected" }
+        bytes
+    }
 }
 
 suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToString()


### PR DESCRIPTION
*Description of changes:*
Adds a missing state check on `ByteStream.toByteArray()` to ensure the stream was exhausted. We do this for `HttpBody.readAll()` (which wraps a ByteStream sometimes) but it should be verified there as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
