### PR TITLE
chore: reconfigure Snyk scan for only build file updates

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -3,11 +3,16 @@ name: Snyk
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**gradle**' # build.gradle.kts, settings.gradle.kts, gradle.properties, etc.
+      - '**snyk**' # .snyk, snyk-scan.yml
   pull_request:
     branches: [ main ]
+    paths:
+      - '**gradle**'
+      - '**snyk**'
   schedule:
-    # 17:00 UTC (9am/10am Pacific) every Tuesday
-    - cron:  '0 17 * * 2'
+    - cron:  '0 17 * * 2' # 17:00 UTC (9am/10am Pacific) every Tuesday
 
 jobs:
   snyk:


### PR DESCRIPTION
## Issue \#

Closes #409 

## Description of changes

Snyk scans should only be necessary for changes which could alter the dependency graph. This change limits scanning on push/PR to only files with **gradle** or **snyk** in the path.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.