### PR TITLE
fix(rt): emulate a real response body more closely to help catch subtle codegen bugs

### DIFF
--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -91,10 +91,10 @@ fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit) = runSusp
                 // emulate a real response stream which typically can only be consumed once
                 // see: https://github.com/awslabs/aws-sdk-kotlin/issues/356
                 object : HttpBody.Streaming() {
-                    private var cnt = 0
+                    private var consumed = false
                     override fun readFrom(): SdkByteReadChannel {
-                        val content = if (cnt > 0) ByteArray(0) else it.encodeToByteArray()
-                        cnt++
+                        val content = if (consumed) ByteArray(0) else it.encodeToByteArray()
+                        consumed = true
                         return SdkByteReadChannel(content)
                     }
                 }

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -7,12 +7,12 @@ package aws.smithy.kotlin.runtime.smithy.test
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import aws.smithy.kotlin.runtime.time.Instant
 
@@ -88,7 +88,16 @@ fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit) = runSusp
             }
 
             val body: HttpBody = testBuilder.expected.body?.let {
-                ByteArrayContent(it.encodeToByteArray())
+                // emulate a real response stream which typically can only be consumed once
+                // see: https://github.com/awslabs/aws-sdk-kotlin/issues/356
+                object : HttpBody.Streaming() {
+                    private var cnt = 0
+                    override fun readFrom(): SdkByteReadChannel {
+                        val content = if (cnt > 0) ByteArray(0) else it.encodeToByteArray()
+                        cnt++
+                        return SdkByteReadChannel(content)
+                    }
+                }
             } ?: HttpBody.Empty
 
             val resp = HttpResponse(testBuilder.expected.statusCode, headers, body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
sibling PR: https://github.com/awslabs/aws-sdk-kotlin/pull/358

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Use a streaming single use `HttpBody` variant for protocol tests which will more closely reflect reality.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
