### PR TITLE
Update regex to handle version segments greater than 9

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
@@ -16,7 +16,7 @@ const val RUNTIME_ROOT_NS = "aws.smithy.kotlin.runtime"
  * Test if a string represents a valid artifact version string
  */
 fun isValidVersion(version: String): Boolean {
-    val re = Regex("\\d\\.\\d\\.\\d[a-z0-9A-Z.-]*\$")
+    val re = Regex("\\d+\\.\\d+\\.\\d[a-z0-9A-Z.-]*\$")
     return re.matches(version)
 }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
@@ -15,7 +15,9 @@ class KotlinDependencyTest {
         val validVersions = listOf(
             "0.1.0",
             "0.1.0-alpha",
-            "1.2.3.4-beta.zulu-x"
+            "1.2.3.4-beta.zulu-x",
+            "0.10.0-alpha",
+            "2342.138234952342.234238234-boo"
         )
         validVersions.forEach {
             assertTrue(isValidVersion(it))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Fixes build errors in https://github.com/awslabs/smithy-kotlin/pull/515 and https://github.com/awslabs/aws-sdk-kotlin/pull/383

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
