### PR TITLE
Fix paginator generation for models that specify non-string cursor

### DIFF
--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -152,7 +152,7 @@ class PaginatorGeneratorTest {
              */
             fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
                 flow {
-                    var cursor: String? = null
+                    var cursor: kotlin.String? = null
                     var isFirstPage: Boolean = true
             
                     while (isFirstPage || (cursor?.isNotEmpty() == true)) {
@@ -192,7 +192,7 @@ class PaginatorGeneratorTest {
              */
             fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
                 flow {
-                    var cursor: String? = null
+                    var cursor: kotlin.String? = null
                     var isFirstPage: Boolean = true
             
                     while (isFirstPage || (cursor?.isNotEmpty() == true)) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/565

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Revert change in feature PR to hardcode member as string, use modeled type.

## Testing Done
* Ran ad-hoc test with dynamodb table with a large amount of data.  Verified affected operations compile and return same number of results paginated as rows contained in table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
