### PR TITLE
chore: address all warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,14 @@ allprojects {
     }
 }
 
+if (project.properties["kotlinWarningsAsErrors"]?.toString()?.toBoolean() == true) {
+    subprojects {
+        tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+            kotlinOptions.allWarningsAsErrors = true
+        }
+    }
+}
+
 apply(from = rootProject.file("gradle/codecoverage.gradle"))
 
 val ktlint by configurations.creating

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -120,5 +120,5 @@ internal class Waiter {
     suspend fun wait() { channel.receive() }
 
     // give the signal to continue
-    fun signal() { channel.offer(Unit) }
+    fun signal() { channel.trySend(Unit).getOrThrow() }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
@@ -24,7 +24,8 @@ internal fun HttpRequest.toKtorRequestBuilder(): KtorHttpRequestBuilder {
     val sdkUrl = this.url
     val sdkHeaders = this.headers
     builder.url {
-        protocol = URLProtocol(sdkUrl.scheme.protocolName.toLowerCase(), sdkUrl.scheme.defaultPort)
+        val protocolName = sdkUrl.scheme.protocolName.replaceFirstChar(Char::lowercaseChar)
+        protocol = URLProtocol(protocolName, sdkUrl.scheme.defaultPort)
         host = sdkUrl.host
         port = sdkUrl.port
         encodedPath = sdkUrl.path.encodeURLPath()

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -382,7 +382,6 @@ class JsonDeserializerTest {
                             else -> throw RuntimeException("unexpected field during test")
                         }
                     }
-                    nested
                 }
                 return nested
             }

--- a/runtime/testing/build.gradle.kts
+++ b/runtime/testing/build.gradle.kts
@@ -4,3 +4,13 @@
  */
 
 description = "Internal test utilities"
+
+kotlin {
+    sourceSets {
+        metadata {
+            dependencies {
+                commonMainApi(project(":runtime:utils"))
+            }
+        }
+    }
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -593,7 +593,8 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         // be different though (e.g. uri/method). We need to generate a serializer/deserializer per/operation
         // NOT per input/output shape
         val deserializerSymbol = buildSymbol {
-            definitionFile = "${op.deserializerName().capitalize()}.kt"
+            val definitionFileName = op.deserializerName().replaceFirstChar(Char::uppercaseChar)
+            definitionFile = "$definitionFileName.kt"
             name = op.deserializerName()
             namespace = "${ctx.settings.pkg.name}.transform"
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -103,6 +103,7 @@ open class DeserializeStructGenerator(
     }
 
     // TODO ~ Not yet implemented
+    @Suppress("UNUSED_PARAMETER") // Until method is implemented
     protected fun renderDocumentShapeDeserializer(memberShape: MemberShape) {
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/FormUrlSerdeDescriptorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/FormUrlSerdeDescriptorGenerator.kt
@@ -77,6 +77,7 @@ open class FormUrlSerdeDescriptorGenerator(
                     traits.add(SerdeFormUrl.FormUrlMapName, *it.toTypedArray())
                 }
             }
+            else -> { } // No action needed
         }
 
         return traits

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -522,6 +522,7 @@ open class SerializeStructGenerator(
         }
     }
 
+    @Suppress("UNUSED_PARAMETER") // Until method is implemented
     private fun renderDocumentShapeSerializer(memberShape: MemberShape) {
         // TODO("Not yet implemented")
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGenerator.kt
@@ -134,6 +134,7 @@ open class XmlSerdeDescriptorGenerator(
                         traitList.add(it)
                     }
             }
+            else -> { } // No action needed
         }
 
         return traitList

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
@@ -50,7 +50,7 @@ fun String.toCamelCase(): String = toPascalCase().replaceFirstChar { c -> c.lowe
  * * 'A' → 'a'
  * * '!' → '!'
  */
-fun Char.toggleCase(): Char = if (isUpperCase()) toLowerCase() else toUpperCase()
+fun Char.toggleCase(): Char = if (isUpperCase()) lowercaseChar() else uppercaseChar()
 
 /**
  * Toggles the case of the first character in the string. For example:

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -179,7 +179,7 @@ class KotlinWriterTest {
             writer.write(previousValue)
         }
 
-        unit.registerSectionWriter(NestedTestId) { writer, previousValue ->
+        unit.registerSectionWriter(NestedTestId) { writer, _ ->
             val state = writer.getContext(NestedTestId.a)
             writer.write("// nested section with state $state")
         }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change fixes or suppresses all warnings currently in **smithy-kotlin**. It also adds a property (settable at command-line with `-PkotlinWarningsAsErrors=true` or in local **gradle.properties**) to fail compilation if warnings exist. This property may be used for a future CI job.

Most of the fixes should be self-explanatory. Feel free to ask if any aren't clear (or could be done better).

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.