### PR TITLE
fix: httpRequestTest with streaming member compile error

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
@@ -111,18 +111,18 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
      */
     protected open fun renderServiceCall() {
         val inputParamName = operation.input.map { "input" }.orElse("")
-        val isStreamingRequest = operation.input.map {
-            val inputShape = model.expectShape(it)
-            inputShape.asStructureShape().get().hasStreamingMember(model)
+        val isStreamingResponse = operation.output.map {
+            val outputShape = model.expectShape(it)
+            outputShape.asStructureShape().get().hasStreamingMember(model)
         }.orElse(false)
 
         // invoke the operation
         val opName = operation.defaultName()
 
         if (operation.output.isPresent) {
-            // streaming requests have a different operation signature that require a block to be passed to
+            // streaming responses have a different operation signature that require a block to be passed to
             // process the response - add an empty block if necessary
-            if (isStreamingRequest) {
+            if (isStreamingResponse) {
                 writer.openBlock("service.#L(#L){ actualResult ->", opName, inputParamName)
                     .call {
                         renderAssertions()


### PR DESCRIPTION
## Issue \#
found while implementing https://github.com/awslabs/aws-sdk-kotlin/pull/182

## Description of changes
We were erroneously generating the request test with additional empty block. This is correct for streaming responses but not for a request with a streaming member.

```kt
service.operation(input){}
```

Changed to predicate off the response members.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
