### PR TITLE
fix: make waiter comparison codegen null-safe

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -84,10 +84,12 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
         val leftIsString = (left as? LiteralExpression)?.isStringValue ?: false
         val rightIsString = (right as? LiteralExpression)?.isStringValue ?: false
 
-        val leftName = if (rightIsString && !leftIsString) "$leftBaseName?.toString()" else leftBaseName
-        val rightName = if (leftIsString && !rightIsString) "$rightBaseName?.toString()" else rightBaseName
+        val leftName = if (rightIsString && !leftIsString) "$leftBaseName.toString()" else leftBaseName
+        val rightName = if (leftIsString && !rightIsString) "$rightBaseName.toString()" else rightBaseName
 
-        return addTempVar("comparison", "$leftName?.compareTo($rightName)?.let { it ${expression.comparator} 0 }")
+        val codegen = "if ($leftBaseName == null || $rightBaseName == null) null " +
+            "else $leftName.compareTo($rightName) ${expression.comparator} 0"
+        return addTempVar("comparison", codegen)
     }
 
     override fun visitCurrentNode(expression: CurrentExpression): String {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
@@ -29,7 +29,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val bar = it?.bar
-                val comparison = foo?.compareTo(bar)?.let { it == 0 }
+                val comparison = if (foo == null || bar == null) null else foo.compareTo(bar) == 0
             """.trimIndent(),
         )
     }
@@ -42,7 +42,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val string = "foo"
                 val bar = it?.bar
-                val comparison = string?.compareTo(bar?.toString())?.let { it == 0 }
+                val comparison = if (string == null || bar == null) null else string.compareTo(bar.toString()) == 0
             """.trimIndent(),
         )
 
@@ -52,7 +52,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val string = "bar"
-                val comparison = foo?.toString()?.compareTo(string)?.let { it == 0 }
+                val comparison = if (foo == null || string == null) null else foo.toString().compareTo(string) == 0
             """.trimIndent(),
         )
     }
@@ -65,7 +65,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val string = "foo"
                 val string2 = "bar"
-                val comparison = string?.compareTo(string2)?.let { it != 0 }
+                val comparison = if (string == null || string2 == null) null else string.compareTo(string2) != 0
             """.trimIndent(),
 
         )
@@ -79,7 +79,7 @@ class KotlinJmespathExpressionVisitorTest {
             expectedCodegen = """
                 val foo = it?.foo
                 val bar = it?.bar
-                val comparison = foo?.compareTo(bar)?.let { it <= 0 }
+                val comparison = if (foo == null || bar == null) null else foo.compareTo(bar) <= 0
             """.trimIndent(),
         )
     }
@@ -122,7 +122,7 @@ class KotlinJmespathExpressionVisitorTest {
                 val fooFiltered = (foo ?: listOf()).filter {
                     val bar = it?.bar
                     val baz = it?.baz
-                    val comparison = bar?.compareTo(baz)?.let { it == 0 }
+                    val comparison = if (bar == null || baz == null) null else bar.compareTo(baz) == 0
                     comparison == true
                 }
             """.trimIndent(),

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -47,6 +47,20 @@ service WaitersTestService {
                 }
             }
         ]
+    },
+    EntityHasComparableNumericalValues: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "size == `42`",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
     }
 )
 @readonly
@@ -64,7 +78,8 @@ structure GetEntityRequest {
 
 structure GetEntityResponse {
     name: String,
-    tags: Tags
+    tags: Tags,
+    size: Integer
 }
 
 map Tags {

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -10,12 +10,12 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 import com.test.DefaultWaitersTestClient
 import com.test.model.GetEntityResponse
 import com.test.waiters.waitUntilEntityExistsBySuccess
+import com.test.waiters.waitUntilEntityHasComparableNumericalValues
 import com.test.waiters.waitUntilEntityHasNameTagByOutput
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.fail
 
 class WaiterTest {
     @OptIn(InternalApi::class)
@@ -73,5 +73,21 @@ class WaiterTest {
         val outcome = client.waitUntilEntityHasNameTagByOutput { name = "foo" }
         assertEquals(4, outcome.attempts)
         assertEquals(tagsResponse, outcome.getOrThrow())
+    }
+
+    @Test
+    fun testNumericalComparison(): Unit = runBlocking {
+        val successResponse = GetEntityResponse { size = 42 }
+        val results = listOf(
+            success { },
+            success { size = null },
+            success { size = 41 },
+            success(successResponse),
+        )
+        val client = DefaultWaitersTestClient(results)
+
+        val outcome = client.waitUntilEntityHasComparableNumericalValues { name = "foo" }
+        assertEquals(4, outcome.attempts)
+        assertEquals(successResponse, outcome.getOrThrow())
     }
 }


### PR DESCRIPTION
## Issue \#

Addresses #572 

## Description of changes

Fixes a previous PR (#583) regressing some of the null-safety in comparison codegen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
