### PR TITLE
fix: make waiter comparison codegen type-safe

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -87,11 +87,7 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
         val leftName = if (rightIsString && !leftIsString) "$leftBaseName?.toString()" else leftBaseName
         val rightName = if (leftIsString && !rightIsString) "$rightBaseName?.toString()" else rightBaseName
 
-        val codegen = when (val comparator = expression.comparator) {
-            ComparatorType.EQUAL, ComparatorType.NOT_EQUAL -> "$leftName $comparator $rightName"
-            else -> "if ($leftName == null || $rightName == null) null else $leftName $comparator $rightName"
-        }
-        return addTempVar("comparison", codegen)
+        return addTempVar("comparison", "$leftName?.compareTo($rightName)?.let { it ${expression.comparator} 0 }")
     }
 
     override fun visitCurrentNode(expression: CurrentExpression): String {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
@@ -29,7 +29,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val bar = it?.bar
-                val comparison = foo == bar
+                val comparison = foo?.compareTo(bar)?.let { it == 0 }
             """.trimIndent(),
         )
     }
@@ -42,7 +42,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val string = "foo"
                 val bar = it?.bar
-                val comparison = string == bar?.toString()
+                val comparison = string?.compareTo(bar?.toString())?.let { it == 0 }
             """.trimIndent(),
         )
 
@@ -52,7 +52,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val string = "bar"
-                val comparison = foo?.toString() == string
+                val comparison = foo?.toString()?.compareTo(string)?.let { it == 0 }
             """.trimIndent(),
         )
     }
@@ -65,7 +65,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val string = "foo"
                 val string2 = "bar"
-                val comparison = string != string2
+                val comparison = string?.compareTo(string2)?.let { it != 0 }
             """.trimIndent(),
 
         )
@@ -79,7 +79,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val bar = it?.bar
-                val comparison = if (foo == null || bar == null) null else foo <= bar
+                val comparison = foo?.compareTo(bar)?.let { it <= 0 }
             """.trimIndent(),
         )
     }
@@ -122,7 +122,7 @@ class KotlinJmespathExpressionVisitorTest {
                 val fooFiltered = (foo ?: listOf()).filter {
                     val bar = it?.bar
                     val baz = it?.baz
-                    val comparison = bar == baz
+                    val comparison = bar?.compareTo(baz)?.let { it == 0 }
                     comparison == true
                 }
             """.trimIndent(),


### PR DESCRIPTION
## Issue \#

Related to #572 

## Description of changes

This was missed somehow in service codegen testing. Because Smithy's JMESPath parser always interprets literals (e.g., `` `42` ``) as doubles (e.g., `42.0`), these numbers aren't suitable for direct operator comparison with non-double values. Updating to use `compareTo` which allows comparison across types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.