### PR TITLE
feat(rt): allow query params to be set from resolved endpoints

### DIFF
--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -39,6 +39,10 @@ fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
     if (endpoint.uri.path.isNotBlank()) {
         val pathPrefix = endpoint.uri.path.removeSuffix("/")
         val original = req.subject.url.path.removePrefix("/")
-        req.subject.url.path = "$pathPrefix/$original"
+        req.subject.url.path = if (original.isNotBlank()) "$pathPrefix/$original" else pathPrefix
+    }
+
+    if (!endpoint.uri.parameters.isEmpty()) {
+        req.subject.url.parameters.appendAll(endpoint.uri.parameters)
     }
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -47,7 +47,5 @@ fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
         }
     }
 
-    if (!endpoint.uri.parameters.isEmpty()) {
-        req.subject.url.parameters.appendAll(endpoint.uri.parameters)
-    }
+    req.subject.url.parameters.appendAll(endpoint.uri.parameters)
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -37,9 +37,14 @@ fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
     req.subject.url.port = endpoint.uri.port
     req.subject.headers["Host"] = hostname
     if (endpoint.uri.path.isNotBlank()) {
-        val pathPrefix = endpoint.uri.path.removeSuffix("/")
-        val original = req.subject.url.path.removePrefix("/")
-        req.subject.url.path = if (original.isNotBlank()) "$pathPrefix/$original" else pathPrefix
+        val opPath = req.subject.url.path
+        val endpointPath = endpoint.uri.path.removeSuffix("/")
+        req.subject.url.path = if (opPath.isNotBlank()) {
+            "$endpointPath/${opPath.removePrefix("/")}"
+        } else {
+            // keep endpoint path as is
+            endpoint.uri.path
+        }
     }
 
     if (!endpoint.uri.parameters.isEmpty()) {

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/Endpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/Endpoint.kt
@@ -13,7 +13,7 @@ import aws.smithy.kotlin.runtime.http.Url
  * The SDK will automatically resolve these endpoints per API client using an internal resolver.
  *
  * @property uri The base URL endpoint clients will use to make API calls to e.g. "api.myservice.com".
- * NOTE: Only `scheme`, `port`, `host` and `path` are valid. Other URL elements like query parameters are ignored.
+ * NOTE: Only `scheme`, `port`, `host` `path`, and `parameters` are valid. Other URL elements are ignored.
 
  * @property isHostnameImmutable Flag indicating that the hostname can be modified by the SDK client.
  *
@@ -32,7 +32,4 @@ data class Endpoint(
     val isHostnameImmutable: Boolean = false,
 ) {
     constructor(uri: String) : this(Url.parse(uri))
-    init {
-        require(uri.parameters.isEmpty()) { "Query parameters are not currently supported by endpoint resolution" }
-    }
 }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/UrlTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/UrlTest.kt
@@ -169,6 +169,12 @@ class UrlTest {
     }
 
     @Test
+    fun itParsesIpv6Hosts() {
+        val actual = Url.parse("http://[2001:db8::1]:80")
+        assertEquals("[2001:db8::1]", actual.host)
+    }
+
+    @Test
     fun testEncodePath() {
         val url = UrlBuilder()
         url.parameters {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
support for aws-sdk-kotlin#475

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Allow resolved endpoints to add query parameters. This allows the ECS credentials provider `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or `AWS_CONTAINER_CREDENTIALS_FULL_URI` to specify query parameters.
* Also fixes the formatting of combining endpoint paths and operation paths when the operation path is empty or `/`. Previously this would result in `/endpoint-path/` and now it will be just `/endpoint-path` without the trailing slash. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
