### PR TITLE
Replace junit imports with kotlin.test imports where possible

### DIFF
--- a/compile-tests/build.gradle.kts
+++ b/compile-tests/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     testImplementation("com.github.tschuchortdev:kotlin-compile-testing:$kotlinCompileTestingVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
 }
 

--- a/compile-tests/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
+++ b/compile-tests/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
@@ -1,9 +1,9 @@
 package software.amazon.smithy.kotlin.codegen
 
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.util.asSmithy
 import software.amazon.smithy.kotlin.codegen.util.testModelChangeAgainstSource
+import kotlin.test.assertTrue
 
 /**
  * These tests cover Smithy model changes that, by policy, are considered backward compatible against

--- a/compile-tests/src/test/kotlin/software/amazon/smithy/kotlin/codegen/WhiteLabelSDKTest.kt
+++ b/compile-tests/src/test/kotlin/software/amazon/smithy/kotlin/codegen/WhiteLabelSDKTest.kt
@@ -1,15 +1,16 @@
 package software.amazon.smithy.kotlin.codegen
 
 import com.tschuchort.compiletesting.KotlinCompilation
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.kotlin.codegen.lang.hardReservedWords
 import software.amazon.smithy.kotlin.codegen.util.asSmithy
 import software.amazon.smithy.kotlin.codegen.util.compileSdkAndTest
 import software.amazon.smithy.model.Model
 import java.io.ByteArrayOutputStream
 import java.net.URL
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Tests that validate the generated source for a white-label SDK
@@ -26,12 +27,12 @@ class WhiteLabelSDKTest {
         val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)
         compileOutputStream.flush()
 
-        assertTrue(compilationResult.exitCode == KotlinCompilation.ExitCode.OK, compileOutputStream.toString())
+        assertEquals(compilationResult.exitCode, KotlinCompilation.ExitCode.OK, compileOutputStream.toString())
     }
 
     // FIXME - disabled until we invest time into improving the extraneous warnings we get for things like parameter never used, etc
     @Test
-    @Disabled
+    @Ignore
     fun `white label sdk compiles without breaching warning threshold`() {
         val model = javaClass.getResource("/kitchen-sink-model.smithy").asSmithy()
 

--- a/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkBufferJVMTest.kt
+++ b/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkBufferJVMTest.kt
@@ -5,8 +5,8 @@
 
 package aws.smithy.kotlin.runtime.io
 
-import kotlin.test.Test
 import java.nio.ByteBuffer
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class SdkBufferJVMTest {

--- a/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkBufferJVMTest.kt
+++ b/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkBufferJVMTest.kt
@@ -5,7 +5,7 @@
 
 package aws.smithy.kotlin.runtime.io
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import java.nio.ByteBuffer
 import kotlin.test.assertEquals
 

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
@@ -15,8 +15,8 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import kotlin.test.Test
 import java.nio.ByteBuffer
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import io.ktor.content.ByteArrayContent as KtorByteArrayContent

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
@@ -15,7 +15,7 @@ import io.ktor.http.content.OutgoingContent
 import io.ktor.util.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.*
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import java.nio.ByteBuffer
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/LangTestUtils.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/LangTestUtils.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.test
 
-import org.junit.jupiter.api.Assertions
+import kotlin.test.assertEquals
 
 /**
  * This file houses test functions specific to Kotlin language particulars.
@@ -24,6 +24,6 @@ internal fun String.assertBalancedBracesAndParens() {
             ')' -> closedParens++
         }
     }
-    Assertions.assertEquals(openBraces, closedBraces, "unmatched open/closed braces:\n$this")
-    Assertions.assertEquals(openParens, closedParens, "unmatched open/close parens:\n$this")
+    assertEquals(openBraces, closedBraces, "unmatched open/closed braces:\n$this")
+    assertEquals(openParens, closedParens, "unmatched open/close parens:\n$this")
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -4,10 +4,10 @@
  */
 package software.amazon.smithy.kotlin.codegen
 
