### PR TITLE
feat: support overriding/subclassing operation serializers

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -316,7 +316,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             writer
                 .addImport(operationSerializerSymbols)
                 .write("")
-                .openBlock("internal class #T: #T<#T> {", serializerSymbol, RuntimeTypes.Http.Operation.HttpSerialize, inputSymbol)
+                .openBlock("internal open class #T: #T<#T> {", serializerSymbol, RuntimeTypes.Http.Operation.HttpSerialize, inputSymbol)
                 .call {
                     writer.openBlock("override suspend fun serialize(context: #T, input: #T): #T {", RuntimeTypes.Core.ExecutionContext, inputSymbol, RuntimeTypes.Http.Request.HttpRequestBuilder)
                         .write("val builder = #T()", RuntimeTypes.Http.Request.HttpRequestBuilder)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -32,7 +32,7 @@ class IdempotentTokenGeneratorTest {
         val contents = getTransformFileContents("AllocateWidgetOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-            internal class AllocateWidgetOperationSerializer: HttpSerialize<AllocateWidgetRequest> {
+            internal open class AllocateWidgetOperationSerializer: HttpSerialize<AllocateWidgetRequest> {
                 override suspend fun serialize(context: ExecutionContext, input: AllocateWidgetRequest): HttpRequestBuilder {
                     val builder = HttpRequestBuilder()
                     builder.method = HttpMethod.POST
@@ -58,7 +58,7 @@ class IdempotentTokenGeneratorTest {
         val contents = getTransformFileContents("AllocateWidgetQueryOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class AllocateWidgetQueryOperationSerializer: HttpSerialize<AllocateWidgetQueryRequest> {
+internal open class AllocateWidgetQueryOperationSerializer: HttpSerialize<AllocateWidgetQueryRequest> {
     override suspend fun serialize(context: ExecutionContext, input: AllocateWidgetQueryRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -82,7 +82,7 @@ internal class AllocateWidgetQueryOperationSerializer: HttpSerialize<AllocateWid
         val contents = getTransformFileContents("AllocateWidgetHeaderOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class AllocateWidgetHeaderOperationSerializer: HttpSerialize<AllocateWidgetHeaderRequest> {
+internal open class AllocateWidgetHeaderOperationSerializer: HttpSerialize<AllocateWidgetHeaderRequest> {
     override suspend fun serialize(context: ExecutionContext, input: AllocateWidgetHeaderRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -62,7 +62,7 @@ class HttpBindingProtocolGeneratorTest {
         contents.assertBalancedBracesAndParens()
         val label1 = "\${input.label1}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
-internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
+internal open class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
     override suspend fun serialize(context: ExecutionContext, input: SmokeTestRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -103,7 +103,7 @@ internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
         val contents = getTransformFileContents("ExplicitStringOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRequest> {
+internal open class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRequest> {
     override suspend fun serialize(context: ExecutionContext, input: ExplicitStringRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -130,7 +130,7 @@ internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRe
         val contents = getTransformFileContents("ExplicitBlobOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobRequest> {
+internal open class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobRequest> {
     override suspend fun serialize(context: ExecutionContext, input: ExplicitBlobRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -157,7 +157,7 @@ internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobReques
         val contents = getTransformFileContents("ExplicitBlobStreamOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlobStreamRequest> {
+internal open class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlobStreamRequest> {
     override suspend fun serialize(context: ExecutionContext, input: ExplicitBlobStreamRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -184,7 +184,7 @@ internal class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlob
         val contents = getTransformFileContents("ExplicitStructOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRequest> {
+internal open class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRequest> {
     override suspend fun serialize(context: ExecutionContext, input: ExplicitStructRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -223,7 +223,7 @@ internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRe
         val contents = getTransformFileContents("EnumInputOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
+internal open class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
     override suspend fun serialize(context: ExecutionContext, input: EnumInputRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -254,7 +254,7 @@ internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
         contents.assertBalancedBracesAndParens()
         val tsLabel = "\${input.tsLabel?.format(TimestampFormat.ISO_8601)}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
-internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRequest> {
+internal open class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRequest> {
     override suspend fun serialize(context: ExecutionContext, input: TimestampInputRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -298,7 +298,7 @@ internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRe
         val contents = getTransformFileContents("BlobInputOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
-internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
+internal open class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
     override suspend fun serialize(context: ExecutionContext, input: BlobInputRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.POST
@@ -331,7 +331,7 @@ internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
         contents.assertBalancedBracesAndParens()
         val label1 = "\${input.hello}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
-internal class ConstantQueryStringOperationSerializer: HttpSerialize<ConstantQueryStringRequest> {
+internal open class ConstantQueryStringOperationSerializer: HttpSerialize<ConstantQueryStringRequest> {
     override suspend fun serialize(context: ExecutionContext, input: ConstantQueryStringRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.GET


### PR DESCRIPTION
## Issue \#

Addresses awslabs/aws-sdk-kotlin#244

## Description of changes

Two changes to support Machine Learning endpoint customization:
* Make operation serializer classes `open` to enable subclassing for specific features (i.e., changing endpoints)
* Add a section around operation serializer config to enable it to be replaced by integrations

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.