### PR TITLE
chore: change buildscript cp for ci

### DIFF
--- a/tests/benchmarks/serde-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/serde-benchmarks/build.gradle.kts
@@ -91,7 +91,6 @@ dependencies {
 val generateSdk = tasks.create<SmithyBuild>("generateSdk") {
     group = "codegen"
     classpath = configurations.getByName("codegen")
-    println(configurations.getByName("codegen"))
     inputs.file(projectDir.resolve("smithy-build.json"))
     inputs.files(configurations.getByName("codegen"))
 }

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -33,19 +33,20 @@ kotlin.sourceSets.getByName("main") {
 
 tasks["smithyBuildJar"].enabled = false
 
-val generateSdk = tasks.create<SmithyBuild>("generateSdk") {
-    group = "codegen"
-    addRuntimeClasspath = true
-    inputs.file(projectDir.resolve("smithy-build.json"))
+val codegen by configurations.creating
+dependencies {
+    codegen(project(":smithy-kotlin-codegen"))
 }
 
-val stageGeneratedSources = tasks.register("stageGeneratedSources") {
+val generateSdk = tasks.register<SmithyBuild>("generateSdk") {
     group = "codegen"
-    dependsOn(generateSdk)
+    classpath = configurations.getByName("codegen")
+    inputs.file(projectDir.resolve("smithy-build.json"))
+    inputs.files(configurations.getByName("codegen"))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>{
-    dependsOn(stageGeneratedSources)
+    dependsOn(generateSdk)
 }
 
 tasks.test {
@@ -62,7 +63,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
-    implementation(project(":smithy-kotlin-codegen"))
+    compileOnly(project(":smithy-kotlin-codegen"))
     implementation(project(":runtime:runtime-core"))
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Update the paginator-tests build script to ensure `smithy-kotlin-codegen` is built before smithy projection needs it AND that it ends up on the classpath. I think before it was only ending up on the classpath but for whatever reason not being built when needed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
