### PR TITLE
refactor: allow non feature middleware; give middleware explicit order

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -100,7 +100,7 @@ fun <T : CodeWriter> T.closeAndOpenBlock(
     vararg args: Any,
 ): T = apply {
     dedent()
-    openBlock(textBeforeNewLine, args)
+    openBlock(textBeforeNewLine, *args)
     indent()
 }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -82,6 +82,29 @@ fun <T : CodeWriter> T.wrapBlockIf(
 }
 
 /**
+ * Extension function that closes the previous block, dedents, opens a new block with [textBeforeNewLine], and indents.
+ *
+ * This is useful for chaining if-if-else-else branches.
+ *
+ * Example:
+ * ```
+ * writer.openBlock("if (foo) {")
+ *     .write("foo()")
+ *     .closeAndOpenBlock("} else {")
+ *     .write("bar()")
+ *     .closeBlock("}")
+ * ```
+ */
+fun <T : CodeWriter> T.closeAndOpenBlock(
+    textBeforeNewLine: String,
+    vararg args: Any,
+): T = apply {
+    dedent()
+    openBlock(textBeforeNewLine, args)
+    indent()
+}
+
+/**
  * Declares a section for extension in codegen.  The [SectionId] should be specified as a child
  * of the type housing the codegen associated with the section. This keeps [SectionId]s closely
  * associated with their targets.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -52,6 +52,7 @@ object RuntimeTypes {
             val HttpDeserialize = runtimeSymbol("HttpDeserialize", KotlinDependency.HTTP, "operation")
             val HttpSerialize = runtimeSymbol("HttpSerialize", KotlinDependency.HTTP, "operation")
             val SdkHttpOperation = runtimeSymbol("SdkHttpOperation", KotlinDependency.HTTP, "operation")
+            val OperationRequest = runtimeSymbol("OperationRequest", KotlinDependency.HTTP, "operation")
             val context = runtimeSymbol("context", KotlinDependency.HTTP, "operation")
             val roundTrip = runtimeSymbol("roundTrip", KotlinDependency.HTTP, "operation")
             val execute = runtimeSymbol("execute", KotlinDependency.HTTP, "operation")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -271,15 +271,9 @@ abstract class HttpProtocolClientGenerator(
             .call {
                 middleware
                     .filter { it.isEnabledFor(ctx, op) }
+                    .sortedBy(ProtocolMiddleware::order)
                     .forEach { middleware ->
-                        middleware.addImportsAndDependencies(writer)
-                        if (middleware.needsConfiguration) {
-                            writer.openBlock("install(#L) {", middleware.name)
-                                .call { middleware.renderConfigure(writer) }
-                                .closeBlock("}")
-                        } else {
-                            writer.write("install(#L)", middleware.name)
-                        }
+                        middleware.render(ctx, op, writer)
                     }
                 if (op.hasTrait<HttpChecksumRequiredTrait>()) {
                     writer.addImport(RuntimeTypes.Http.Md5ChecksumMiddleware)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -17,7 +17,7 @@ class HttpProtocolClientGeneratorTest {
     private val deprecatedTestContents: String
     private val writer: KotlinWriter = KotlinWriter(TestModelDefault.NAMESPACE)
 
-    class MockProtocolMiddleware1 : ProtocolMiddleware {
+    class MockProtocolMiddleware1 : HttpFeatureMiddleware() {
         override val name: String = "MockProtocolMiddleware1"
         override fun renderConfigure(writer: KotlinWriter) {
             writer.write("configurationField1 = \"testing\"")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #287
support for https://github.com/awslabs/aws-sdk-kotlin/pull/301

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Allow middleware to register interceptors inline without defining a `Feature`. 
* Allow middleware to define an order


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
