### PR TITLE
refactor(rt): make SdkClient implement Closeable

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -77,7 +77,7 @@ subprojects {
                 kotlin.srcDir("$platform/$srcDir")
                 resources.srcDir("$platform/${resourcesPrefix}resources")
                 languageSettings.progressiveMode = true
-                experimentalAnnotations.forEach { languageSettings.useExperimentalAnnotation(it) }
+                experimentalAnnotations.forEach { languageSettings.optIn(it) }
             }
         }
     }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Closeable.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Closeable.kt
@@ -8,10 +8,21 @@ package aws.smithy.kotlin.runtime.io
 // this really should live in the stdlib...
 // https://youtrack.jetbrains.com/issue/KT-31066
 
+/**
+ * A resource than can be closed. The [close] method is invoked to release resources
+ * an object is holding (e.g. such as open files)
+ */
 public expect interface Closeable {
+    /**
+     * Release any resources held by this object
+     */
     public fun close()
 }
 
+/**
+ * Executes the given [block] on this resource and then closes it whether an exception has
+ * occurred or not.
+ */
 public inline fun <C : Closeable, R> C.use(block: (C) -> R): R {
     var closed = false
 
@@ -22,7 +33,7 @@ public inline fun <C : Closeable, R> C.use(block: (C) -> R): R {
             closed = true
             close()
         } catch (second: Throwable) {
-            first.addSuppressedInternal(second)
+            first.addSuppressed(second)
         }
 
         throw first
@@ -32,6 +43,3 @@ public inline fun <C : Closeable, R> C.use(block: (C) -> R): R {
         }
     }
 }
-
-@PublishedApi
-internal expect fun Throwable.addSuppressedInternal(other: Throwable)

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/CloseableJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/CloseableJVM.kt
@@ -5,19 +5,4 @@
 
 package aws.smithy.kotlin.runtime.io
 
-import java.lang.reflect.Method
-
 public actual typealias Closeable = java.io.Closeable
-
-@PublishedApi
-internal actual fun Throwable.addSuppressedInternal(other: Throwable) {
-    AddSuppressedMethod?.invoke(this, other)
-}
-
-private val AddSuppressedMethod: Method? by lazy {
-    try {
-        Throwable::class.java.getMethod("addSuppressed", Throwable::class.java)
-    } catch (t: Throwable) {
-        null
-    }
-}

--- a/runtime/runtime-core/build.gradle.kts
+++ b/runtime/runtime-core/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         commonMain {
             dependencies {
                 // io types are exposed as part of content/*
+                // SdkClient also implements Closeable
                 api(project(":runtime:io"))
                 // Attributes property bag is exposed as client options
                 api(project(":runtime:utils"))

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/SdkClient.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/SdkClient.kt
@@ -4,11 +4,13 @@
  */
 package aws.smithy.kotlin.runtime
 
+import aws.smithy.kotlin.runtime.io.Closeable
+
 /**
  * Common interface all generated service clients implement
  */
-interface SdkClient {
+interface SdkClient : Closeable {
     val serviceName: String
 
-    fun close() {}
+    override fun close() {}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #248 
closes https://github.com/awslabs/aws-sdk-kotlin/issues/102
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Have `SdkClient` (which all generated clients implement already) implement `Closeable` rather than defining a separate `close()` method

This will mean that generated clients can now make use of [use](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html) where a client is closed automatically

e.g.

```kotlin

S3Client{ region = "us-east-1" }.use { client -> 
      client.putObject { ... }
}
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
