### PR TITLE
feat: implement Jmespath expression parsing for all modeled AWS services

### DIFF
--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.util
+
+/**
+ * Determines the length of a collection. This is a synonym for [Collection.size].
+ */
+val <T> Collection<T>.length: Int
+    get() = size

--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -53,6 +53,7 @@ val generateSdkRuntimeVersion by tasks.registering {
 // unlike the runtime, smithy-kotlin codegen package is not expected to run on Android...we can target 1.8
 tasks.compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     dependsOn(generateSdkRuntimeVersion)
 }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -119,6 +119,10 @@ object RuntimeTypes {
         val AttributeKey = runtimeSymbol("AttributeKey", KotlinDependency.UTILS)
         val Sha256 = runtimeSymbol("Sha256", KotlinDependency.UTILS)
         val urlEncodeComponent = runtimeSymbol("urlEncodeComponent", KotlinDependency.UTILS, "text")
+
+        object Convenience {
+            val length = runtimeSymbol("length", KotlinDependency.UTILS)
+        }
     }
 
     object Serde {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -111,7 +111,7 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
         writer.openBlock("val #L = (#L ?: listOf()).filter {", filteredName, leftName)
 
         val comparisonName = childBlock(expression.comparison!!)
-        writer.write(comparisonName)
+        writer.write("#L == true", comparisonName)
 
         writer.closeBlock("}")
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
@@ -52,7 +52,7 @@ class AcceptorGeneratorTest {
         val expected = """
             val $acceptorListName = listOf<Acceptor<DescribeFooRequest, DescribeFooResponse>>(
                 OutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val name = it.name
+                    val name = it?.name
                     name?.toString() == "foo"
                 },
             )
@@ -65,22 +65,22 @@ class AcceptorGeneratorTest {
         val expected = """
             val $acceptorListName = listOf<Acceptor<DescribeFooRequest, DescribeFooResponse>>(
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val input = it.input
+                    val input = it?.input
                     val id = input?.id
                     id?.toString() == "foo"
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
+                    val output = it?.output
                     val isDeprecated = output?.isDeprecated
                     isDeprecated == false
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
+                    val output = it?.output
                     val tags = output?.tags
                     (tags?.size ?: 0) > 1 && tags?.all { it?.toString() == "foo" }
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
+                    val output = it?.output
                     val tags = output?.tags
                     tags?.any { it?.toString() == "foo" } ?: false
                 },


### PR DESCRIPTION
## Issue \#

Addresses #572 

## Description of changes

This change implements handling for the remaining types of Jmespath expressions that are currently used in AWS service models. It explicitly does not implement expression types which are today unused (e.g., boolean and expressions, index/slice expressions, multiselect hash expressions, certain types of literals, etc.).

This change overhauls the existing skeleton of `KotlinJmespathExpressionVisitor` and removes all usage of the model. This greatly simplifies the implementation but, since code generator is now unaware of the exact types of shapes it's operating on, there are two main downsides:
* Use of null checks and null-safe operators (e.g., `?.`, `?:`) in places that are technically unnecessary. The compiler issues warnings when building the generated code but it runs as expected.
* The Jmespath `length` function works over strings and collections but in Kotlin, strings have `length` but collections have `size`. To allow the codegen to work independent of type, I added a convenience property for `Collection<T>.length` which delegates to `size`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.