### PR TITLE
Fully qualify nested struct dsl builder type

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -243,8 +243,8 @@ class StructureGenerator(
                     val (memberName, memberSymbol) = memberNameSymbolIndex[member]!!
                     writer.dokka("construct an [${memberSymbol.fullName}] inside the given [block]")
                     writer.renderAnnotations(member)
-                    openBlock("fun #L(block: #L.Builder.() -> #Q) {", memberName, memberSymbol.name, KotlinTypes.Unit)
-                        .write("this.#L = #L.invoke(block)", memberName, memberSymbol.name)
+                    openBlock("fun #L(block: #Q.Builder.() -> #Q) {", memberName, memberSymbol, KotlinTypes.Unit)
+                        .write("this.#L = #Q.invoke(block)", memberName, memberSymbol)
                         .closeBlock("}")
                 }
             }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -190,8 +190,8 @@ class StructureGeneratorTest {
                 /**
                  * construct an [com.test.model.Qux] inside the given [block]
                  */
-                fun quux(block: Qux.Builder.() -> kotlin.Unit) {
-                    this.quux = Qux.invoke(block)
+                fun quux(block: com.test.model.Qux.Builder.() -> kotlin.Unit) {
+                    this.quux = com.test.model.Qux.invoke(block)
                 }
             }
         """.formatForTest()


### PR DESCRIPTION
Fix collision in elastibeanstalk with nested struct dsl builder functions

<!--- Provide a general summary of your changes in the Title above -->


## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/532

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Issue found when doing service build testing against https://github.com/awslabs/smithy-kotlin/pull/534

## Testing Done
* Build and test all services locally after change, verify no name collisions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
