### PR TITLE
feat(rt): add conversion from HttpRequest -> builder

### DIFF
--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequest.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequest.kt
@@ -4,10 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.request
 
-import aws.smithy.kotlin.runtime.http.Headers
-import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.Url
+import aws.smithy.kotlin.runtime.http.*
 
 /**
  * Immutable representation of an HTTP request
@@ -20,5 +17,27 @@ data class HttpRequest(
 ) {
     companion object {
         operator fun invoke(block: HttpRequestBuilder.() -> Unit): HttpRequest = HttpRequestBuilder().apply(block).build()
+    }
+}
+
+/**
+ * Convert an HttpRequest back to an [HttpRequestBuilder]
+ */
+fun HttpRequest.toBuilder(): HttpRequestBuilder {
+    val req = this
+    return HttpRequestBuilder().apply {
+        method = req.method
+        headers.appendAll(req.headers)
+        url {
+            scheme = req.url.scheme
+            host = req.url.host
+            port = req.url.port
+            path = req.url.path
+            parameters.appendAll(req.url.parameters)
+            fragment = req.url.fragment
+            userInfo = req.url.userInfo
+            forceQuery = req.url.forceQuery
+        }
+        body = req.body
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* add convenience `HttpRequest` -> `HttpRequestBuilder` conversion

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
