### PR TITLE
fix: remove leaky trace logging from XML serde

### DIFF
--- a/runtime/serde/serde-xml/build.gradle.kts
+++ b/runtime/serde/serde-xml/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":runtime:serde"))
-                implementation(project(":runtime:logging"))
             }
         }
         jvmMain {
@@ -24,12 +23,6 @@ kotlin {
                 implementation("xmlpull:xmlpull:$xmlpullVersion")
                 // https://mvnrepository.com/artifact/org.ogce/xpp3
                 implementation("org.ogce:xpp3:$xpp3Version")
-            }
-        }
-        jvmTest {
-            dependencies {
-                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
-                implementation("org.slf4j:slf4j-api:$slf4jVersion")
             }
         }
 

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.serde.xml
 
-import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.serde.*
 
 // Represents aspects of SdkFieldDescriptor that are particular to the Xml format
@@ -33,12 +32,9 @@ class XmlDeserializer(
 
     constructor(input: ByteArray, validateRootElement: Boolean = false) : this(xmlStreamReader(input), validateRootElement)
 
-    private val logger = Logger.getLogger<XmlDeserializer>()
     private var firstStructCall = true
 
     override fun deserializeStruct(descriptor: SdkObjectDescriptor): Deserializer.FieldIterator {
-        logger.trace { "Deserializing struct $descriptor under ${reader.lastToken}" }
-
         if (firstStructCall) {
             if (!descriptor.hasTrait<XmlSerialName>()) throw DeserializationException("Top-level struct $descriptor requires a XmlSerialName trait but has none.")
 
@@ -72,8 +68,6 @@ class XmlDeserializer(
     }
 
     override fun deserializeList(descriptor: SdkFieldDescriptor): Deserializer.ElementIterator {
-        logger.trace { "Deserializing list $descriptor under ${reader.lastToken}" }
-
         val depth = when (descriptor.hasTrait<Flattened>()) {
             true -> XmlStreamReader.SubtreeStartDepth.CURRENT
             else -> XmlStreamReader.SubtreeStartDepth.CHILD
@@ -82,11 +76,8 @@ class XmlDeserializer(
         return XmlListDeserializer(reader.subTreeReader(depth), descriptor)
     }
 
-    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
-        logger.trace { "Deserializing map $descriptor under ${reader.lastToken}" }
-
-        return XmlMapDeserializer(reader.subTreeReader(XmlStreamReader.SubtreeStartDepth.CURRENT), descriptor)
-    }
+    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator =
+        XmlMapDeserializer(reader.subTreeReader(XmlStreamReader.SubtreeStartDepth.CURRENT), descriptor)
 }
 
 /**

--- a/runtime/serde/serde-xml/jvm/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderXmlPull.kt
+++ b/runtime/serde/serde-xml/jvm/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderXmlPull.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.serde.xml
 
-import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.serde.DeserializationException
 import aws.smithy.kotlin.runtime.util.push
 import org.xmlpull.mxp1.MXParser
@@ -33,7 +32,6 @@ internal class XmlStreamReaderXmlPull(
         }
     }
 
-    private val logger = Logger.getLogger<XmlStreamReaderXmlPull>()
     private val peekStack = mutableListOf(parser.takeNextValidToken())
     private var _lastToken = parser.lastToken()
 
@@ -63,8 +61,6 @@ internal class XmlStreamReaderXmlPull(
             XmlStreamReader.SubtreeStartDepth.CURRENT -> _lastToken?.depth
         } ?: throw DeserializationException("Unable to determine last node depth in $this")
 
-        logger.trace { "Creating subtree at $subTreeDepth next token: ${internalPeek(1)}" }
-
         return SubTreeReader(this, subtreeStartDepth, subTreeDepth)
     }
 
@@ -76,7 +72,6 @@ internal class XmlStreamReaderXmlPull(
             false -> peekStack.removeAt(0)
         }.also { token ->
             this._lastToken = token
-            logger.trace { "${token.depth.indent()}$token" }
         }
     }
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

While auditing our logging posture, I noticed that our XML deserializer logged response data (including potentially-sensitive data) at `TRACE` level. That's unnecessary given that it can be enabled by `SdkLogMode.LogResponseWithBody`. Thus, removing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