-import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
+import kotlin.test.Test
 
 // NOTE: protocol conformance is mostly handled by the protocol tests suite
 class IdempotentTokenGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -5,21 +5,21 @@
 
 package software.amazon.smithy.kotlin.codegen
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class KotlinSettingsTest {
     @Test
     fun `infers default service`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -42,7 +42,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `correctly reads rootProject var from build settings`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -67,7 +67,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `correctly reads generateBuildFiles var from build settings`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -92,7 +92,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `correctly reads optin annotations from build settings`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -117,7 +117,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `throws exception with empty package name`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -131,7 +131,7 @@ class KotlinSettingsTest {
             }
         """.trimIndent()
 
-        assertThrows<CodegenException> {
+        assertFailsWith<CodegenException> {
             KotlinSettings.from(
                 model,
                 Node.parse(contents).expectObjectNode()
@@ -141,7 +141,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `throws exception with invalid package name`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {
@@ -155,7 +155,7 @@ class KotlinSettingsTest {
             }
         """.trimIndent()
 
-        assertThrows<CodegenException> {
+        assertFailsWith<CodegenException> {
             KotlinSettings.from(
                 model,
                 Node.parse(contents).expectObjectNode()
@@ -165,7 +165,7 @@ class KotlinSettingsTest {
 
     @Test
     fun `allows valid package name`() {
-        val model = javaClass.getResource("simple-service.smithy").toSmithyModel()
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
             {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -5,12 +5,12 @@
 
 package software.amazon.smithy.kotlin.codegen
 
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/ImportDeclarationsTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/ImportDeclarationsTest.kt
@@ -4,9 +4,9 @@
  */
 package software.amazon.smithy.kotlin.codegen.core
 
-import kotlin.test.assertEquals
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ImportDeclarationsTest {
     @Test

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/ImportDeclarationsTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/ImportDeclarationsTest.kt
@@ -4,8 +4,8 @@
  */
 package software.amazon.smithy.kotlin.codegen.core
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 
 class ImportDeclarationsTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDelegatorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDelegatorTest.kt
@@ -6,14 +6,14 @@ package software.amazon.smithy.kotlin.codegen.core
 
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.build.PluginContext
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.model.node.Node
+import kotlin.test.assertTrue
 
 class KotlinDelegatorTest {
     @Test fun `it renders files into namespace`() {
@@ -40,9 +40,9 @@ class KotlinDelegatorTest {
         KotlinCodegenPlugin().execute(context)
 
         // inputs and outputs are renamed. See OperationNormalizer
-        Assertions.assertTrue(manifest.hasFile("src/main/kotlin/com/test/model/GetFooRequest.kt"))
-        Assertions.assertTrue(manifest.hasFile("src/main/kotlin/com/test/model/GetFooResponse.kt"))
-        Assertions.assertTrue(manifest.hasFile("src/main/kotlin/com/test/TestClient.kt"))
+        assertTrue(manifest.hasFile("src/main/kotlin/com/test/model/GetFooRequest.kt"))
+        assertTrue(manifest.hasFile("src/main/kotlin/com/test/model/GetFooResponse.kt"))
+        assertTrue(manifest.hasFile("src/main/kotlin/com/test/TestClient.kt"))
     }
 
     @Test fun `it adds imports`() {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDelegatorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDelegatorTest.kt
@@ -6,13 +6,13 @@ package software.amazon.smithy.kotlin.codegen.core
 
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
-import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.build.PluginContext
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.model.node.Node
+import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class KotlinDelegatorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -5,11 +5,11 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -5,13 +5,13 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class KotlinWriterTest {
 
@@ -20,7 +20,7 @@ class KotlinWriterTest {
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
         writer.dokka("These are the docs.\nMore.")
         val result = writer.toString()
-        Assertions.assertTrue(result.contains("/**\n * These are the docs.\n * More.\n */\n"))
+        assertTrue(result.contains("/**\n * These are the docs.\n * More.\n */\n"))
     }
 
     @Test
@@ -29,7 +29,7 @@ class KotlinWriterTest {
         val docs = "This is $ valid documentation."
         writer.dokka(docs)
         val result = writer.toString()
-        Assertions.assertTrue(result.contains("/**\n * " + docs + "\n */\n"))
+        assertTrue(result.contains("/**\n * " + docs + "\n */\n"))
     }
 
     /**
@@ -92,7 +92,7 @@ class KotlinWriterTest {
 
         val actual = unit.toString()
 
-        Assertions.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -132,7 +132,7 @@ class KotlinWriterTest {
 
         val actual = unit.toString()
 
-        Assertions.assertEquals(expected, actual)
+        assertEquals(expected, actual)
     }
 
     object TestId : SectionId {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
@@ -5,12 +5,12 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.prependNamespaceAndService
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.traits.EnumDefinition
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NamingTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.core
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.prependNamespaceAndService
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -4,9 +4,9 @@
  */
 package software.amazon.smithy.kotlin.codegen.core
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -257,7 +257,7 @@ class SymbolProviderTest {
         assertEquals("java.math", bigSymbol.namespace)
         assertEquals("null", bigSymbol.defaultValue())
         assertEquals(true, bigSymbol.isBoxed)
-        assertEquals("$type", bigSymbol.name)
+        assertEquals(type, bigSymbol.name)
     }
 
     @Test

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -4,9 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.core
 
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.DisplayName
-import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
@@ -21,6 +19,8 @@ import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.StreamingTrait
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class SymbolProviderTest {
     @Test

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/BuiltinPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/BuiltinPreprocessorTest.kt
@@ -7,12 +7,12 @@ package software.amazon.smithy.kotlin.codegen.lang
 
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldNotContainAll
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 
 class BuiltinPreprocessorTest {
     @Test

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/BuiltinPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/BuiltinPreprocessorTest.kt
@@ -7,7 +7,7 @@ package software.amazon.smithy.kotlin.codegen.lang
 
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldNotContainAll
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.lang
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -5,12 +5,12 @@
 
 package software.amazon.smithy.kotlin.codegen.lang
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.DocumentationTrait
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DocumentationPreprocessorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.lang
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/OperationNormalizerTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/OperationNormalizerTest.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.kotlin.codegen.model
 
 import io.kotest.matchers.string.shouldContain
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationInput
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationOutput
@@ -16,6 +15,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import kotlin.test.*
+import kotlin.test.Test
 
 class OperationNormalizerTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/OperationNormalizerTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/OperationNormalizerTest.kt
@@ -6,7 +6,7 @@
 package software.amazon.smithy.kotlin.codegen.model
 
 import io.kotest.matchers.string.shouldContain
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationInput
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationOutput

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
@@ -4,8 +4,8 @@
  */
 package software.amazon.smithy.kotlin.codegen.model
 
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
+import kotlin.test.*
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.KotlinDependency
 
 class SymbolBuilderTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
@@ -4,9 +4,9 @@
  */
 package software.amazon.smithy.kotlin.codegen.model
 
+import software.amazon.smithy.kotlin.codegen.core.KotlinDependency
 import kotlin.test.*
 import kotlin.test.Test
-import software.amazon.smithy.kotlin.codegen.core.KotlinDependency
 
 class SymbolBuilderTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -7,7 +7,7 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -7,7 +7,6 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
@@ -16,6 +15,7 @@ import software.amazon.smithy.kotlin.codegen.model.hasIdempotentTokenMember
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
+import kotlin.test.Test
 
 class ClientConfigGeneratorTest {
     private fun getModel(): Model = loadModelFromResource("idempotent-token-test-model.smithy")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
@@ -6,14 +6,14 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.StringShape
+import kotlin.test.assertFailsWith
 
 class EnumGeneratorTest {
 
@@ -254,7 +254,7 @@ sealed class Baz {
         val provider = KotlinCodegenPlugin.createSymbolProvider(model)
         val symbol = provider.toSymbol(shape)
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
-        val ex = assertThrows<CodegenException> {
+        val ex = assertFailsWith<CodegenException> {
             EnumGenerator(shape, symbol, writer).render()
         }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
@@ -6,13 +6,13 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.StringShape
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class EnumGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
@@ -254,7 +254,7 @@ class ExceptionGeneratorTest {
             val writer = KotlinWriter(TestModelDefault.NAMESPACE)
             val ctx = GenerationContext(model, provider, model.defaultSettings())
 
-            val e = assertThrows<CodegenException> {
+            val e = assertFailsWith<CodegenException> {
                 ExceptionBaseClassGenerator.render(ctx, writer)
             }
             e.message.shouldContainOnlyOnceWithDiff("Generated base error type 'TestException' collides with com.test#TestException.")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
@@ -6,8 +6,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldNotContain
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
@@ -168,7 +167,7 @@ class ExceptionGeneratorTest {
         val struct = model.expectShape<StructureShape>("com.error.test#InternalServerException")
         val renderingCtx = RenderingContext(writer, struct, model, provider, model.defaultSettings())
 
-        val e = assertThrows<CodegenException> {
+        val e = assertFailsWith<CodegenException> {
             StructureGenerator(renderingCtx).render()
         }
         e.message.shouldContainOnlyOnceWithDiff("Message is a reserved name for exception types and cannot be used for any other property")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldNotContain
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
@@ -18,6 +17,7 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.ApplicationProto
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.*
+import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class ExceptionGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
@@ -5,13 +5,13 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContain
-import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.core.KotlinDependency.Companion.CORE
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.model.node.Node
+import kotlin.test.Test
 
 class GradleGeneratorTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
@@ -5,7 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContain
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -5,7 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.KotlinSettings

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -5,7 +5,6 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
@@ -16,6 +15,7 @@ import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.kotlin.codegen.trimEveryLine
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 
 class ServiceGeneratorTest {
     private val commonTestContents: String

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -5,7 +5,6 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
@@ -15,6 +14,7 @@ import software.amazon.smithy.model.node.NumberNode
 import software.amazon.smithy.model.node.StringNode
 import software.amazon.smithy.model.node.ToNode
 import software.amazon.smithy.model.shapes.*
+import kotlin.test.Test
 
 class ShapeValueGeneratorTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -5,7 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -5,9 +5,9 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.TestInstance
+import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -5,9 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.TestInstance
-import kotlin.test.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
@@ -16,6 +14,8 @@ import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.kotlin.codegen.trimEveryLine
 import software.amazon.smithy.model.shapes.StructureShape
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class StructureGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
@@ -5,16 +5,20 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.expectShape
-import software.amazon.smithy.kotlin.codegen.test.*
+import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
+import software.amazon.smithy.kotlin.codegen.test.createSymbolProvider
+import software.amazon.smithy.kotlin.codegen.test.prependNamespaceAndService
+import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
+import software.amazon.smithy.kotlin.codegen.test.shouldContainWithDiff
+import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.kotlin.codegen.trimEveryLine
 import software.amazon.smithy.model.shapes.UnionShape
-import java.lang.IllegalStateException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class UnionGeneratorTest {
     @Test
@@ -91,7 +95,7 @@ class UnionGeneratorTest {
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
         val generator = UnionGenerator(model, provider, writer, union)
 
-        Assertions.assertThrows(IllegalStateException::class.java) {
+        assertFailsWith<IllegalStateException> {
             generator.render()
         }
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -6,8 +6,8 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import io.kotest.matchers.string.shouldNotContain
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.core.RUNTIME_ROOT_NS
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -6,13 +6,13 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import io.kotest.matchers.string.shouldNotContain
-import kotlin.test.assertTrue
-import kotlin.test.Test
 import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.kotlin.codegen.core.RUNTIME_ROOT_NS
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 // NOTE: protocol conformance is mostly handled by the protocol tests suite
 class HttpBindingProtocolGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -4,13 +4,13 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
-import kotlin.test.assertEquals
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.KotlinDependency
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.kotlin.codegen.trimEveryLine
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class HttpProtocolClientGeneratorTest {
     private val commonTestContents: String

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -4,8 +4,8 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.KotlinDependency
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.model.expectShape
@@ -16,6 +15,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
+import kotlin.test.Test
 
 class HttpStringValuesMapSerializerTest {
     private val defaultModel = loadModelFromResource("http-binding-protocol-generator-test.smithy")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.model.expectShape

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.kotlin.codegen.test.*

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -5,10 +5,10 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
 
 class DeserializeStructGeneratorTest {
     private val modelPrefix = """

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
@@ -4,11 +4,11 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
+import kotlin.test.Test
 
 class DeserializeUnionGeneratorTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.ShapeId
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
@@ -5,9 +5,9 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 
 class JsonSerdeDescriptorGeneratorTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
@@ -4,11 +4,11 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
 
 class SerializeStructGeneratorTest {
     private val modelPrefix = """

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
@@ -4,7 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
 
 class SerializeUnionGeneratorTest {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
@@ -4,8 +4,8 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.test.*
+import kotlin.test.Test
 
 class SerializeUnionGeneratorTest {
     private val modelPrefix = """

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGeneratorTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.RUNTIME_ROOT_NS
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.ShapeId

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerdeDescriptorGeneratorTest.kt
@@ -5,10 +5,10 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.serde
 
-import kotlin.test.Test
 import software.amazon.smithy.kotlin.codegen.core.RUNTIME_ROOT_NS
 import software.amazon.smithy.kotlin.codegen.test.*
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 
 class XmlSerdeDescriptorGeneratorTest {
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtilsTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtilsTest.kt
@@ -5,7 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.utils
 
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CaseUtilsTest {


### PR DESCRIPTION


## Issue \#
N/A

## Description of changes
* Refactor unit tests to use kotlin.test over junit where possible for consistency.


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
