### PR TITLE
fix(codegen); fix rendering of middleware without configure

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
@@ -68,7 +68,7 @@ abstract class HttpFeatureMiddleware : ProtocolMiddleware {
                 .call { renderConfigure(writer) }
                 .closeBlock("}")
         } else {
-            writer.write("install(#L)", name)
+            writer.write("op.install(#L)", name)
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
Sibling to https://github.com/awslabs/aws-sdk-kotlin/pull/424

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Fix rendering of feature middleware that doesn't require configuration. This was broken in #533 where the context of the renderer changed, we didn't notice because we apparently didn't have any middleware until now that triggered this path. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
