### PR TITLE
fix(codegen): undo exception renaming

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.kotlin.codegen.core
 
 import software.amazon.smithy.kotlin.codegen.lang.isValidKotlinIdentifier
-import software.amazon.smithy.kotlin.codegen.model.isError
 import software.amazon.smithy.kotlin.codegen.utils.splitOnWordBoundaries
 import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
 import software.amazon.smithy.kotlin.codegen.utils.toPascalCase
@@ -19,26 +18,11 @@ import java.util.logging.Logger
 
 // (somewhat) centralized naming rules
 
-private const val defaultErrorSuffix = "Exception"
-private val allowableErrorSuffixes = listOf(
-    defaultErrorSuffix,
-    "Fault",
-    "Error",
-)
-
 /**
  * Get the default name for a shape (for code generation).  Delegates to
  * Smithy to rename shapes when configured to do so in the model.
  */
-fun Shape.defaultName(serviceShape: ServiceShape): String {
-    val name = id.getName(serviceShape).toPascalCase()
-
-    return if (this.isError && allowableErrorSuffixes.none(name::endsWith)) {
-        name + defaultErrorSuffix
-    } else {
-        name
-    }
-}
+fun Shape.defaultName(serviceShape: ServiceShape): String = id.getName(serviceShape).toPascalCase()
 
 /**
  * Get the default name for a member shape (for code generation)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -347,39 +347,6 @@ class SymbolProviderTest {
     }
 
     @Test
-    fun `suffixes error shape names when necessary`() {
-        assertEquals("SomethingWentWrongException", getExceptionName("SomethingWentWrong"))
-    }
-
-    @Test
-    fun `does not suffix error shape names that already end in "Exception"`() {
-        assertEquals("ThereCanBeNoException", getExceptionName("ThereCanBeNoException"))
-    }
-
-    @Test
-    fun `does not suffix error shape names that already end in "Error"`() {
-        assertEquals("HumanError", getExceptionName("HumanError"))
-    }
-
-    @Test
-    fun `does not suffix error shape names that already end in "Fault"`() {
-        assertEquals("SanAndreasFault", getExceptionName("SanAndreasFault"))
-    }
-
-    private fun getExceptionName(forShapeName: String): String {
-        val model = """
-            @error("client")
-            structure $forShapeName {
-                message: String
-            }
-        """.prependNamespaceAndService().toSmithyModel()
-
-        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
-        val member = model.expectShape<StructureShape>("com.test#$forShapeName")
-        return provider.toSymbol(member).name
-    }
-
-    @Test
     fun `creates documents`() {
         val document = DocumentShape.builder().id("foo.bar#MyDocument").build()
         val model = """


### PR DESCRIPTION
*Issue #, if available:* closes awslabs/aws-sdk-kotlin#154

*Description of changes:* Undo the change added by #288 because it causes problems with shape conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
