### PR TITLE
Refactor writer and symbols to handle pagination 

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -31,7 +31,7 @@ private const val SDK_ID = "sdkId"
 /**
  * Settings used by [KotlinCodegenPlugin]
  */
-class KotlinSettings(
+data class KotlinSettings(
     val service: ShapeId,
     val pkg: PackageSettings,
     val sdkId: String,

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -148,7 +148,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         val valueType = if (shape.hasTrait<SparseTrait>()) "${reference.name}?" else reference.name
 
         return createSymbolBuilder(shape, "List<$valueType>", boxed = true)
-            .addReference(reference)
+            .addReferences(reference)
             .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableListOf<$valueType>")
             .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "listOf<$valueType>")
             .build()
@@ -159,9 +159,10 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         val valueType = if (shape.hasTrait<SparseTrait>()) "${reference.name}?" else reference.name
 
         return createSymbolBuilder(shape, "Map<String, $valueType>", boxed = true)
-            .addReference(reference)
+            .addReferences(reference)
             .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableMapOf<String, $valueType>")
             .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "mapOf<String, $valueType>")
+            .putProperty(SymbolProperty.ENTRY_EXPRESSION, "Map.Entry<String, $valueType>")
             .build()
     }
 
@@ -258,4 +259,11 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         namespace: String,
         boxed: Boolean = false
     ): Symbol.Builder = createSymbolBuilder(shape, typeName, boxed).namespace(namespace, ".")
+}
+
+// Add a reference and it's children
+private fun Symbol.Builder.addReferences(ref: Symbol): Symbol.Builder {
+    addReference(ref)
+    ref.references.forEach { addReference(it) }
+    return this
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -96,7 +96,7 @@ fun isValidKotlinIdentifier(s: String): Boolean {
  * Flag indicating if this symbol is a Kotlin built-in symbol
  */
 val Symbol.isBuiltIn: Boolean
-    get() = namespace.startsWith("kotlin.")
+    get() = namespace == "kotlin" || namespace.startsWith("kotlin.")
 
 /**
  * Escape characters in strings to ensure they are treated as pure literals.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -96,7 +96,7 @@ fun isValidKotlinIdentifier(s: String): Boolean {
  * Flag indicating if this symbol is a Kotlin built-in symbol
  */
 val Symbol.isBuiltIn: Boolean
-    get() = namespace.startsWith("kotlin")
+    get() = namespace.startsWith("kotlin.")
 
 /**
  * Escape characters in strings to ensure they are treated as pure literals.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilder.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilder.kt
@@ -98,3 +98,19 @@ fun SymbolBuilder.namespace(dependency: KotlinDependency, subpackage: String = "
 
     dependency(dependency)
 }
+
+/**
+ * Convert a String in "<package>.<name>" format to a symbol where the last segment of a '.' delimited list becomes
+ * the name and the rest becomes the namespace.
+ *
+ * ex: com.foo.bar.Thing -> (name=Thing, namespace=com.foo.bar)
+ */
+fun String.toSymbol(): Symbol =
+    buildSymbol {
+        require(this@toSymbol.isNotBlank()) { "Invalid string to convert to symbol" }
+        val segments = split(".")
+        name = segments.last()
+        namespace = segments
+            .dropLast(1)
+            .joinToString(separator = ".") { it }
+    }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
@@ -29,6 +29,9 @@ object SymbolProperty {
 
     // Immutable collection type
     const val IMMUTABLE_COLLECTION_FUNCTION: String = "immutableCollectionType"
+
+    // Entry type for Maps
+    const val ENTRY_EXPRESSION: String = "entryExpression"
 }
 
 /**

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
@@ -4,7 +4,9 @@
  */
 package software.amazon.smithy.kotlin.codegen.lang
 
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -22,5 +24,23 @@ class KotlinTypesTest {
         listOf("", "aws-packg", "some random thing", "gar@bage?", "  white space").forEach {
             assertFalse(it.isValidPackageName())
         }
+    }
+
+    @Test
+    fun `it identifies single segment stdlib types`() {
+        val testSymbol = buildSymbol {
+            name = "String"
+            namespace = "kotlin"
+        }
+        assertEquals( true, testSymbol.isBuiltIn)
+    }
+
+    @Test
+    fun `it identifies multi-segment stdlib types`() {
+        val testSymbol = buildSymbol {
+            name = "Duration"
+            namespace = "kotlin.time"
+        }
+        assertEquals( true, testSymbol.isBuiltIn)
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypesTest.kt
@@ -32,7 +32,7 @@ class KotlinTypesTest {
             name = "String"
             namespace = "kotlin"
         }
-        assertEquals( true, testSymbol.isBuiltIn)
+        assertEquals(true, testSymbol.isBuiltIn)
     }
 
     @Test
@@ -41,6 +41,6 @@ class KotlinTypesTest {
             name = "Duration"
             namespace = "kotlin.time"
         }
-        assertEquals( true, testSymbol.isBuiltIn)
+        assertEquals(true, testSymbol.isBuiltIn)
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
@@ -42,7 +42,7 @@ class SymbolBuilderTest {
     @Test
     fun `it builds symbol from String`() {
         val expected = buildSymbol {
-            name="Foo"
+            name = "Foo"
             namespace = "x.y.z"
         }
 
@@ -52,7 +52,7 @@ class SymbolBuilderTest {
     @Test
     fun `it builds symbol without namespace String`() {
         val expected = buildSymbol {
-            name="Foo"
+            name = "Foo"
         }
 
         assertEquals(expected.namespace, "Foo".toSymbol().namespace)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilderTest.kt
@@ -38,4 +38,24 @@ class SymbolBuilderTest {
         assertEquals(1, x.references.size)
         assertEquals(1, x.dependencies.size)
     }
+
+    @Test
+    fun `it builds symbol from String`() {
+        val expected = buildSymbol {
+            name="Foo"
+            namespace = "x.y.z"
+        }
+
+        assertEquals(expected, "x.y.z.Foo".toSymbol())
+    }
+
+    @Test
+    fun `it builds symbol without namespace String`() {
+        val expected = buildSymbol {
+            name="Foo"
+        }
+
+        assertEquals(expected.namespace, "Foo".toSymbol().namespace)
+        assertEquals(expected.name, "Foo".toSymbol().name)
+    }
 }


### PR DESCRIPTION
…and nicer codegen blocks

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/124

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Changes to symbol resolution to pull out nested generics to handle Pagination codegen use cases.  As-is codegen of paginators with nested items fails because expressions such as `Map<String, List<SomeType>>` will not pull out the reference to `SomeType` and so we miss the import in codegen.
* Tweaks to `KotlinWriter` functions to return the instance for better readability
* Make `KotlinSettings` a data class so easier inspection at debug time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
