### PR TITLE
fix(rt): only retry client errors if metadata allows

### DIFF
--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicy.kt
@@ -49,9 +49,11 @@ open class StandardRetryPolicy : RetryPolicy<Any?> {
         }
     }
 
-    @Suppress("UNUSED_PARAMETER") // `ex` is mandated by `EvaluationStrategy` but not required by method body
-    private fun evaluateClientException(ex: ClientException): RetryDirective? =
+    private fun evaluateClientException(ex: ClientException): RetryDirective? = if (ex.sdkErrorMetadata.isRetryable) {
         RetryDirective.RetryError(RetryErrorType.ClientSide)
+    } else {
+        null
+    }
 
     private fun evaluateServiceException(ex: ServiceException): RetryDirective? = with(ex.sdkErrorMetadata) {
         when {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicyTest.kt
@@ -38,7 +38,7 @@ class StandardRetryPolicyTest {
     }
 
     @Test
-    fun testClientSideException() {
+    fun testRetryableClientException() {
         val ex = ServiceException()
         ex.sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = true
         ex.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ServiceException.ErrorType.Client
@@ -47,9 +47,9 @@ class StandardRetryPolicyTest {
     }
 
     @Test
-    fun testClientException() {
+    fun testNonRetryableClientException() {
         val result = test(ClientException())
-        assertEquals(RetryDirective.RetryError(RetryErrorType.ClientSide), result)
+        assertEquals(RetryDirective.TerminateAndFail, result)
     }
 
     @Test

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryPolicyTest.kt
@@ -38,10 +38,18 @@ class StandardRetryPolicyTest {
     }
 
     @Test
-    fun testRetryableClientException() {
+    fun testClientSideException() {
         val ex = ServiceException()
         ex.sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = true
         ex.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = ServiceException.ErrorType.Client
+        val result = test(ex)
+        assertEquals(RetryDirective.RetryError(RetryErrorType.ClientSide), result)
+    }
+
+    @Test
+    fun testRetryableClientException() {
+        val ex = ClientException()
+        ex.sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = true
         val result = test(ex)
         assertEquals(RetryDirective.RetryError(RetryErrorType.ClientSide), result)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes #555 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Do not retry `ClientException` unless metadata explicitly allows it. In general client exceptions are a class of exception that aren't retryable (serialization/deserialization errors, state errors, configuration errors, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
