### PR TITLE
fix: uri literals with dollar sign not escaped correctly

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -419,7 +419,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                         writer.write("#S.$encodeFn,", "\${$identifier}")
                     } else {
                         // literal
-                        writer.write("#S,", segment.content.toEscapedLiteral())
+                        writer.write("\"#L\",", segment.content.toEscapedLiteral())
                     }
                 }
             }
@@ -434,7 +434,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                     it.content.toEscapedLiteral()
                 }
             )
-            writer.write("path = #S", resolvedPath)
+            writer.write("path = \"#L\"", resolvedPath)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
fixes #395

*Description of changes:*
The `S` formatter on CodeWriter will escape backslashes in the string which results in incorrect escaping generated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
