### PR TITLE
fix(rt): explicitly specify UTF-8 encoding for XML serializer

### DIFF
--- a/client-runtime/serde/serde-xml/jvm/src/software/aws/clientrt/serde/xml/XmlStreamWriterXmlPull.kt
+++ b/client-runtime/serde/serde-xml/jvm/src/software/aws/clientrt/serde/xml/XmlStreamWriterXmlPull.kt
@@ -8,6 +8,7 @@ package software.aws.clientrt.serde.xml
 import org.xmlpull.v1.XmlPullParserFactory
 import org.xmlpull.v1.XmlSerializer
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 
 class XmlPullSerializer(pretty: Boolean, private val serializer: XmlSerializer = xmlSerializerFactory()) :
     XmlStreamWriter {
@@ -16,7 +17,7 @@ class XmlPullSerializer(pretty: Boolean, private val serializer: XmlSerializer =
     private val buffer = ByteArrayOutputStream()
 
     init {
-        serializer.setOutput(buffer, null)
+        serializer.setOutput(buffer, StandardCharsets.UTF_8.name())
         if (pretty) {
             serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-indentation", " ".repeat(4))
             serializer.setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-line-separator", "\n")


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:* This fixes a bug with the [pizza test in `XmlStreamWriterTest.itHandlesEscaping()`](https://github.com/awslabs/smithy-kotlin/blob/87cfa07dcf3163c1fa364d2bd2df1d41cd8560cf/client-runtime/serde/serde-xml/common/test/software/aws/clientrt/serde/xml/XmlStreamWriterTest.kt#L83) on Windows. Namely, absent an explicit encoding, the serializer defaults to `Charsets.defaultCharset()` which is usually [CP-1252](https://en.wikipedia.org/wiki/Windows-1252) on Windows/English. The [restXml spec](https://awslabs.github.io/smithy/1.0/spec/aws/aws-restxml-protocol.html#xml-shape-serialization) states strings should be uncoded as UTF-8. The [XML 1.0 specification](https://www.w3.org/TR/REC-xml/#charencoding) also states (obliquely) that non-ASCII characters are UTF-8 if not specified by a doctype encoding or byte order mark.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
