### PR TITLE
feat: add convenience extension method for detecting if a Shape has the Streaming trait

### DIFF
--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -47,3 +47,10 @@ val ExecutionContext.idempotencyTokenProvider: IdempotencyTokenProvider
 @InternalApi
 val ExecutionContext.sdkLogMode: SdkLogMode
     get() = getOrNull(SdkClientOption.LogMode) ?: SdkLogMode.Default
+
+/**
+ * Get the [OperationName] from the context.
+ */
+@InternalApi
+val ExecutionContext.operationName: String?
+    get() = getOrNull(SdkClientOption.OperationName)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -100,6 +100,7 @@ object RuntimeTypes {
 
     object Utils {
         val AttributeKey = runtimeSymbol("AttributeKey", KotlinDependency.UTILS)
+        val Sha256 = runtimeSymbol("Sha256", KotlinDependency.UTILS)
         val urlEncodeComponent = runtimeSymbol("urlEncodeComponent", KotlinDependency.UTILS, "text")
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -161,3 +161,9 @@ val Shape.isNumberShape: Boolean
  */
 val Shape.isSparse: Boolean
     get() = hasTrait<SparseTrait>()
+
+/**
+ * Test if a shape has the streaming trait applied.
+ */
+val Shape.isStreaming: Boolean
+    get() = hasTrait<StreamingTrait>()


### PR DESCRIPTION
## Issue \#

Addresses awslabs/aws-sdk-kotlin#245

## Description of changes

Adds a convenience extension method for detecting the Streaming trait on shapes, which helps slightly with the integration for Glacier request body checksums.

**Also**: Expose `Sha256` type in `RuntimeTypes` for codegen in **aws-sdk-kotlin**.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.