### PR TITLE
feat: add codegen wrappers for retries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,7 @@ kotlinxBenchmarkVersion=0.3.1
 
 # serialization
 gsonVersion=2.8.5
+kamlVersion=0.36.0
 xmlpullVersion=1.1.3.1
 xpp3Version=1.1.6
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -48,6 +48,10 @@ object RuntimeTypes {
             val HttpResponse = runtimeSymbol("HttpResponse", KotlinDependency.HTTP, "response")
         }
 
+        object Retries {
+            val StandardRetryFeature = runtimeSymbol("StandardRetryFeature", KotlinDependency.HTTP, "retries")
+        }
+
         object Operation {
             val HttpDeserialize = runtimeSymbol("HttpDeserialize", KotlinDependency.HTTP, "operation")
             val HttpSerialize = runtimeSymbol("HttpSerialize", KotlinDependency.HTTP, "operation")
@@ -77,6 +81,18 @@ object RuntimeTypes {
             val StringContent = runtimeSymbol("StringContent", KotlinDependency.CORE, "content")
             val toByteArray = runtimeSymbol("toByteArray", KotlinDependency.CORE, "content")
             val decodeToString = runtimeSymbol("decodeToString", KotlinDependency.CORE, "content")
+        }
+
+        object Retries {
+            object Impl {
+                val ExponentialBackoffWithJitter = runtimeSymbol("ExponentialBackoffWithJitter", KotlinDependency.CORE, "retries.impl")
+                val ExponentialBackoffWithJitterOptions = runtimeSymbol("ExponentialBackoffWithJitterOptions", KotlinDependency.CORE, "retries.impl")
+                val StandardRetryPolicy = runtimeSymbol("StandardRetryPolicy", KotlinDependency.CORE, "retries.impl")
+                val StandardRetryStrategy = runtimeSymbol("StandardRetryStrategy", KotlinDependency.CORE, "retries.impl")
+                val StandardRetryStrategyOptions = runtimeSymbol("StandardRetryStrategyOptions", KotlinDependency.CORE, "retries.impl")
+                val StandardRetryTokenBucket = runtimeSymbol("StandardRetryTokenBucket", KotlinDependency.CORE, "retries.impl")
+                val StandardRetryTokenBucketOptions = runtimeSymbol("StandardRetryTokenBucketOptions", KotlinDependency.CORE, "retries.impl")
+            }
         }
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/KotlinIntegration.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/KotlinIntegration.kt
@@ -44,6 +44,12 @@ interface KotlinIntegration {
         get() = listOf()
 
     /**
+     * Get the list of other integrations to replace (i.e., removed from codegen when _this_ integration is present).
+     */
+    val replacesIntegrations: Set<Class<out KotlinIntegration>>
+        get() = setOf()
+
+    /**
      * Allows integration to specify [SectionWriterBinding]s to
      * override or change codegen at specific, defined points.
      * See [SectionWriter] for more details.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.RenderingContext
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.hasIdempotentTokenMember
@@ -98,6 +99,7 @@ class ClientConfigGenerator(
                 ctx.writer.addImport(baseClass)
             }
             ctx.writer.addImport(it.symbol)
+            ctx.writer.addImportReferences(it.symbol, SymbolReference.ContextOption.USE)
         }
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/retries/StandardRetryIntegration.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/retries/StandardRetryIntegration.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.kotlin.codegen.retries
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolReference.*
+import software.amazon.smithy.kotlin.codegen.core.*
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
+import software.amazon.smithy.kotlin.codegen.model.namespace
+import software.amazon.smithy.kotlin.codegen.rendering.ClientConfigProperty
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.HttpFeatureMiddleware
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolMiddleware
+
+/**
+ * Adds retry wrappers around operation invocations, driven by client config (which specifies the [RetryStrategy]) and
+ * a middleware (which specifies the [RetryPolicy][aws.smithy.kotlin.runtime.retries.RetryPolicy]). This class is
+ * `open` and may be subclassed to customize the strategy and/or policy. Note that codegen which specifies a subclass of
+ * this should probably configure [replacesIntegrations] to remove the base implementation—otherwise, multiple copies of
+ * the config properties may be included in client config.
+ */
+open class StandardRetryIntegration : KotlinIntegration {
+    override fun additionalServiceConfigProps(ctx: CodegenContext): List<ClientConfigProperty> =
+        listOf(
+            ClientConfigProperty {
+                val retryStrategyBlock = """
+                    run {
+                        val strategyOptions = StandardRetryStrategyOptions.Default
+                        val tokenBucket = StandardRetryTokenBucket(StandardRetryTokenBucketOptions.Default)
+                        val delayer = ExponentialBackoffWithJitter(ExponentialBackoffWithJitterOptions.Default)
+                        StandardRetryStrategy(strategyOptions, tokenBucket, delayer)
+                    }
+                """.trimIndent()
+
+                symbol = buildSymbol {
+                    name = "RetryStrategy"
+                    namespace(KotlinDependency.CORE, "retries")
+                    nullable = false
+                    reference(RuntimeTypes.Core.Retries.Impl.StandardRetryStrategy, ContextOption.USE)
+                    reference(RuntimeTypes.Core.Retries.Impl.StandardRetryStrategyOptions, ContextOption.USE)
+                    reference(RuntimeTypes.Core.Retries.Impl.StandardRetryTokenBucket, ContextOption.USE)
+                    reference(RuntimeTypes.Core.Retries.Impl.StandardRetryTokenBucketOptions, ContextOption.USE)
+                    reference(RuntimeTypes.Core.Retries.Impl.ExponentialBackoffWithJitter, ContextOption.USE)
+                    reference(RuntimeTypes.Core.Retries.Impl.ExponentialBackoffWithJitterOptions, ContextOption.USE)
+                }
+                name = "retryStrategy"
+                documentation = """
+                    The [RetryStrategy] implementation to use for service calls. All API calls will be wrapped by the
+                    strategy.
+                """.trimIndent()
+                constantValue = retryStrategyBlock
+            }
+        )
+
+    override fun customizeMiddleware(
+        ctx: ProtocolGenerator.GenerationContext,
+        resolved: List<ProtocolMiddleware>
+    ): List<ProtocolMiddleware> = resolved.filter { it !is StandardRetryIntegration } + middleware
+
+    private val middleware = object : HttpFeatureMiddleware() {
+        override val name: String = "StandardRetryFeature"
+
+        override fun renderConfigure(writer: KotlinWriter) {
+            writer.addImport(RuntimeTypes.Http.Retries.StandardRetryFeature)
+            retryPolicyInfo.imports.forEach(writer::addImport)
+
+            writer.write("strategy = config.retryStrategy")
+            writer.write("policy = ${retryPolicyInfo.literalSpecification}")
+        }
+    }
+
+    /**
+     * Specifies the retry policy name and imports to use. This can be overriden in subclasses.
+     */
+    protected open val retryPolicyInfo: RetryPolicyInfo
+        get() = RetryPolicyInfo("StandardRetryPolicy.Default", RuntimeTypes.Core.Retries.Impl.StandardRetryPolicy)
+}
+
+/**
+ * A codegen description of a retry policy.
+ * @param literalSpecification The codegen string literal specifying the
+ * [RetryPolicy][aws.smithy.kotlin.runtime.retries.RetryPolicy] to use.
+ * @param imports A set of [Symbol] imports to include at codegen time.
+ */
+data class RetryPolicyInfo(val literalSpecification: String, val imports: Set<Symbol>) {
+    /**
+     * Constructs a new [RetryPolicyInfo]. This convenience constructor allows specifying imports as `vararg` (which a
+     * data class's primary constructor cannot).
+     * @param literalSpecification The codegen string literal specifying the
+     * [RetryPolicy][aws.smithy.kotlin.runtime.retries.RetryPolicy] to use.
+     * @param imports A set of [Symbol] imports to include at codegen time.
+     */
+    constructor(literalSpecification: String, vararg imports: Symbol) : this(literalSpecification, imports.toSet())
+}

--- a/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -1,2 +1,3 @@
 software.amazon.smithy.kotlin.codegen.lang.BuiltinPreprocessor
 software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor
+software.amazon.smithy.kotlin.codegen.retries.StandardRetryIntegration

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -7,9 +7,11 @@ package software.amazon.smithy.kotlin.codegen.rendering
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.model.hasIdempotentTokenMember
 import software.amazon.smithy.kotlin.codegen.test.*
@@ -201,5 +203,45 @@ class Config private constructor(builder: BuilderImpl) {
         """.toSmithyModel()
 
         model.expectShape<ServiceShape>("com.test#ResourceService").hasIdempotentTokenMember(model) shouldBe true
+    }
+
+    @Test
+    fun `it imports references`() {
+        val model = getModel()
+
+        val serviceShape = model.expectShape<ServiceShape>(TestModelDefault.SERVICE_SHAPE_ID)
+
+        val testCtx = model.newTestContext()
+        val writer = KotlinWriter(TestModelDefault.NAMESPACE)
+        val renderingCtx = testCtx.toRenderingContext(writer, serviceShape)
+
+        val customProps = arrayOf(
+            ClientConfigProperty {
+                name = "complexProp"
+                symbol = buildSymbol {
+                    name = "ComplexType"
+                    namespace = "test.complex"
+                    reference(
+                        buildSymbol { name = "SubTypeA"; namespace = "test.complex" },
+                        SymbolReference.ContextOption.USE
+                    )
+                    reference(
+                        buildSymbol { name = "SubTypeB"; namespace = "test.complex" },
+                        SymbolReference.ContextOption.USE
+                    )
+                }
+            }
+        )
+
+        ClientConfigGenerator(renderingCtx, detectDefaultProps = false, builderReturnType = null, *customProps).render()
+        val contents = writer.toString()
+
+        listOf(
+            "test.complex.ComplexType",
+            "test.complex.SubTypeA",
+            "test.complex.SubTypeB",
+        )
+            .map { "import $it" }
+            .forEach(contents::shouldContain)
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -516,6 +516,86 @@ class StructureGeneratorTest {
         )
     }
 
+    @Test
+    fun `it renders client errors`() {
+        testErrorShape(
+            "client",
+            null,
+            null,
+            null,
+            "sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ErrorType.Client",
+        )
+    }
+
+    @Test
+    fun `it renders server errors`() {
+        testErrorShape(
+            "server",
+            null,
+            null,
+            null,
+            "sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ErrorType.Server",
+        )
+    }
+
+    @Test
+    fun `it renders retryable errors`() {
+        testErrorShape(
+            "client",
+            "@retryable",
+            "sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = true",
+            "sdkErrorMetadata.attributes[ErrorMetadata.ThrottlingError] = false",
+            "sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ErrorType.Client",
+        )
+    }
+
+    @Test
+    fun `it renders retryable throttling errors`() {
+        testErrorShape(
+            "client",
+            "@retryable(throttling: true)",
+            "sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = true",
+            "sdkErrorMetadata.attributes[ErrorMetadata.ThrottlingError] = true",
+            "sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ErrorType.Client",
+        )
+    }
+
+    private fun testErrorShape(
+        errorType: String,
+        retryableTrait: String?,
+        initRetryableLine: String?,
+        initThrottlingLine: String?,
+        initErrorTypeLine: String?,
+    ) {
+        val model = listOfNotNull(
+            "@error(\"$errorType\")",
+            retryableTrait,
+            "structure FooError { }",
+        )
+            .joinToString("\n")
+            .prependNamespaceAndService()
+            .toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
+        val writer = KotlinWriter(TestModelDefault.NAMESPACE)
+        val struct = model.expectShape<StructureShape>("com.test#FooError")
+        val renderingCtx = RenderingContext(writer, struct, model, provider, model.defaultSettings())
+        StructureGenerator(renderingCtx).render()
+        val contents = writer.toString()
+
+        val expectedInit = listOfNotNull(
+            "init {",
+            initRetryableLine.indent(),
+            initThrottlingLine.indent(),
+            initErrorTypeLine.indent(),
+            "}",
+        )
+            .joinToString("\n")
+            .formatForTest()
+
+        contents.shouldContainOnlyOnceWithDiff(expectedInit)
+    }
+
     private fun generateStructure(model: String): String {
         val fullModel = model.prependNamespaceAndService().toSmithyModel()
 
@@ -529,3 +609,5 @@ class StructureGeneratorTest {
         return writer.toString()
     }
 }
+
+private fun String?.indent(indentation: String = "    "): String? = if (this == null) null else "$indentation$this"


### PR DESCRIPTION
## Issue \#

Closes #224 

## Description of changes

Implements the codegen support and wrappers for retrying all operations. Runtime components were implemented in #487.

This PR includes the first example of **replaceable integrations** which may be controversial. I chose that to allow a default strategy/policy in **smithy-kotlin** but allow overriding for specific codegen use cases (like **aws-sdk-kotlin**). Comments on this approach are welcome.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.