### PR TITLE
chore: optimize codegen for size round1

### DIFF
--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -56,7 +56,7 @@ class SdkHttpOperation<I, O>(
     }
 
     companion object {
-        fun <I, O> build(block: SdkHttpOperationBuilder<I, O>.() -> Unit): SdkHttpOperation<I, O> =
+        inline fun <I, O> build(block: SdkHttpOperationBuilder<I, O>.() -> Unit): SdkHttpOperation<I, O> =
             SdkHttpOperationBuilder<I, O>().apply(block).build()
     }
 }
@@ -109,4 +109,4 @@ class SdkHttpOperationBuilder<I, O> {
 /**
  * Configure HTTP operation context elements
  */
-fun <I, O> SdkHttpOperationBuilder<I, O>.context(block: HttpOperationContext.Builder.() -> Unit) = context.apply(block)
+inline fun <I, O> SdkHttpOperationBuilder<I, O>.context(block: HttpOperationContext.Builder.() -> Unit) = context.apply(block)

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
@@ -62,7 +62,7 @@ interface Deserializer {
      *
      * @param descriptor SdkObjectDescriptor the structure descriptor
      */
-    suspend fun deserializeStruct(descriptor: SdkObjectDescriptor): FieldIterator
+    fun deserializeStruct(descriptor: SdkObjectDescriptor): FieldIterator
 
     /**
      * Begin deserialization of a list type. Use the returned [ElementIterator] to drive
@@ -73,7 +73,7 @@ interface Deserializer {
      *
      * @param descriptor SdkFieldDescriptor the structure descriptor
      */
-    suspend fun deserializeList(descriptor: SdkFieldDescriptor): ElementIterator
+    fun deserializeList(descriptor: SdkFieldDescriptor): ElementIterator
 
     /**
      * Begin deserialization of a map type. Use the returned [EntryIterator] to drive
@@ -84,7 +84,7 @@ interface Deserializer {
      *
      * @param descriptor SdkFieldDescriptor the structure descriptor
      */
-    suspend fun deserializeMap(descriptor: SdkFieldDescriptor): EntryIterator
+    fun deserializeMap(descriptor: SdkFieldDescriptor): EntryIterator
 
     /**
      * Iterator over raw elements in a collection
@@ -94,12 +94,12 @@ interface Deserializer {
          * Advance to the next element. Returns false when no more elements are in the list
          * or the document has been read completely.
          */
-        suspend fun hasNextElement(): Boolean
+        fun hasNextElement(): Boolean
 
         /**
          * Returns true if the next token contains a value, or false otherwise.
          */
-        suspend fun nextHasValue(): Boolean
+        fun nextHasValue(): Boolean
     }
 
     /**
@@ -110,17 +110,17 @@ interface Deserializer {
          * Advance to the next element. Returns false when no more elements are in the map
          * or the document has been read completely.
          */
-        suspend fun hasNextEntry(): Boolean
+        fun hasNextEntry(): Boolean
 
         /**
          * Read the next key
          */
-        suspend fun key(): String
+        fun key(): String
 
         /**
          * Returns true if the next token contains a value, or false otherwise.
          */
-        suspend fun nextHasValue(): Boolean
+        fun nextHasValue(): Boolean
     }
 
     /**
@@ -130,12 +130,12 @@ interface Deserializer {
         /**
          * Returns the index of the next field found, null if fields exhausted, or [UNKNOWN_FIELD].
          */
-        suspend fun findNextFieldIndex(): Int?
+        fun findNextFieldIndex(): Int?
 
         /**
          * Skip the next field value recursively. Meant for discarding unknown fields
          */
-        suspend fun skipValue()
+        fun skipValue()
 
         companion object {
             /**
@@ -153,60 +153,60 @@ interface PrimitiveDeserializer {
     /**
      * Deserialize and return the next token as a [Byte]
      */
-    suspend fun deserializeByte(): Byte
+    fun deserializeByte(): Byte
 
     /**
      * Deserialize and return the next token as an [Int]
      */
-    suspend fun deserializeInt(): Int
+    fun deserializeInt(): Int
 
     /**
      * Deserialize and return the next token as a [Short]
      */
-    suspend fun deserializeShort(): Short
+    fun deserializeShort(): Short
 
     /**
      * Deserialize and return the next token as a [Long]
      */
-    suspend fun deserializeLong(): Long
+    fun deserializeLong(): Long
 
     /**
      * Deserialize and return the next token as a [Float]
      */
-    suspend fun deserializeFloat(): Float
+    fun deserializeFloat(): Float
 
     /**
      * Deserialize and return the next token as a [Double]
      */
-    suspend fun deserializeDouble(): Double
+    fun deserializeDouble(): Double
 
     /**
      * Deserialize and return the next token as a [String]
      */
-    suspend fun deserializeString(): String
+    fun deserializeString(): String
 
     /**
      * Deserialize and return the next token as a [Boolean]
      */
-    suspend fun deserializeBoolean(): Boolean
+    fun deserializeBoolean(): Boolean
 
     /**
      * Consume the next token if represents a null value. Always returns null.
      */
-    suspend fun deserializeNull(): Nothing?
+    fun deserializeNull(): Nothing?
 }
 
