### PR TITLE
fix: upgrade kotlin-test to 1.5.30-RC

### DIFF
--- a/compile-tests/build.gradle.kts
+++ b/compile-tests/build.gradle.kts
@@ -12,6 +12,7 @@ extra["moduleName"] = "software.amazon.smithy.kotlin.codegen"
 val smithyVersion: String by project
 val kotestVersion: String by project
 val kotlinVersion: String by project
+val kotlinTestVersion: String by project
 val junitVersion: String by project
 val kotlinCompileTestingVersion: String by project
 
@@ -29,8 +30,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$kotlinCompileTestingVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinTestVersion")
 }
 
 tasks.test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ sdkVersion=0.4.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.5.20
+kotlinTestVersion=1.5.30-RC
 dokkaVersion=1.4.32
 
 # kotlin libraries

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -52,8 +52,8 @@ kotlin {
         androidTest {
             dependencies {
                 implementation "junit:junit:$junitVersion"
-                implementation "org.jetbrains.kotlin:kotlin-test"
-                implementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+                implementation "org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion"
+                implementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinTestVersion"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion"
                 implementation "io.kotest:kotest-assertions-core-jvm:$kotestVersion"
                 implementation "androidx.test:runner:1.3.0"

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -10,8 +10,8 @@ kotlin.sourceSets {
         implementation group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-core", version: coroutinesVersion
     }
     commonTest.dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-test-common:$kotlinVersion"
-        implementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
+        implementation "org.jetbrains.kotlin:kotlin-test-common:$kotlinTestVersion"
+        implementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinTestVersion"
         implementation "io.kotest:kotest-assertions-core:$kotestVersion"
     }
 }

--- a/gradle/jvm.gradle
+++ b/gradle/jvm.gradle
@@ -14,8 +14,8 @@ kotlin {
         }
 
         jvmTest.dependencies {
-            api "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-            api "org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion"
+            api "org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion"
+            api "org.jetbrains.kotlin:kotlin-test-junit5:$kotlinTestVersion"
             implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutinesVersion"
 
             implementation "org.junit.jupiter:junit-jupiter:$junitVersion"

--- a/runtime/smithy-test/build.gradle.kts
+++ b/runtime/smithy-test/build.gradle.kts
@@ -8,6 +8,7 @@ extra["displayName"] = "Smithy :: Kotlin :: Test"
 extra["moduleName"] = "aws.smithy.kotlin.runtime.smithy.test"
 
 val kotlinVersion: String by project
+val kotlinTestVersion: String by project
 val kotlinxSerializationVersion: String = "0.20.0"
 
 kotlin {
@@ -19,7 +20,7 @@ kotlin {
                 implementation(project(":runtime:testing"))
                 implementation(project(":runtime:serde:serde-xml"))
 
-                implementation("org.jetbrains.kotlin:kotlin-test-common:$kotlinVersion")
+                implementation("org.jetbrains.kotlin:kotlin-test-common:$kotlinTestVersion")
 
                 // kotlinx-serialization::JsonElement allows comparing arbitrary JSON docs for equality
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kotlinxSerializationVersion")
@@ -34,7 +35,7 @@ kotlin {
         jvmMain {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVersion")
-                implementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+                implementation("org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion")
             }
         }
     }

--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -19,6 +19,7 @@ version = sdkVersion
 
 val smithyVersion: String by project
 val kotlinVersion: String by project
+val kotlinTestVersion: String by project
 val junitVersion: String by project
 val kotestVersion: String by project
 
@@ -33,8 +34,8 @@ dependencies {
     // These are not set as test dependencies so they can be shared with other modules
     implementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     implementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
-    implementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-test:$kotlinTestVersion")
+    implementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinTestVersion")
 }
 
 val generateSdkRuntimeVersion by tasks.registering {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
@@ -35,6 +35,7 @@ private fun getDefaultRuntimeVersion(): String {
 const val RUNTIME_GROUP: String = "aws.smithy.kotlin"
 val RUNTIME_VERSION: String = System.getProperty("smithy.kotlin.codegen.clientRuntimeVersion", getDefaultRuntimeVersion())
 val KOTLIN_COMPILER_VERSION: String = System.getProperty("smithy.kotlin.codegen.kotlinCompilerVersion", "1.5.20")
+val KOTLIN_TEST_VERSION: String = System.getProperty("smithy.kotlin.codegen.kotlinTestVersion", "1.5.30-RC")
 
 // See: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
 enum class GradleConfiguration {
@@ -77,8 +78,8 @@ data class KotlinDependency(
         val SMITHY_TEST = KotlinDependency(GradleConfiguration.TestImplementation, "$RUNTIME_ROOT_NS.smithy.test", RUNTIME_GROUP, "smithy-test", RUNTIME_VERSION)
 
         // External third-party dependencies
-        val KOTLIN_TEST = KotlinDependency(GradleConfiguration.TestImplementation, "kotlin.test", "org.jetbrains.kotlin", "kotlin-test", KOTLIN_COMPILER_VERSION)
-        val KOTLIN_TEST_JUNIT5 = KotlinDependency(GradleConfiguration.TestImplementation, "kotlin.test.junit5", "org.jetbrains.kotlin", "kotlin-test-junit5", KOTLIN_COMPILER_VERSION)
+        val KOTLIN_TEST = KotlinDependency(GradleConfiguration.TestImplementation, "kotlin.test", "org.jetbrains.kotlin", "kotlin-test", KOTLIN_TEST_VERSION)
+        val KOTLIN_TEST_JUNIT5 = KotlinDependency(GradleConfiguration.TestImplementation, "kotlin.test.junit5", "org.jetbrains.kotlin", "kotlin-test-junit5", KOTLIN_TEST_VERSION)
         val JUNIT_JUPITER_ENGINE = KotlinDependency(GradleConfiguration.TestRuntimeOnly, "org.junit.jupiter", "org.junit.jupiter", "junit-jupiter-engine", "5.4.2")
     }
 


### PR DESCRIPTION
## Issue \#

No local issue. A generic JB issue describes the problem: https://youtrack.jetbrains.com/issue/KT-47477

## Description of changes

Some build environments are encountering errors when trying to build **smithy-kotlin**:

```
Execution failed for task ':compileTestKotlinJvm'.
> Error while evaluating property 'filteredArgumentsMap' of task ':compileTestKotlinJvm'
   > Could not resolve all files for configuration ':jvmTestCompileClasspath'.
      > Could not resolve org.jetbrains.kotlin:kotlin-test:1.5.20.
        Required by:
            project :
         > Unable to find a variant of org.jetbrains.kotlin:kotlin-test:1.5.20 providing the requested capability org.jetbrains.kotlin:kotlin-test-framework-junit5:
              - Variant compile provides org.jetbrains.kotlin:kotlin-test:1.5.20
              - Variant runtime provides org.jetbrains.kotlin:kotlin-test:1.5.20
              - Variant platform-compile provides org.jetbrains.kotlin:kotlin-test-derived-platform:1.5.20
              - Variant platform-runtime provides org.jetbrains.kotlin:kotlin-test-derived-platform:1.5.20
              - Variant enforced-platform-compile provides org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:1.5.20
              - Variant enforced-platform-runtime provides org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:1.5.20
```

This is apparently [a known issue in **kotlin-test**](https://youtrack.jetbrains.com/issue/KT-47477) fixed in 1.5.30. Since 1.5.30 is still in pre-release, using 1.5.30-RC instead.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
