### PR TITLE
fix: delegate when to set content-type to binding resolver; fix content-length for empty bodies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ ktorVersion=1.6.3
 atomicFuVersion=0.16.1
 
 # codegen
-smithyVersion=1.13.0
+smithyVersion=1.13.1
 smithyGradleVersion=0.5.3
 
 # testing/utility

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
@@ -59,11 +59,12 @@ fun httpRequestTest(block: HttpRequestTestBuilder.() -> Unit) = runSuspendTest {
             }
 
             // capture the request that was built by the service operation
-            if (request.body.contentLength != null) {
+            val contentLength = request.body.contentLength
+            if (contentLength != null && contentLength > 0) {
                 // Content-Length header is not expected to be set by serialize implementations. It is expected
                 // to be read from [HttpBody::contentLength] by the underlying engine and set appropriately
                 // add it in here so tests that define it can pass
-                testHeaders["Content-Length"] = request.body.contentLength.toString()
+                testHeaders["Content-Length"] = contentLength.toString()
             }
 
             actual = request.copy(headers = testHeaders.build())

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -415,8 +415,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 .write("builder.body = #T(payload)", RuntimeTypes.Http.ByteArrayContent)
         }
 
-        writer.openBlock("if (builder.body !is #T.Empty) {", "}", RuntimeTypes.Http.HttpBody) {
-            val contentType = resolver.determineRequestContentType(op)
+        resolver.determineRequestContentType(op)?.let { contentType ->
             writer.write("builder.headers.setMissing(\"Content-Type\", #S)", contentType)
         }
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingResolver.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingResolver.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
+import software.amazon.smithy.kotlin.codegen.utils.getOrNull
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.knowledge.HttpBindingIndex
@@ -68,9 +69,9 @@ interface HttpBindingResolver {
      * Determine the request content type for the protocol.
      *
      * @param operationShape [OperationShape] associated with content type
-     * @return content type
+     * @return content type or null if no content-type header should be set
      */
-    fun determineRequestContentType(operationShape: OperationShape): String
+    fun determineRequestContentType(operationShape: OperationShape): String?
 
     /**
      * Determine the timestamp format depending on input parameter values.
@@ -140,9 +141,9 @@ class HttpTraitResolver(
         else -> error { "Unimplemented resolving bindings for ${shape.javaClass.canonicalName}" }
     }
 
-    override fun determineRequestContentType(operationShape: OperationShape): String = bindingIndex
+    override fun determineRequestContentType(operationShape: OperationShape): String? = bindingIndex
         .determineRequestContentType(operationShape, defaultContentType)
-        .orElse(defaultContentType)
+        .getOrNull()
 
     override fun determineTimestampFormat(
         member: ToShapeId,

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -43,9 +43,7 @@ class IdempotentTokenGeneratorTest {
             
                     val payload = serializeAllocateWidgetOperationBody(context, input)
                     builder.body = ByteArrayContent(payload)
-                    if (builder.body !is HttpBody.Empty) {
-                        builder.headers.setMissing("Content-Type", "application/json")
-                    }
+                    builder.headers.setMissing("Content-Type", "application/json")
                     return builder
                 }
             }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -86,9 +86,7 @@ internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
 
         val payload = serializeSmokeTestOperationBody(context, input)
         builder.body = ByteArrayContent(payload)
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/json")
-        }
+        builder.headers.setMissing("Content-Type", "application/json")
         return builder
     }
 }
@@ -115,9 +113,7 @@ internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRe
         if (input.payload1 != null) {
             builder.body = ByteArrayContent(input.payload1.toByteArray())
         }
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "text/plain")
-        }
+        builder.headers.setMissing("Content-Type", "text/plain")
         return builder
     }
 }
@@ -142,9 +138,7 @@ internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobReques
         if (input.payload1 != null) {
             builder.body = ByteArrayContent(input.payload1)
         }
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/octet-stream")
-        }
+        builder.headers.setMissing("Content-Type", "application/octet-stream")
         return builder
     }
 }
@@ -169,9 +163,7 @@ internal class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlob
         if (input.payload1 != null) {
             builder.body = input.payload1.toHttpBody() ?: HttpBody.Empty
         }
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/octet-stream")
-        }
+        builder.headers.setMissing("Content-Type", "application/octet-stream")
         return builder
     }
 }
@@ -197,9 +189,7 @@ internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRe
             val payload = serializeExplicitStructOperationBody(context, input)
             builder.body = ByteArrayContent(payload)
         }
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/json")
-        }
+        builder.headers.setMissing("Content-Type", "application/json")
         return builder
     }
 }
@@ -238,9 +228,7 @@ internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
 
         val payload = serializeEnumInputOperationBody(context, input)
         builder.body = ByteArrayContent(payload)
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/json")
-        }
+        builder.headers.setMissing("Content-Type", "application/json")
         return builder
     }
 }
@@ -280,9 +268,7 @@ internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRe
 
         val payload = serializeTimestampInputOperationBody(context, input)
         builder.body = ByteArrayContent(payload)
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/json")
-        }
+        builder.headers.setMissing("Content-Type", "application/json")
         return builder
     }
 }
@@ -313,9 +299,7 @@ internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
 
         val payload = serializeBlobInputOperationBody(context, input)
         builder.body = ByteArrayContent(payload)
-        if (builder.body !is HttpBody.Empty) {
-            builder.headers.setMissing("Content-Type", "application/json")
-        }
+        builder.headers.setMissing("Content-Type", "application/json")
         return builder
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-kotlin#390
sibling to https://github.com/awslabs/aws-sdk-kotlin/pull/402

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Fixes related to protocol tests added in smithy 1.13 for restJson1 protocol

* Only set `Content-Length` in mock engine for protocol tests when non-null and positive. `HttpBody.Empty` has a content-length of 0 and we were sending `Content-Length: 0`
* We were not properly using the http binding index to compute content types. We should not have fallen back to a default content type—instead we need to use exactly what is given. 
* upgrade smithy to latest bug fix release `1.13.1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