-suspend fun Deserializer.deserializeStruct(descriptor: SdkObjectDescriptor, block: suspend Deserializer.FieldIterator.() -> Unit) {
+inline fun Deserializer.deserializeStruct(descriptor: SdkObjectDescriptor, block: Deserializer.FieldIterator.() -> Unit) {
     val deserializer = deserializeStruct(descriptor)
     block(deserializer)
 }
 
-suspend fun <T> Deserializer.deserializeList(descriptor: SdkFieldDescriptor, block: suspend Deserializer.ElementIterator.() -> T): T {
+inline fun <T> Deserializer.deserializeList(descriptor: SdkFieldDescriptor, block: Deserializer.ElementIterator.() -> T): T {
     val deserializer = deserializeList(descriptor)
     return block(deserializer)
 }
 
-suspend fun <T> Deserializer.deserializeMap(descriptor: SdkFieldDescriptor, block: suspend Deserializer.EntryIterator.() -> T): T {
+inline fun <T> Deserializer.deserializeMap(descriptor: SdkFieldDescriptor, block: Deserializer.EntryIterator.() -> T): T {
     val deserializer = deserializeMap(descriptor)
     return block(deserializer)
 }

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
@@ -7,40 +7,29 @@ package aws.smithy.kotlin.runtime.serde
 /**
  * Metadata container for all fields of an object/class
  */
-class SdkObjectDescriptor private constructor(builder: BuilderImpl) : SdkFieldDescriptor(
+class SdkObjectDescriptor private constructor(builder: Builder) : SdkFieldDescriptor(
     kind = SerialKind.Struct, traits = builder.traits
 ) {
     val fields: List<SdkFieldDescriptor> = builder.fields
 
     companion object {
-        fun build(block: DslBuilder.() -> Unit): SdkObjectDescriptor = BuilderImpl().apply(block).build()
+        inline fun build(block: Builder.() -> Unit): SdkObjectDescriptor = Builder().apply(block).build()
     }
 
-    interface DslBuilder {
-        /**
-         * Declare a field belonging to this object
-         */
-        fun field(field: SdkFieldDescriptor)
-        /**
-         * Declare a trait belonging to this object
-         */
-        fun trait(trait: FieldTrait)
-        fun build(): SdkObjectDescriptor
-    }
+    class Builder {
+        internal val fields: MutableList<SdkFieldDescriptor> = mutableListOf()
+        internal val traits: MutableSet<FieldTrait> = mutableSetOf()
 
-    private class BuilderImpl : DslBuilder {
-        val fields: MutableList<SdkFieldDescriptor> = mutableListOf()
-        val traits: MutableSet<FieldTrait> = mutableSetOf()
-
-        override fun field(field: SdkFieldDescriptor) {
+        fun field(field: SdkFieldDescriptor) {
             field.index = fields.size
             fields.add(field)
         }
 
-        override fun trait(trait: FieldTrait) {
+        fun trait(trait: FieldTrait) {
             traits.add(trait)
         }
 
-        override fun build(): SdkObjectDescriptor = SdkObjectDescriptor(this)
+        @PublishedApi
+        internal fun build(): SdkObjectDescriptor = SdkObjectDescriptor(this)
     }
 }

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkSerializable.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkSerializable.kt
@@ -26,4 +26,5 @@ private data class SdkSerializableLambda<T>(
     }
 }
 
+// FIXME - this causes backing classes to be generated behind the scenes and contributes to the overall jar size
 fun <T> asSdkSerializable(input: T, serializeFn: SerializeFn<T>): SdkSerializable = SdkSerializableLambda(input, serializeFn)

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -21,21 +21,21 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
     // deserializing a single byte isn't common in JSON - we are going to assume that bytes are represented
     // as numbers and user understands any truncation issues. `deserializeByte` is more common in binary
     // formats (e.g. protobufs) where the binary encoding stores metadata in a single byte (e.g. flags or headers)
-    override suspend fun deserializeByte(): Byte = nextNumberValue { it.toByteOrNull() ?: it.toDouble().toInt().toByte() }
+    override fun deserializeByte(): Byte = nextNumberValue { it.toByteOrNull() ?: it.toDouble().toInt().toByte() }
 
-    override suspend fun deserializeInt(): Int = nextNumberValue { it.toIntOrNull() ?: it.toDouble().toInt() }
+    override fun deserializeInt(): Int = nextNumberValue { it.toIntOrNull() ?: it.toDouble().toInt() }
 
-    override suspend fun deserializeShort(): Short = nextNumberValue { it.toShortOrNull() ?: it.toDouble().toInt().toShort() }
+    override fun deserializeShort(): Short = nextNumberValue { it.toShortOrNull() ?: it.toDouble().toInt().toShort() }
 
-    override suspend fun deserializeLong(): Long = nextNumberValue { it.toLongOrNull() ?: it.toDouble().toLong() }
+    override fun deserializeLong(): Long = nextNumberValue { it.toLongOrNull() ?: it.toDouble().toLong() }
 
-    override suspend fun deserializeFloat(): Float = deserializeDouble().toFloat()
+    override fun deserializeFloat(): Float = deserializeDouble().toFloat()
 
-    override suspend fun deserializeDouble(): Double = nextNumberValue { it.toDouble() }
+    override fun deserializeDouble(): Double = nextNumberValue { it.toDouble() }
 
     // assert the next token is a Number and execute [block] with the raw value as a string. Returns result
     // of executing the block. This is mostly so that numeric conversions can keep as much precision as possible
-    private suspend fun <T> nextNumberValue(block: (value: String) -> T): T {
+    private fun <T> nextNumberValue(block: (value: String) -> T): T {
         val token = reader.nextToken()
         return when {
             token is JsonToken.Number -> block(token.value)
@@ -44,7 +44,7 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
         }
     }
 
-    override suspend fun deserializeString(): String =
+    override fun deserializeString(): String =
         // allow for tokens to be consumed as string even when the next token isn't a quoted string
         when (val token = reader.nextToken()) {
             is JsonToken.String -> token.value
@@ -53,17 +53,17 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
             else -> throw DeserializationException("$token cannot be deserialized as type String")
         }
 
-    override suspend fun deserializeBoolean(): Boolean {
+    override fun deserializeBoolean(): Boolean {
         val token = reader.nextTokenOf<JsonToken.Bool>()
         return token.value
     }
 
-    override suspend fun deserializeNull(): Nothing? {
+    override fun deserializeNull(): Nothing? {
         reader.nextTokenOf<JsonToken.Null>()
         return null
     }
 
-    override suspend fun deserializeStruct(descriptor: SdkObjectDescriptor): Deserializer.FieldIterator =
+    override fun deserializeStruct(descriptor: SdkObjectDescriptor): Deserializer.FieldIterator =
         when (reader.peek()) {
             JsonToken.BeginObject -> {
                 reader.nextTokenOf<JsonToken.BeginObject>()
@@ -73,24 +73,24 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
             else -> throw DeserializationException("Unexpected token type ${reader.peek()}")
         }
 
-    override suspend fun deserializeList(descriptor: SdkFieldDescriptor): Deserializer.ElementIterator {
+    override fun deserializeList(descriptor: SdkFieldDescriptor): Deserializer.ElementIterator {
         reader.nextTokenOf<JsonToken.BeginArray>()
         return this
     }
 
-    override suspend fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
+    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
         reader.nextTokenOf<JsonToken.BeginObject>()
         return this
     }
 
-    override suspend fun key(): String {
+    override fun key(): String {
         val token = reader.nextTokenOf<JsonToken.Name>()
         return token.value
     }
 
-    override suspend fun nextHasValue(): Boolean = reader.peek() != JsonToken.Null
+    override fun nextHasValue(): Boolean = reader.peek() != JsonToken.Null
 
-    override suspend fun hasNextEntry(): Boolean =
+    override fun hasNextEntry(): Boolean =
         when (reader.peek()) {
             JsonToken.EndObject -> {
                 // consume the token
@@ -102,7 +102,7 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
             else -> true
         }
 
-    override suspend fun hasNextElement(): Boolean =
+    override fun hasNextElement(): Boolean =
         when (reader.peek()) {
             JsonToken.EndArray -> {
                 // consume the token
@@ -116,9 +116,9 @@ class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementI
 
 // Represents the deserialization of a null object.
 private class JsonNullFieldIterator(deserializer: JsonDeserializer) : Deserializer.FieldIterator, Deserializer by deserializer, PrimitiveDeserializer by deserializer {
-    override suspend fun findNextFieldIndex(): Int? = null
+    override fun findNextFieldIndex(): Int? = null
 
-    override suspend fun skipValue() {
+    override fun skipValue() {
         throw DeserializationException("This should not be called during deserialization.")
     }
 }
@@ -129,7 +129,7 @@ private class JsonFieldIterator(
     deserializer: JsonDeserializer
 ) : Deserializer.FieldIterator, Deserializer by deserializer, PrimitiveDeserializer by deserializer {
 
-    override suspend fun findNextFieldIndex(): Int? {
+    override fun findNextFieldIndex(): Int? {
         val candidate = when (reader.peek()) {
             JsonToken.EndObject -> {
                 // consume the token
@@ -161,7 +161,7 @@ private class JsonFieldIterator(
         return candidate
     }
 
-    override suspend fun skipValue() {
+    override fun skipValue() {
         // stream reader skips the *next* token
         reader.skipNext()
     }

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonLexer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonLexer.kt
@@ -62,16 +62,16 @@ internal class JsonLexer(
     private val state = StateManager()
     private var idx = 0
 
-    override suspend fun nextToken(): JsonToken {
+    override fun nextToken(): JsonToken {
         val next = peek()
         peeked = null
         state.update()
         return next
     }
 
-    override suspend fun peek(): JsonToken = peeked ?: doPeek().also { peeked = it }
+    override fun peek(): JsonToken = peeked ?: doPeek().also { peeked = it }
 
-    override suspend fun skipNext() {
+    override fun skipNext() {
         val startDepth = state.size
         nextToken()
         while (state.size > startDepth) {

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamReader.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamReader.kt
@@ -14,17 +14,17 @@ interface JsonStreamReader {
     /**
      * Grab the next token in the stream
      */
-    suspend fun nextToken(): JsonToken
+    fun nextToken(): JsonToken
 
     /**
      * Recursively skip the next token. Meant for discarding unwanted/unrecognized properties in a JSON document
      */
-    suspend fun skipNext()
+    fun skipNext()
 
     /**
      * Peek at the next token type
      */
-    suspend fun peek(): JsonToken
+    fun peek(): JsonToken
 }
 
 /*
@@ -34,7 +34,7 @@ interface JsonStreamReader {
 fun jsonStreamReader(payload: ByteArray): JsonStreamReader = JsonLexer(payload)
 
 // return the next token and require that it be of type [TExpected] or else throw an exception
-internal suspend inline fun <reified TExpected : JsonToken> JsonStreamReader.nextTokenOf(): TExpected {
+internal inline fun <reified TExpected : JsonToken> JsonStreamReader.nextTokenOf(): TExpected {
     val token = this.nextToken()
     requireToken<TExpected>(token)
     return token as TExpected

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.json
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.math.abs
@@ -14,7 +13,7 @@ import kotlin.test.*
 @OptIn(ExperimentalStdlibApi::class)
 class JsonDeserializerTest {
     @Test
-    fun itHandlesDoubles() = runSuspendTest {
+    fun itHandlesDoubles() {
         val tests = mapOf(
             "1.2" to 1.2,
             "\"-Infinity\"" to Double.NEGATIVE_INFINITY,
@@ -37,7 +36,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesFloats() = runSuspendTest {
+    fun itHandlesFloats() {
         val tests = mapOf(
             "1.2" to 1.2f,
             "\"-Infinity\"" to Float.NEGATIVE_INFINITY,
@@ -60,7 +59,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesInt() = runSuspendTest {
+    fun itHandlesInt() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeInt()
@@ -69,7 +68,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesByteAsNumber() = runSuspendTest {
+    fun itHandlesByteAsNumber() {
         val payload = "1".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeByte()
@@ -78,7 +77,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesShort() = runSuspendTest {
+    fun itHandlesShort() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeShort()
@@ -87,7 +86,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesLong() = runSuspendTest {
+    fun itHandlesLong() {
         val payload = "1.2".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeLong()
@@ -96,7 +95,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesBool() = runSuspendTest {
+    fun itHandlesBool() {
         val payload = "true".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeBoolean()
@@ -105,7 +104,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesString() = runSuspendTest {
+    fun itHandlesString() {
         // allow deserializeString() to consume tokens other than JsonToken.String as raw string values
         // this supports custom deserialization (e.g. timestamps) of the raw value
         val tests = listOf(
@@ -125,7 +124,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesNull() = runSuspendTest {
+    fun itHandlesNull() {
         val payload = "null".encodeToByteArray()
         val stringDeserializer = JsonDeserializer(payload)
         stringDeserializer.deserializeNull()
@@ -135,7 +134,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesLists() = runSuspendTest {
+    fun itHandlesLists() {
         val payload = "[1,2,3]".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeList(SdkFieldDescriptor(SerialKind.List)) {
@@ -150,7 +149,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesSparseLists() = runSuspendTest {
+    fun itHandlesSparseLists() {
         val payload = "[1,null,3]".encodeToByteArray()
         val deserializer = JsonDeserializer(payload)
         val actual = deserializer.deserializeList(SdkFieldDescriptor(SerialKind.List)) {
@@ -166,7 +165,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesMaps() = runSuspendTest {
+    fun itHandlesMaps() {
         val payload = """
             {
                 "key1": 1,
@@ -186,7 +185,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itChecksNullValuesOfNonSparseMaps() = runSuspendTest {
+    fun itChecksNullValuesOfNonSparseMaps() {
         val payload = """
             {
                 "key1": 1,
@@ -222,7 +221,7 @@ class JsonDeserializerTest {
                 field(Y_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): BasicStructTest {
+            fun deserialize(deserializer: Deserializer): BasicStructTest {
                 val result = BasicStructTest()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -240,7 +239,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesBasicStructs() = runSuspendTest {
+    fun itHandlesBasicStructs() {
         val payload = """
         {
             "x": 1,
@@ -265,7 +264,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesListOfObjects() = runSuspendTest {
+    fun itHandlesListOfObjects() {
         val payload = """
         [
             {
@@ -294,7 +293,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itEnumeratesUnknownStructFields() = runSuspendTest {
+    fun itEnumeratesUnknownStructFields() {
         val payload = """
         {
             "x": 1,
@@ -331,7 +330,7 @@ class JsonDeserializerTest {
                 field(INT2_FIELD_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): Nested2 {
+            fun deserialize(deserializer: Deserializer): Nested2 {
                 val struct = deserializer.deserializeStruct(OBJ_DESCRIPTOR)
                 val nested2 = Nested2()
                 loop@ while (true) {
@@ -367,7 +366,7 @@ class JsonDeserializerTest {
                 field(BOOL2_FIELD_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): Nested {
+            fun deserialize(deserializer: Deserializer): Nested {
                 val nested = Nested()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -428,7 +427,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itHandlesKitchenSink() = runSuspendTest {
+    fun itHandlesKitchenSink() {
         val payload = """
         {
             "int": 1,
@@ -516,7 +515,7 @@ class JsonDeserializerTest {
     }
 
     @Test
-    fun itSkipsExplicitNulls() = runSuspendTest {
+    fun itSkipsExplicitNulls() {
         val payload = """
          {
              "x": 1,

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonStreamReaderTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonStreamReaderTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.json
 
 import aws.smithy.kotlin.runtime.serde.DeserializationException
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.string.shouldContain
 import kotlin.test.*
@@ -67,7 +66,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesObjects() = runSuspendTest {
+    fun itDeserializesObjects() {
         // language=JSON
         val actual = """ 
             {
@@ -88,7 +87,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun isDeserializesArrays() = runSuspendTest {
+    fun isDeserializesArrays() {
         // language=JSON
         val actual = """[ "hello", "world" ]""".allTokens()
 
@@ -102,14 +101,14 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itFailsOnUnclosedArrays(): Unit = runSuspendTest {
+    fun itFailsOnUnclosedArrays() {
         assertFailsWith<DeserializationException> {
             """[ "hello", "world" """.allTokens()
         }.message.shouldContain("expected one of `,`, `]`")
     }
 
     @Test
-    fun itFailsOnNaN(): Unit = runSuspendTest {
+    fun itFailsOnNaN() {
         assertFailsWith<DeserializationException>("Invalid number") {
             // language=JSON
             """[NaN]""".allTokens()
@@ -117,14 +116,14 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itFailsOnMissingComma(): Unit = runSuspendTest {
+    fun itFailsOnMissingComma() {
         assertFailsWith<DeserializationException> {
             """[3[4]]""".allTokens()
         }.message.shouldContain("Unexpected JSON token at offset 2; found `[`, expected one of `,`, `]`")
     }
 
     @Test
-    fun itFailsOnTrailingComma(): Unit = runSuspendTest {
+    fun itFailsOnTrailingComma() {
         assertFailsWith<DeserializationException> {
             """["",]""".allTokens()
         }.message.shouldContain("Unexpected JSON token at offset 4; found `]`, expected one of `{`, `[`")
@@ -135,7 +134,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesSingleScalarStrings() = runSuspendTest {
+    fun itDeserializesSingleScalarStrings() {
         // language=JSON
         val actual = "\"hello\"".allTokens()
         actual.shouldContainExactly(
@@ -145,7 +144,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesSingleScalarNumbers() = runSuspendTest {
+    fun itDeserializesSingleScalarNumbers() {
         // language=JSON
         val actual = "1.2".allTokens()
         actual.shouldContainExactly(
@@ -155,7 +154,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itCanHandleAllDataTypes() = runSuspendTest {
+    fun itCanHandleAllDataTypes() {
         // language=JSON
         val actual = """[ "hello", true, false, 1.0, 1, -34.234e3, null ]""".allTokens()
 
@@ -174,7 +173,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun canHandleNesting() = runSuspendTest {
+    fun canHandleNesting() {
         // language=JSON
         val actual = """
         [
@@ -208,7 +207,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itSkipsValuesRecursively() = runSuspendTest {
+    fun itSkipsValuesRecursively() {
         val payload = """
         {
             "x": 1,
@@ -241,7 +240,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itSkipsValuesRecursivelyAfterPeek() = runSuspendTest {
+    fun itSkipsValuesRecursivelyAfterPeek() {
         val payload = """
         {
             "x": 1,
@@ -293,7 +292,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun testPeek() = runSuspendTest {
+    fun testPeek() {
         val reader = newReader(KitchenSink.payload)
         KitchenSink.tokens.forEachIndexed { idx, expectedToken ->
             repeat(2) {
@@ -304,7 +303,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun itSkipsSimpleValues() = runSuspendTest {
+    fun itSkipsSimpleValues() {
         val payload = """
         {
             "x": 1,
@@ -329,13 +328,13 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun kitchenSink() = runSuspendTest {
+    fun kitchenSink() {
         val actual = KitchenSink.payload.allTokens()
         actual.shouldContainExactly(KitchenSink.tokens)
     }
 
     @Test
-    fun itHandlesEscapes() = runSuspendTest {
+    fun itHandlesEscapes() {
         val tests = listOf(
             """\"quote""" to "\"quote",
             """\/forward-slash""" to "/forward-slash",
@@ -366,7 +365,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun testUnescapeControls(): Unit = runSuspendTest {
+    fun testUnescapeControls() {
         assertEquals("\"test\"", """"\"test\""""".decodeJsonStringToken())
         assertEquals("foo\rbar", """"foo\rbar"""".decodeJsonStringToken())
         assertEquals("foo\r\n", """"foo\r\n"""".decodeJsonStringToken())
@@ -375,7 +374,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun testUnicodeUnescape(): Unit = runSuspendTest {
+    fun testUnicodeUnescape() {
         assertFailsWith<DeserializationException> {
             """"\uD801\nasdf"""".allTokens()
         }.message.shouldContain("Expected surrogate pair")
@@ -406,7 +405,7 @@ class JsonStreamReaderTest {
     }
 
     @Test
-    fun testUnescapedControlChars() = runSuspendTest {
+    fun testUnescapedControlChars() {
         assertFailsWith<DeserializationException> {
             """["new
 line"]""".allTokens()
@@ -424,7 +423,7 @@ line"]""".allTokens()
     }
 
     @Test
-    fun testUnicodeTokens() = runSuspendTest {
+    fun testUnicodeTokens() {
 
         val languages = listOf(
             "こんにちは世界",
@@ -456,7 +455,7 @@ line"]""".allTokens()
     }
 }
 
-private suspend fun String.decodeJsonStringToken(): String {
+private fun String.decodeJsonStringToken(): String {
     val reader = newReader(this)
     val tokens = mutableListOf<JsonToken>()
     while (true) {
@@ -474,7 +473,7 @@ private suspend fun String.decodeJsonStringToken(): String {
     return token.value
 }
 
-private suspend fun String.allTokens(): List<JsonToken> {
+private fun String.allTokens(): List<JsonToken> {
     val reader = newReader(this)
     val tokens = mutableListOf<JsonToken>()
     while (true) {

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -36,7 +36,7 @@ class XmlDeserializer(
     private val logger = Logger.getLogger<XmlDeserializer>()
     private var firstStructCall = true
 
-    override suspend fun deserializeStruct(descriptor: SdkObjectDescriptor): Deserializer.FieldIterator {
+    override fun deserializeStruct(descriptor: SdkObjectDescriptor): Deserializer.FieldIterator {
         logger.trace { "Deserializing struct $descriptor under ${reader.lastToken}" }
 
         if (firstStructCall) {
@@ -71,7 +71,7 @@ class XmlDeserializer(
         return XmlStructDeserializer(descriptor, reader.subTreeReader(), parentToken, attribFields)
     }
 
-    override suspend fun deserializeList(descriptor: SdkFieldDescriptor): Deserializer.ElementIterator {
+    override fun deserializeList(descriptor: SdkFieldDescriptor): Deserializer.ElementIterator {
         logger.trace { "Deserializing list $descriptor under ${reader.lastToken}" }
 
         val depth = when (descriptor.hasTrait<Flattened>()) {
@@ -82,7 +82,7 @@ class XmlDeserializer(
         return XmlListDeserializer(reader.subTreeReader(depth), descriptor)
     }
 
-    override suspend fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
+    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
         logger.trace { "Deserializing map $descriptor under ${reader.lastToken}" }
 
         return XmlMapDeserializer(reader.subTreeReader(XmlStreamReader.SubtreeStartDepth.CURRENT), descriptor)
@@ -103,7 +103,7 @@ internal class XmlMapDeserializer(
 ) : PrimitiveDeserializer by primitiveDeserializer, Deserializer.EntryIterator {
     private val mapTrait = descriptor.findTrait<XmlMapName>() ?: XmlMapName.Default
 
-    override suspend fun hasNextEntry(): Boolean {
+    override fun hasNextEntry(): Boolean {
         // Seek to either the entry or key token depending on the flatness of the map
         val nextEntryToken = when (descriptor.hasTrait<Flattened>()) {
             true -> reader.seek<XmlToken.BeginElement> { it.name.local == mapTrait.key }
@@ -113,7 +113,7 @@ internal class XmlMapDeserializer(
         return nextEntryToken != null
     }
 
-    override suspend fun key(): String {
+    override fun key(): String {
         // Seek to the key begin token
         reader.seek<XmlToken.BeginElement> { it.name.local == mapTrait.key }
             ?: error("Unable to find key $mapTrait.key in $descriptor")
@@ -124,7 +124,7 @@ internal class XmlMapDeserializer(
         return keyValueToken.value ?: throw DeserializationException("Key unspecified in $descriptor")
     }
 
-    override suspend fun nextHasValue(): Boolean {
+    override fun nextHasValue(): Boolean {
         // Expect a begin and value (or another begin) token if Map entry has a value
         val peekBeginToken = reader.peek(1) ?: throw DeserializationException("Unexpected termination of token stream in $descriptor")
         val peekValueToken = reader.peek(2) ?: throw DeserializationException("Unexpected termination of token stream in $descriptor")
@@ -149,7 +149,7 @@ internal class XmlListDeserializer(
     private val flattened = descriptor.hasTrait<Flattened>()
     private val elementName = (descriptor.findTrait<XmlCollectionName>() ?: XmlCollectionName.Default).element
 
-    override suspend fun hasNextElement(): Boolean {
+    override fun hasNextElement(): Boolean {
         if (!flattened && firstCall) {
             val nextToken = reader.peek()
             val matchedListDescriptor = nextToken is XmlToken.BeginElement && descriptor.nameMatches(nextToken.name.tag)
@@ -195,7 +195,7 @@ internal class XmlListDeserializer(
         }
     }
 
-    override suspend fun nextHasValue(): Boolean = reader.peek() !is XmlToken.EndElement
+    override fun nextHasValue(): Boolean = reader.peek() !is XmlToken.EndElement
 }
 
 /**
@@ -215,7 +215,7 @@ internal class XmlStructDeserializer(
     // Used to track direct deserialization or further nesting between calls to findNextFieldIndex() and deserialize<Type>()
     private var reentryFlag: Boolean = false
 
-    override suspend fun findNextFieldIndex(): Int? {
+    override fun findNextFieldIndex(): Int? {
         if (inNestedMode()) {
             // Returning from a nested struct call.  Nested deserializer consumed
             // tokens so clear them here to avoid processing stale state
@@ -243,7 +243,7 @@ internal class XmlStructDeserializer(
         return parsedFieldLocations.firstOrNull()?.fieldIndex ?: Deserializer.FieldIterator.UNKNOWN_FIELD
     }
 
-    private suspend fun <T> deserializeValue(transform: ((String) -> T)): T {
+    private fun <T> deserializeValue(transform: ((String) -> T)): T {
         // Set and validate mode
         reentryFlag = false
         if (parsedFieldLocations.isEmpty()) throw DeserializationException("matchedFields is empty, was findNextFieldIndex() called?")
@@ -269,25 +269,25 @@ internal class XmlStructDeserializer(
         }
     }
 
-    override suspend fun skipValue() = reader.skipNext()
+    override fun skipValue() = reader.skipNext()
 
-    override suspend fun deserializeByte(): Byte = deserializeValue { it.toIntOrNull()?.toByte() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeByte(): Byte = deserializeValue { it.toIntOrNull()?.toByte() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeInt(): Int = deserializeValue { it.toIntOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeInt(): Int = deserializeValue { it.toIntOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeShort(): Short = deserializeValue { it.toIntOrNull()?.toShort() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeShort(): Short = deserializeValue { it.toIntOrNull()?.toShort() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeLong(): Long = deserializeValue { it.toLongOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeLong(): Long = deserializeValue { it.toLongOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeFloat(): Float = deserializeValue { it.toFloatOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeFloat(): Float = deserializeValue { it.toFloatOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeDouble(): Double = deserializeValue { it.toDoubleOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
+    override fun deserializeDouble(): Double = deserializeValue { it.toDoubleOrNull() ?: throw DeserializationException("Unable to deserialize $it") }
 
-    override suspend fun deserializeString(): String = deserializeValue { it }
+    override fun deserializeString(): String = deserializeValue { it }
 
-    override suspend fun deserializeBoolean(): Boolean = deserializeValue { it.toBoolean() }
+    override fun deserializeBoolean(): Boolean = deserializeValue { it.toBoolean() }
 
-    override suspend fun deserializeNull(): Nothing? {
+    override fun deserializeNull(): Nothing? {
         reader.takeNextAs<XmlToken.EndElement>()
         return null
     }
@@ -308,7 +308,7 @@ internal class XmlStructDeserializer(
 }
 
 // Extract the attributes from the last-read token and match them to [FieldLocation] on the [SdkObjectDescriptor].
-private suspend fun XmlStreamReader.tokenAttributesToFieldLocations(descriptor: SdkObjectDescriptor): MutableList<FieldLocation> =
+private fun XmlStreamReader.tokenAttributesToFieldLocations(descriptor: SdkObjectDescriptor): MutableList<FieldLocation> =
     if (descriptor.hasXmlAttributes && lastToken is XmlToken.BeginElement) {
         val attribFields = descriptor.fields.filter { it.hasTrait<XmlAttribute>() }
         val matchedAttribFields = attribFields.filter { it.findFieldLocation(lastToken as XmlToken.BeginElement, peek() ?: throw DeserializationException("Unexpected end of tokens")) != null }
@@ -363,7 +363,7 @@ private fun SdkObjectDescriptor.fieldTokenMatcher(fieldDescriptor: SdkFieldDescr
 }
 
 // Return the next token of the specified type or throw [DeserializerStateException] if incorrect type.
-internal suspend inline fun <reified TExpected : XmlToken> XmlStreamReader.takeNextAs(): TExpected {
+internal inline fun <reified TExpected : XmlToken> XmlStreamReader.takeNextAs(): TExpected {
     val token = this.nextToken() ?: throw DeserializationException("Expected ${TExpected::class} but instead found null")
     requireToken<TExpected>(token)
     return token as TExpected

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
@@ -15,7 +15,7 @@ internal class XmlPrimitiveDeserializer(private val reader: XmlStreamReader, pri
 
     constructor(input: ByteArray, fieldDescriptor: SdkFieldDescriptor) : this(xmlStreamReader(input), fieldDescriptor)
 
-    private suspend fun <T> deserializeValue(transform: ((String) -> T)): T {
+    private fun <T> deserializeValue(transform: ((String) -> T)): T {
         if (reader.peek() is XmlToken.BeginElement) {
             // In the case of flattened lists, we "fall" into the first member as there is no wrapper.
             // this conditional checks that case for the first element of the list.
@@ -33,23 +33,23 @@ internal class XmlPrimitiveDeserializer(private val reader: XmlStreamReader, pri
             ?.also<T> { reader.takeNextAs<XmlToken.EndElement>() } ?: throw DeserializationException("$token specifies nonexistent or invalid value.")
     }
 
-    override suspend fun deserializeByte(): Byte = deserializeValue { it.toIntOrNull()?.toByte() ?: throw DeserializationException("Unable to deserialize $it as Byte") }
+    override fun deserializeByte(): Byte = deserializeValue { it.toIntOrNull()?.toByte() ?: throw DeserializationException("Unable to deserialize $it as Byte") }
 
-    override suspend fun deserializeInt(): Int = deserializeValue { it.toIntOrNull() ?: throw DeserializationException("Unable to deserialize $it as Int") }
+    override fun deserializeInt(): Int = deserializeValue { it.toIntOrNull() ?: throw DeserializationException("Unable to deserialize $it as Int") }
 
-    override suspend fun deserializeShort(): Short = deserializeValue { it.toIntOrNull()?.toShort() ?: throw DeserializationException("Unable to deserialize $it as Short") }
+    override fun deserializeShort(): Short = deserializeValue { it.toIntOrNull()?.toShort() ?: throw DeserializationException("Unable to deserialize $it as Short") }
 
-    override suspend fun deserializeLong(): Long = deserializeValue { it.toLongOrNull() ?: throw DeserializationException("Unable to deserialize $it as Long") }
+    override fun deserializeLong(): Long = deserializeValue { it.toLongOrNull() ?: throw DeserializationException("Unable to deserialize $it as Long") }
 
-    override suspend fun deserializeFloat(): Float = deserializeValue { it.toFloatOrNull() ?: throw DeserializationException("Unable to deserialize $it as Float") }
+    override fun deserializeFloat(): Float = deserializeValue { it.toFloatOrNull() ?: throw DeserializationException("Unable to deserialize $it as Float") }
 
-    override suspend fun deserializeDouble(): Double = deserializeValue { it.toDoubleOrNull() ?: throw DeserializationException("Unable to deserialize $it as Double") }
+    override fun deserializeDouble(): Double = deserializeValue { it.toDoubleOrNull() ?: throw DeserializationException("Unable to deserialize $it as Double") }
 
-    override suspend fun deserializeString(): String = deserializeValue { it }
+    override fun deserializeString(): String = deserializeValue { it }
 
-    override suspend fun deserializeBoolean(): Boolean = deserializeValue { it.toBoolean() }
+    override fun deserializeBoolean(): Boolean = deserializeValue { it.toBoolean() }
 
-    override suspend fun deserializeNull(): Nothing? {
+    override fun deserializeNull(): Nothing? {
         reader.nextToken() ?: throw DeserializationException("Unexpected end of stream")
         reader.seek<XmlToken.EndElement>()
         reader.nextToken() ?: throw DeserializationException("Unexpected end of stream")

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
@@ -34,26 +34,26 @@ interface XmlStreamReader {
      * current level + 1 (CHILD), starting at the next node to be read from the stream.
      * @param subtreeStartDepth Determines minimum depth of the subtree
      */
-    suspend fun subTreeReader(subtreeStartDepth: SubtreeStartDepth = SubtreeStartDepth.CHILD): XmlStreamReader
+    fun subTreeReader(subtreeStartDepth: SubtreeStartDepth = SubtreeStartDepth.CHILD): XmlStreamReader
 
     /**
      * Return the next actionable token or null if stream is exhausted.
      *
      * @throws XmlGenerationException upon any error.
      */
-    suspend fun nextToken(): XmlToken?
+    fun nextToken(): XmlToken?
 
     /**
      * Recursively skip the next token. Meant for discarding unwanted/unrecognized nodes in an XML document
      */
-    suspend fun skipNext()
+    fun skipNext()
 
     /**
      * Peek at the next token type.  Successive calls will return the same value, meaning there is only one
      * look-ahead at any given time during the parsing of input data.
      * @param index a positive integer representing index of node from current to peek.  Index of 1 is the next node.
      */
-    suspend fun peek(index: Int = 1): XmlToken?
+    fun peek(index: Int = 1): XmlToken?
 }
 
 /**
@@ -61,7 +61,7 @@ interface XmlStreamReader {
  *
  * @param selectionPredicate predicate that evaluates nodes of the required type to match
  */
-suspend inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate: (T) -> Boolean = { true }): T? {
+inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate: (T) -> Boolean = { true }): T? {
     var token: XmlToken? = lastToken
     var foundMatch = false
 

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode.kt
@@ -35,7 +35,7 @@ class XmlNode {
 
     companion object {
 
-        suspend fun parse(xmlpayload: ByteArray): XmlNode {
+        fun parse(xmlpayload: ByteArray): XmlNode {
             val reader = xmlStreamReader(xmlpayload)
             return parseDom(reader)
         }
@@ -58,7 +58,7 @@ class XmlNode {
 }
 
 // parse a string into a dom representation
-suspend fun parseDom(reader: XmlStreamReader): XmlNode {
+fun parseDom(reader: XmlStreamReader): XmlNode {
 
     val nodeStack: ListStack<XmlNode> = mutableListOf()
 

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/SharedTestData.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/SharedTestData.kt
@@ -26,7 +26,7 @@ class SimpleStructClass {
             field(Z_DESCRIPTOR)
         }
 
-        suspend fun deserialize(deserializer: Deserializer): SimpleStructClass {
+        fun deserialize(deserializer: Deserializer): SimpleStructClass {
             val result = SimpleStructClass()
             deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                 loop@ while (true) {
@@ -60,7 +60,7 @@ class SimpleStructOfStringsClass {
             field(Y_DESCRIPTOR)
         }
 
-        suspend fun deserialize(deserializer: Deserializer): SimpleStructOfStringsClass {
+        fun deserialize(deserializer: Deserializer): SimpleStructOfStringsClass {
             val result = SimpleStructOfStringsClass()
             deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                 loop@ while (true) {
@@ -91,7 +91,7 @@ class StructWithAttribsClass {
             field(Y_DESCRIPTOR)
         }
 
-        suspend fun deserialize(deserializer: Deserializer): StructWithAttribsClass {
+        fun deserialize(deserializer: Deserializer): StructWithAttribsClass {
             val result = StructWithAttribsClass()
             deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                 loop@ while (true) {
@@ -129,7 +129,7 @@ class StructWithMultiAttribsAndTextValClass {
             field(Y_DESCRIPTOR)
         }
 
-        suspend fun deserialize(deserializer: Deserializer): StructWithMultiAttribsAndTextValClass {
+        fun deserialize(deserializer: Deserializer): StructWithMultiAttribsAndTextValClass {
             val result = StructWithMultiAttribsAndTextValClass()
             deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                 loop@ while (true) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerAWSTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerAWSTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -24,7 +23,7 @@ class XmlDeserializerAWSTest {
                 field(COMMENT_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): HostedZoneConfig {
+            fun deserialize(deserializer: Deserializer): HostedZoneConfig {
                 val builder = BuilderImpl()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -77,7 +76,7 @@ class XmlDeserializerAWSTest {
                 field(HOSTED_ZONE_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): CreateHostedZoneRequest {
+            fun deserialize(deserializer: Deserializer): CreateHostedZoneRequest {
                 val builder = BuilderImpl()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -119,7 +118,7 @@ class XmlDeserializerAWSTest {
     }
 
     @Test
-    fun itHandlesRoute53XML() = runSuspendTest {
+    fun itHandlesRoute53XML() {
         val testXml = """
                <?xml version="1.0" encoding="UTF-8"?><!--
                  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerListTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerListTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,7 +21,7 @@ class XmlDeserializerListTest {
             operator fun invoke(block: DslBuilder.() -> Unit) = BuilderImpl().apply(block).build()
             fun dslBuilder(): DslBuilder = BuilderImpl()
 
-            suspend fun deserialize(
+            fun deserialize(
                 deserializer: Deserializer,
                 OBJ_DESCRIPTOR: SdkObjectDescriptor,
                 ELEMENT_LIST_FIELD_DESCRIPTOR: SdkFieldDescriptor
@@ -70,7 +69,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesListSingleElement() = runSuspendTest {
+    fun itHandlesListSingleElement() {
         val payload = """
             <object>
                 <list>
@@ -92,7 +91,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesListMultipleElementsAndCustomMemberName() = runSuspendTest {
+    fun itHandlesListMultipleElementsAndCustomMemberName() {
         val payload = """
             <object>
                 <list>
@@ -122,7 +121,7 @@ class XmlDeserializerListTest {
             operator fun invoke(block: DslBuilder.() -> Unit) = BuilderImpl().apply(block).build()
             fun dslBuilder(): DslBuilder = BuilderImpl()
 
-            suspend fun deserialize(
+            fun deserialize(
                 deserializer: Deserializer,
                 OBJ_DESCRIPTOR: SdkObjectDescriptor,
                 ELEMENT_LIST_FIELD_DESCRIPTOR: SdkFieldDescriptor
@@ -175,7 +174,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesSparseLists() = runSuspendTest {
+    fun itHandlesSparseLists() {
         val payload = """
             <object>
                 <list>
@@ -200,7 +199,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesEmptyLists() = runSuspendTest {
+    fun itHandlesEmptyLists() {
         val payload = """
             <object>
                 <list>                    
@@ -221,7 +220,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesFlatLists() = runSuspendTest {
+    fun itHandlesFlatLists() {
         val payload = """
             <object>
                 <element>1</element>
@@ -242,7 +241,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesListOfObjectsWithMissingFields() = runSuspendTest {
+    fun itHandlesListOfObjectsWithMissingFields() {
         val payload = """
             <object>
                <list>
@@ -293,7 +292,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesListOfObjectsWithEmptyValues() = runSuspendTest {
+    fun itHandlesListOfObjectsWithEmptyValues() {
         val payload = """
             <object>
                <list>
@@ -339,7 +338,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesNestedLists() = runSuspendTest {
+    fun itHandlesNestedLists() {
         val payload = """
             <NestedListResponse>
                 <parentList>
@@ -384,7 +383,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesListsOfStructs() = runSuspendTest {
+    fun itHandlesListsOfStructs() {
         val payload = """
             <FooResponse>
                 <parentList>
@@ -412,7 +411,7 @@ class XmlDeserializerListTest {
     }
 
     @Test
-    fun itHandlesFlatListsOfStructs() = runSuspendTest {
+    fun itHandlesFlatListsOfStructs() {
         val payload = """
             <FooResponse>
                 <flatList>
@@ -445,7 +444,7 @@ class XmlDeserializerListTest {
 
 internal class FooOperationDeserializer {
 
-    suspend fun deserialize(
+    fun deserialize(
         deserializer: Deserializer,
         LIST_DESCRIPTOR: SdkFieldDescriptor
     ): FooResponse {
@@ -490,7 +489,7 @@ internal class PayloadStructDocumentDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): PayloadStruct {
+    fun deserialize(deserializer: Deserializer): PayloadStruct {
         val builder = PayloadStruct.dslBuilder()
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
             loop@while (true) {
@@ -694,7 +693,7 @@ internal class NestedListOperationOperationDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): NestedListResponse {
+    fun deserialize(deserializer: Deserializer): NestedListResponse {
         val builder = NestedListResponse.dslBuilder()
 
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerMapTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerMapTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.test.Test
 
@@ -13,7 +12,7 @@ import kotlin.test.Test
 class XmlDeserializerMapTest {
 
     @Test
-    fun itHandlesMapsWithDefaultNodeNames() = runSuspendTest {
+    fun itHandlesMapsWithDefaultNodeNames() {
         val payload = """
             <object>
                 <values>
@@ -60,7 +59,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesMapsWithCustomNodeNames() = runSuspendTest {
+    fun itHandlesMapsWithCustomNodeNames() {
         val payload = """
             <object>
                 <mymap>
@@ -108,7 +107,7 @@ class XmlDeserializerMapTest {
 
     // https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html#flattened-map-serialization
     @Test
-    fun itHandlesFlatMaps() = runSuspendTest {
+    fun itHandlesFlatMaps() {
         val payload = """
             <object>
                 <flatMap>
@@ -157,7 +156,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesEmptyMaps() = runSuspendTest {
+    fun itHandlesEmptyMaps() {
         val payload = """
             <object>
                 <map />
@@ -197,7 +196,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesSparseMaps() = runSuspendTest {
+    fun itHandlesSparseMaps() {
         val payload = """
             <object>
                 <values>
@@ -249,7 +248,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesCheckingMapValuesForNull() = runSuspendTest {
+    fun itHandlesCheckingMapValuesForNull() {
         val payload = """
             <object>
                 <values>
@@ -297,7 +296,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesNestedMap() = runSuspendTest {
+    fun itHandlesNestedMap() {
         val payload = """
             <object>
                 <map>
@@ -380,7 +379,7 @@ class XmlDeserializerMapTest {
     }
 
     @Test
-    fun itHandlesNestedStructAsValue() = runSuspendTest {
+    fun itHandlesNestedStructAsValue() {
 
         val payload = """
             <XmlMapsInputOutput>
@@ -418,7 +417,7 @@ internal class XmlMapsOperationDeserializer() {
         }
     }
 
-    suspend fun deserialize(deserializer: XmlDeserializer): XmlMapsInputOutput {
+    fun deserialize(deserializer: XmlDeserializer): XmlMapsInputOutput {
         val builder = XmlMapsInputOutput.dslBuilder()
 
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
@@ -455,7 +454,7 @@ internal class GreetingStructDocumentDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): GreetingStruct {
+    fun deserialize(deserializer: Deserializer): GreetingStruct {
         val builder = GreetingStruct.dslBuilder()
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
             loop@while (true) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerNamespaceTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerNamespaceTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,7 +13,7 @@ import kotlin.test.assertEquals
 class XmlDeserializerNamespaceTest {
 
     @Test
-    fun `it handles struct with namespace declarations but default tags`() = runSuspendTest {
+    fun `it handles struct with namespace declarations but default tags`() {
         val payload = """
            <MyStructure xmlns="http://foo.com">
                 <foo xmlns:bar="http://foo2.com">example1</foo>
@@ -43,7 +42,7 @@ class XmlDeserializerNamespaceTest {
                 field(BAR_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): NamespaceStructTest {
+            fun deserialize(deserializer: Deserializer): NamespaceStructTest {
                 val result = NamespaceStructTest()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -61,7 +60,7 @@ class XmlDeserializerNamespaceTest {
     }
 
     @Test
-    fun `it handles struct with node namespace`() = runSuspendTest {
+    fun `it handles struct with node namespace`() {
         val payload = """
            <MyStructure xmlns:baz="http://foo.com">
                 <foo>example1</foo>
@@ -90,7 +89,7 @@ class XmlDeserializerNamespaceTest {
                 field(BAR_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): NodeNamespaceStructTest {
+            fun deserialize(deserializer: Deserializer): NodeNamespaceStructTest {
                 val result = NodeNamespaceStructTest()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerPrimitiveTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerPrimitiveTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +14,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerPrimitiveTest {
     @Test
-    fun itHandlesDoubles() = runSuspendTest {
+    fun itHandlesDoubles() {
         val deserializer = XmlPrimitiveDeserializer("<node>1.2</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Double, XmlSerialName("node")))
         val actual = deserializer.deserializeDouble()
         val expected = 1.2
@@ -23,7 +22,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesFloats() = runSuspendTest {
+    fun itHandlesFloats() {
         val deserializer = XmlPrimitiveDeserializer("<node>1.2</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Float, XmlSerialName("node")))
         val actual = deserializer.deserializeFloat()
         val expected = 1.2f
@@ -31,7 +30,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesInt() = runSuspendTest {
+    fun itHandlesInt() {
         val deserializer = XmlPrimitiveDeserializer("<node>${Int.MAX_VALUE}</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Integer, XmlSerialName("node")))
         val actual = deserializer.deserializeInt()
         val expected = 2147483647
@@ -39,7 +38,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesByteAsNumber() = runSuspendTest {
+    fun itHandlesByteAsNumber() {
         val deserializer = XmlPrimitiveDeserializer("<node>1</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Byte, XmlSerialName("node")))
         val actual = deserializer.deserializeByte()
         val expected: Byte = 1
@@ -47,7 +46,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesShort() = runSuspendTest {
+    fun itHandlesShort() {
         val deserializer = XmlPrimitiveDeserializer("<node>${Short.MAX_VALUE}</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Short, XmlSerialName("node")))
         val actual = deserializer.deserializeShort()
         val expected: Short = 32767
@@ -55,7 +54,7 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesLong() = runSuspendTest {
+    fun itHandlesLong() {
         val deserializer = XmlPrimitiveDeserializer("<node>${Long.MAX_VALUE}</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Long, XmlSerialName("node")))
         val actual = deserializer.deserializeLong()
         val expected = 9223372036854775807L
@@ -63,14 +62,14 @@ class XmlDeserializerPrimitiveTest {
     }
 
     @Test
-    fun itHandlesBool() = runSuspendTest {
+    fun itHandlesBool() {
         val deserializer = XmlPrimitiveDeserializer("<node>true</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Boolean, XmlSerialName("node")))
         val actual = deserializer.deserializeBoolean()
         assertTrue(actual)
     }
 
     @Test
-    fun itFailsInvalidTypeSpecificationForInt() = runSuspendTest {
+    fun itFailsInvalidTypeSpecificationForInt() {
         val deserializer = XmlPrimitiveDeserializer("<node>1.2</node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Integer, XmlSerialName("node")))
         assertFailsWith(DeserializationException::class) {
             deserializer.deserializeInt()
@@ -79,7 +78,7 @@ class XmlDeserializerPrimitiveTest {
 
     @Test
     // TODO: It's unclear if this test should result in an exception or null value.
-    fun itFailsMissingTypeSpecificationForInt() = runSuspendTest {
+    fun itFailsMissingTypeSpecificationForInt() {
         val deserializer = XmlPrimitiveDeserializer("<node></node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Integer, XmlSerialName("node")))
         assertFailsWith(DeserializationException::class) {
             deserializer.deserializeInt()
@@ -88,7 +87,7 @@ class XmlDeserializerPrimitiveTest {
 
     @Test
     // TODO: It's unclear if this test should result in an exception or null value.
-    fun itFailsWhitespaceTypeSpecificationForInt() = runSuspendTest {
+    fun itFailsWhitespaceTypeSpecificationForInt() {
         val deserializer = XmlPrimitiveDeserializer("<node> </node>".wrapInStruct(), SdkFieldDescriptor(SerialKind.Integer, XmlSerialName("node")))
         assertFailsWith(DeserializationException::class) {
             deserializer.deserializeInt()

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerStructTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerStructTest.kt
@@ -5,14 +5,13 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerStructTest {
     @Test
-    fun `it handles basic structs with attribs`() = runSuspendTest {
+    fun `it handles basic structs with attribs`() {
         val payload = """
                <?xml version="1.0" encoding="UTF-8"?>
                <!--
@@ -31,7 +30,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun `it handles basic structs with multi attribs and text`() = runSuspendTest {
+    fun `it handles basic structs with multi attribs and text`() {
         val payload = """
                <?xml version="1.0" encoding="UTF-8"?>
                <!--
@@ -53,7 +52,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesBasicStructsWithAttribsAndText() = runSuspendTest {
+    fun itHandlesBasicStructsWithAttribsAndText() {
         val payload = """
             <payload xa="1" ya="2">
                 <x>x1</x>
@@ -91,7 +90,7 @@ class XmlDeserializerStructTest {
                 field(Z_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): BasicAttribTextStructTest {
+            fun deserialize(deserializer: Deserializer): BasicAttribTextStructTest {
                 val result = BasicAttribTextStructTest()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -115,7 +114,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesBasicStructs() = runSuspendTest {
+    fun itHandlesBasicStructs() {
         val payload = """
             <payload>
                 <x>1</x>
@@ -131,7 +130,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesBasicStructsWithNullValues() = runSuspendTest {
+    fun itHandlesBasicStructsWithNullValues() {
         val payload1 = """
             <payload>
                 <x>a</x>
@@ -160,7 +159,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itEnumeratesUnknownStructFields() = runSuspendTest {
+    fun itEnumeratesUnknownStructFields() {
         val payload = """
                <payload z="strval">
                    <x>1</x>
@@ -177,7 +176,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesNestedXmlStructures() = runSuspendTest {
+    fun itHandlesNestedXmlStructures() {
         val payload = """
             <RecursiveShapesInputOutput>
                 <nested>
@@ -226,7 +225,7 @@ class XmlDeserializerStructTest {
                 field(ATTRIBUTE_DESCRIPTOR)
             }
 
-            suspend fun deserialize(deserializer: Deserializer): AliasStruct {
+            fun deserialize(deserializer: Deserializer): AliasStruct {
                 val result = AliasStruct()
                 deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
                     loop@ while (true) {
@@ -244,7 +243,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesAliasMatchingOnElements() = runSuspendTest {
+    fun itHandlesAliasMatchingOnElements() {
         val tests = listOf(
             "<Struct><Message>Hi there</Message></Struct>",
             "<Struct><message>Hi there</message></Struct>",
@@ -259,7 +258,7 @@ class XmlDeserializerStructTest {
     }
 
     @Test
-    fun itHandlesAliasMatchingOnAttributes() = runSuspendTest {
+    fun itHandlesAliasMatchingOnAttributes() {
         val tests = listOf(
             """<Struct Attribute="Hi there"></Struct>""",
             """<Struct attribute="Hi there"></Struct>""",
@@ -283,7 +282,7 @@ internal class RecursiveShapesOperationDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutput {
+    fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutput {
         val builder = RecursiveShapesInputOutput.dslBuilder()
 
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
@@ -311,7 +310,7 @@ internal class RecursiveShapesInputOutputNested1DocumentDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutputNested1 {
+    fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutputNested1 {
         val builder = RecursiveShapesInputOutputNested1.dslBuilder()
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
             loop@while (true) {
@@ -338,7 +337,7 @@ internal class RecursiveShapesInputOutputNested2DocumentDeserializer {
         }
     }
 
-    suspend fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutputNested2 {
+    fun deserialize(deserializer: Deserializer): RecursiveShapesInputOutputNested2 {
         val builder = RecursiveShapesInputOutputNested2.dslBuilder()
         deserializer.deserializeStruct(OBJ_DESCRIPTOR) {
             loop@while (true) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
@@ -5,13 +5,12 @@
 package aws.smithy.kotlin.runtime.serde.xml
 
 import aws.smithy.kotlin.runtime.serde.DeserializationException
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.test.*
 
 @OptIn(ExperimentalStdlibApi::class)
 class XmlStreamReaderTest {
     @Test
-    fun itDeserializesXml() = runSuspendTest {
+    fun itDeserializesXml() {
         val payload = """
             <root>
                 <x>1</x>
@@ -34,7 +33,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesXmlWithEscapedCharacters() = runSuspendTest {
+    fun itDeserializesXmlWithEscapedCharacters() {
         val payload = """<root>&lt;string&gt;</root>""".trimIndent().encodeToByteArray()
         val actual = xmlStreamReader(payload).allTokens()
 
@@ -47,7 +46,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesXmlTextWithAmpersands() = runSuspendTest {
+    fun itDeserializesXmlTextWithAmpersands() {
         val payload = """             
             <value>{&quot;Version&quot;:&quot;2008-10-17&quot;,&quot;Id&quot;:&quot;__default_policy_ID&quot;,&quot;Statement&quot;:[{&quot;Sid&quot;:&quot;__default_statement_ID&quot;,&quot;Effect&quot;:&quot;Allow&quot;,&quot;Principal&quot;:{&quot;AWS&quot;:&quot;*&quot;},&quot;Action&quot;:[&quot;SNS:GetTopicAttributes&quot;,&quot;SNS:SetTopicAttributes&quot;,&quot;SNS:AddPermission&quot;,&quot;SNS:RemovePermission&quot;,&quot;SNS:DeleteTopic&quot;,&quot;SNS:Subscribe&quot;,&quot;SNS:ListSubscriptionsByTopic&quot;,&quot;SNS:Publish&quot;,&quot;SNS:Receive&quot;],&quot;Resource&quot;:&quot;arn:aws:sns:us-west-2:406669096152:kg-test&quot;,&quot;Condition&quot;:{&quot;StringEquals&quot;:{&quot;AWS:SourceOwner&quot;:&quot;406669096152&quot;}}}]}</value>            
         """.trimIndent().encodeToByteArray()
@@ -62,7 +61,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itDeserializesXmlWithAttributes() = runSuspendTest {
+    fun itDeserializesXmlWithAttributes() {
         val payload = """
             <batch>
                 <add id="tt0484562">
@@ -89,13 +88,13 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun garbageInGarbageOut() = runSuspendTest {
+    fun garbageInGarbageOut() {
         val payload = """you try to parse me once, jokes on me..try twice jokes on you bucko.""".trimIndent().encodeToByteArray()
         assertFailsWith(DeserializationException::class) { xmlStreamReader(payload).allTokens() }
     }
 
     @Test
-    fun itIgnoresXmlComments() = runSuspendTest {
+    fun itIgnoresXmlComments() {
         val payload = """
                <?xml version="1.0" encoding="UTF-8"?>
                <!--
@@ -118,7 +117,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesNilNodeValues() = runSuspendTest {
+    fun itHandlesNilNodeValues() {
         val payload = """<null></null>""".encodeToByteArray()
         val actual = xmlStreamReader(payload).allTokens()
         val expected = listOf(
@@ -130,7 +129,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun kitchenSink() = runSuspendTest {
+    fun kitchenSink() {
         val payload = """
         <root>
           <num>1</num>    
@@ -196,7 +195,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itSkipsValuesRecursively() = runSuspendTest {
+    fun itSkipsValuesRecursively() {
         val payload = """
             <payload>
                 <x>1></x>
@@ -238,7 +237,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itSkipsSimpleValues() = runSuspendTest {
+    fun itSkipsSimpleValues() {
         val payload = """
             <payload>
                 <x>1</x>
@@ -265,7 +264,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesNestedNodesOfSameName() = runSuspendTest {
+    fun itHandlesNestedNodesOfSameName() {
         val payload = """
             <Response>
                <Response>abc</Response>
@@ -287,7 +286,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itPeeksWithoutImpactingNestingLevel() = runSuspendTest {
+    fun itPeeksWithoutImpactingNestingLevel() {
         val payload = """
            <l1>
                <l2>
@@ -320,7 +319,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesNamespaceDefaults() = runSuspendTest {
+    fun itHandlesNamespaceDefaults() {
         val payload = """
             <MyStructure xmlns="http://foo.com">
                 <foo>bar</foo>
@@ -341,7 +340,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesNamespacePrefixes() = runSuspendTest {
+    fun itHandlesNamespacePrefixes() {
         val payload = """
             <MyStructure xmlns:baz="http://foo.com">
                 <foo>what</foo>
@@ -365,7 +364,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesNamespacedAttributes() = runSuspendTest {
+    fun itHandlesNamespacedAttributes() {
         val payload = """
             <MyStructure xmlns:baz="http://foo.com">
                 <foo baz:k1="v1"></foo>
@@ -384,7 +383,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itSubTrees() = runSuspendTest {
+    fun itSubTrees() {
         val payload = """
             <root>
                 <a>
@@ -450,7 +449,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesPeekingMultipleLevels() = runSuspendTest {
+    fun itHandlesPeekingMultipleLevels() {
         val payload = """
             <r>
                 <a>
@@ -492,7 +491,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itHandlesSeekingToNodes() = runSuspendTest {
+    fun itHandlesSeekingToNodes() {
         val payload = """
             <r>
                 <a a1="asdf">
@@ -528,7 +527,7 @@ class XmlStreamReaderTest {
     }
 
     @Test
-    fun itThrowsErrorsOnInvalidXmlSequences() = runSuspendTest {
+    fun itThrowsErrorsOnInvalidXmlSequences() {
         val invalidTextList = listOf(
             """&lte;""",
             "&lte;",
@@ -551,7 +550,7 @@ class XmlStreamReaderTest {
     }
 }
 
-suspend fun XmlStreamReader.allTokens(): List<XmlToken> {
+fun XmlStreamReader.allTokens(): List<XmlToken> {
     val tokenList = mutableListOf<XmlToken>()
     var nextToken: XmlToken?
     do {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/dom/XmlDomTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/dom/XmlDomTest.kt
@@ -6,14 +6,13 @@
 package aws.smithy.kotlin.runtime.serde.xml.dom
 
 import aws.smithy.kotlin.runtime.serde.xml.XmlToken
-import aws.smithy.kotlin.runtime.testing.runSuspendTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class XmlDomTest {
     @Test
-    fun smokeTest() = runSuspendTest {
+    fun smokeTest() {
         val payload = """
             <Foo>
                 <Bar>b1</Bar>
@@ -36,7 +35,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun testBasicRoundTripToXmlString() = runSuspendTest {
+    fun testBasicRoundTripToXmlString() {
         val payload = "<Foo><Bar>b1</Bar><Bar>b2</Bar></Foo>"
         val dom = XmlNode.parse(payload.encodeToByteArray())
         val actual = dom.toXmlString(false)
@@ -44,7 +43,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun testBasicToXmlStringPretty() = runSuspendTest {
+    fun testBasicToXmlStringPretty() {
         val expected = """
             <Foo>
                 <Bar>b1</Bar>
@@ -58,7 +57,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun testToXmlStringPretty() = runSuspendTest {
+    fun testToXmlStringPretty() {
         val expected = """
             <Foo>
                 <Bar>b1</Bar>
@@ -79,7 +78,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun xmlNamespaceTest() = runSuspendTest {
+    fun xmlNamespaceTest() {
         val payload = """
             <Foo xmlns="http://foo.com">
                 <Bar>b1</Bar>
@@ -96,7 +95,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun xmlNamespacePrefixTest() = runSuspendTest {
+    fun xmlNamespacePrefixTest() {
         val payload = """
             <Foo xmlns:baz="http://foo.com">
                 <baz:Bar>b1</baz:Bar>
@@ -113,7 +112,7 @@ class XmlDomTest {
     }
 
     @Test
-    fun xmlNamespaceAttributeTest() = runSuspendTest {
+    fun xmlNamespaceAttributeTest() {
         val payload = """
             <Foo xmlns:baz="http://foo.com">
                 <Bar baz:k1="v1"></Bar>

--- a/runtime/serde/serde-xml/jvm/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderXmlPull.kt
+++ b/runtime/serde/serde-xml/jvm/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderXmlPull.kt
@@ -48,7 +48,7 @@ internal class XmlStreamReaderXmlPull(
     override val lastToken: XmlToken?
         get() = _lastToken
 
-    override suspend fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader {
+    override fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader {
         val currentReader = this
         val previousToken = lastToken
         val nextToken = internalPeek(1)
@@ -68,7 +68,7 @@ internal class XmlStreamReaderXmlPull(
         return SubTreeReader(this, subtreeStartDepth, subTreeDepth)
     }
 
-    override suspend fun nextToken(): XmlToken? {
+    override fun nextToken(): XmlToken? {
         if (!hasNext()) return null
 
         return when (peekStack.isEmpty()) {
@@ -84,13 +84,13 @@ internal class XmlStreamReaderXmlPull(
     // 1: if the next token is BeginElement, then that node is skipped
     // 2: if the next token is Text or EndElement, read tokens until the end of the current node is exited
     // 3: if the next token is EndDocument, NOP
-    override suspend fun skipNext() {
+    override fun skipNext() {
         if (internalPeek(1).isTerminal()) return
 
         traverseNode(nextToken() ?: error("nextToken() unexpectedly returned null"), parser.depth)
     }
 
-    override suspend fun peek(index: Int): XmlToken? {
+    override fun peek(index: Int): XmlToken? {
         val peekState = internalPeek(index)
 
         return if (peekState.isTerminal(minimumDepth)) null else peekState
@@ -111,7 +111,7 @@ internal class XmlStreamReaderXmlPull(
         return lastToken.isNotTerminal() && nextToken.isNotTerminal(minimumDepth)
     }
 
-    private tailrec suspend fun traverseNode(st: XmlToken, startDepth: Int) {
+    private tailrec fun traverseNode(st: XmlToken, startDepth: Int) {
         if (st == XmlToken.EndDocument) return
         if (st is XmlToken.EndElement && parser.depth == startDepth) return
         val next = nextToken() ?: return
@@ -196,10 +196,10 @@ private class SubTreeReader(
     override val lastToken: XmlToken?
         get() = currentReader.lastToken
 
-    override suspend fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader =
+    override fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader =
         currentReader.subTreeReader(subtreeStartDepth)
 
-    override suspend fun nextToken(): XmlToken? {
+    override fun nextToken(): XmlToken? {
         var peekToken = currentReader.peek(1) ?: return null
 
         if (subtreeStartDepth == XmlStreamReader.SubtreeStartDepth.CHILD && peekToken.depth < minimumDepth) {
@@ -213,11 +213,11 @@ private class SubTreeReader(
         return if (peekToken.depth >= minimumDepth) currentReader.nextToken() else null
     }
 
-    override suspend fun skipNext() {
+    override fun skipNext() {
         currentReader.skipNext()
     }
 
-    override suspend fun peek(index: Int): XmlToken? {
+    override fun peek(index: Int): XmlToken? {
         val peekToken = currentReader.peek(index) ?: return null
 
         return if (peekToken.depth >= minimumDepth) peekToken else null
@@ -231,13 +231,13 @@ private class TerminalReader(private val parent: XmlStreamReader) : XmlStreamRea
     override val lastToken: XmlToken?
         get() = parent.lastToken
 
-    override suspend fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader = this
+    override fun subTreeReader(subtreeStartDepth: XmlStreamReader.SubtreeStartDepth): XmlStreamReader = this
 
-    override suspend fun nextToken(): XmlToken? = null
+    override fun nextToken(): XmlToken? = null
 
-    override suspend fun skipNext() = Unit
+    override fun skipNext() = Unit
 
-    override suspend fun peek(index: Int): XmlToken? = null
+    override fun peek(index: Int): XmlToken? = null
 }
 
 private fun XmlPullParser.qualifiedName(): XmlToken.QualifiedName =

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -112,7 +112,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
      * This function is invoked inside the body of the serialize function which has the following signature:
      *
      * ```
-     * suspend fun serializeFooDocumentBody(serializer: Serializer, input: Foo) {
+     * fun serializeFooDocumentBody(serializer: Serializer, input: Foo) {
      *     <-- CURRENT WRITER CONTEXT -->
      * }
      * ```
@@ -131,7 +131,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
      * This function is invoked inside the body of the deserialize function which has the following signature:
      *
      * ```
-     * suspend fun deserializeFooDocumentBody(deserializer: Deserializer): Foo {
+     * fun deserializeFooDocumentBody(deserializer: Deserializer): Foo {
      *     <-- CURRENT WRITER CONTEXT -->
      * }
      * ```
@@ -661,7 +661,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                     // render a function responsible for deserializing the members bound to the payload
                     // this function is delegated to by the `HttpDeserialize` implementation generated
                     writer.write("")
-                        .openBlock("private suspend fun #L(builder: #T.DslBuilder, payload: ByteArray) {", "}", op.bodyDeserializerName(), outputSymbol) {
+                        .openBlock("private fun #L(builder: #T.DslBuilder, payload: ByteArray) {", "}", op.bodyDeserializerName(), outputSymbol) {
                             renderDeserializeOperationBody(ctx, op, writer)
                         }
                 }
@@ -730,7 +730,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                     // shape can be re-used as a document member.
                     writer.write("")
                         .openBlock(
-                            "private suspend fun #L(builder: #L, payload: ByteArray) {", "}",
+                            "private fun #L(builder: #L, payload: ByteArray) {", "}",
                             outputSymbol.errorDeserializerName(),
                             "${outputSymbol.name}.DslBuilder",
                         ) {
@@ -797,8 +797,6 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                         .map { it.member }
 
                     if (documentMembers.isNotEmpty()) {
-                        // TODO - we should not be slurping the entire contents into memory, instead our deserializers
-                        // should work off of an SdkByteReadChannel
                         writer
                             .addImport(RuntimeTypes.Http.readAll)
                             .write("val payload = response.body.#T()", RuntimeTypes.Http.readAll)
@@ -1114,7 +1112,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         writer
             .addImport(documentDeserializerSymbols)
             .write("")
-            .openBlock("internal suspend fun #T(deserializer: #T): #T {", deserializerSymbol, RuntimeTypes.Serde.Deserializer, symbol)
+            .openBlock("internal fun #T(deserializer: #T): #T {", deserializerSymbol, RuntimeTypes.Serde.Deserializer, symbol)
             .call {
                 if (shape.isUnionShape) {
                     writer.write("var value: #T? = null", symbol)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
@@ -64,7 +64,7 @@ abstract class HttpFeatureMiddleware : ProtocolMiddleware {
 
     override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
         if (needsConfiguration) {
-            writer.openBlock("install(#L) {", name)
+            writer.openBlock("op.install(#L) {", name)
                 .call { renderConfigure(writer) }
                 .closeBlock("}")
         } else {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -82,7 +82,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFoo"
             }
         }
-        registerGetFooMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.roundTrip(client, input)
     }
 """,
@@ -97,7 +99,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooNoInput"
             }
         }
-        registerGetFooNoInputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.roundTrip(client, input)
     }
 """,
@@ -112,7 +116,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooNoOutput"
             }
         }
-        registerGetFooNoOutputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.roundTrip(client, input)
     }
 """,
@@ -127,7 +133,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooStreamingInput"
             }
         }
-        registerGetFooStreamingInputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.roundTrip(client, input)
     }
 """,
@@ -142,7 +150,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooStreamingOutput"
             }
         }
-        registerGetFooStreamingOutputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.execute(client, input, block)
     }
 """,
@@ -157,7 +167,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooStreamingOutputNoInput"
             }
         }
-        registerGetFooStreamingOutputNoInputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.execute(client, input, block)
     }
 """,
@@ -172,7 +184,9 @@ class HttpProtocolClientGeneratorTest {
                 operationName = "GetFooStreamingInputNoOutput"
             }
         }
-        registerGetFooStreamingInputNoOutputMiddleware(config, op)
+        op.install(MockProtocolMiddleware1) {
+            configurationField1 = "testing"
+        }
         return op.roundTrip(client, input)
     }
 """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/411

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* remove `suspend` from deserialization (we aren't using it anyway and the benchmarks show that it is too slow so we aren't likely to ever use it)
    * NOTE: The errors deserialization is still implemented with suspend because exception deserializers implement `HttpDeserialize`
* added `inline` to several places where it was missing
    * inspection of generated code revealed that we were often capturing variables in a lambda and thus a backing class was being generated by the compiler
* inlined the middleware registration which removes a lot of unnecessary extra classes being generated
    * this still suffers from the lambda closures being generated all over the place, e.g. `op.install(Feature) { <lambda capture> }`
    * there will be some follow up work to refactor our middleware types to probably just implement `Middleware` directly rather than feature. I don't see how to inline these as designed
    * this also has the advantage of middleware registration/generation having complete access to the internals of a service client including config, private variables, not to mention access to the input type directly (@ianbotsf this would probably allow the predict endpoint middleware to be implemented differently...)
 

These changes show a 1MB reduction in jar size for dynamodb
```
> ls -lsah
total 18128

10056 -rw-r--r--  1    4.9M Nov 12 10:16 dynamodb-0.9.2-alpha-original.jar
 8072 -rw-r--r--   1    3.9M Nov 12 11:01 dynamodb-0.9.2-alpha.jar
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
