### PR TITLE
feat: enable signing for published artifacts

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -4,7 +4,7 @@
  */
 
 apply plugin: 'maven-publish'
-
+apply plugin: 'signing'
 
 publishing {
     repositories {
@@ -40,6 +40,16 @@ publishing {
                 developerConnection = "scm:git:ssh://github.com/awslabs/smith-kotlin.git"
                 url = "https://github.com/awslabs/smithy-kotlin"
             }
+        }
+    }
+
+    if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+        signing {
+            useInMemoryPgpKeys(
+                    (String) project.property("signingKey"),
+                    (String) project.property("signingPassword")
+            )
+            sign(publications)
         }
     }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Enable PGP key signing of artifacts, necessary before uploading to Maven Central.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.