### PR TITLE
chore: upgrade smithy to 1.17.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ atomicFuVersion=0.17.0
 kotlinxSerializationVersion=1.3.0
 
 # codegen
-smithyVersion=1.13.1
+smithyVersion=1.17.0
 smithyGradleVersion=0.5.3
 
 # testing/utility

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
@@ -5,17 +5,80 @@
 package aws.smithy.kotlin.runtime.http.util
 
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.util.InternalApi
 
 /**
- * Attempt to split an HTTP header [value] by commas and returns the resulting list
+ * Attempt to split an HTTP header [value] by commas and returns the resulting list.
+ * This parsing implements [RFC-7230's](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6)
+ * specification for header values.
  */
-fun splitHeaderListValues(value: String): List<String> = value.split(",").map { it.trim() }
+@InternalApi
+fun splitHeaderListValues(value: String): List<String> {
+    // value.split(",").map { it.trim() }
+    val results = mutableListOf<String>()
+    var currIdx = 0
+    while (currIdx < value.length) {
+        val next = when (value[currIdx]) {
+            // skip ws
+            ' ', '\t' -> {
+                currIdx++
+                continue
+            }
+            '\"' -> value.readNextQuoted(currIdx)
+            else -> value.readNextUnquoted(currIdx)
+        }
+        currIdx = next.first
+        results.add(next.second)
+    }
+
+    return results
+}
+
+private fun String.readNextQuoted(startIdx: Int, delim: Char = ','): Pair<Int, String> {
+    // startIdx is start of the quoted value, there must be at least an ending quotation mark
+    check(startIdx + 1 < length) { "unbalanced quoted header value" }
+
+    // find first non-escaped quote or end of string
+    var endIdx = startIdx + 1
+    while (endIdx < length) {
+        when (this[endIdx]) {
+            '\\' -> endIdx++ // skip escaped chars
+            '"' -> break
+        }
+        endIdx++
+    }
+
+    val next = substring(startIdx + 1, endIdx)
+
+    // consume trailing quote
+    if (endIdx < length && this[endIdx] == '"') endIdx++
+
+    // consume delim
+    if (endIdx < length && this[endIdx] == delim) endIdx++
+
+    val unescaped = next.replace("\\\"", "\"")
+        .replace("\\\\", "\\")
+
+    return Pair(endIdx, unescaped)
+}
+
+private fun String.readNextUnquoted(startIdx: Int, delim: Char = ','): Pair<Int, String> {
+    check(startIdx < this.length)
+    var endIdx = startIdx
+    while (endIdx < length && this[endIdx] != delim) endIdx++
+
+    val next = substring(startIdx, endIdx)
+    if (endIdx < length && this[endIdx] == delim) endIdx++
+
+    return Pair(endIdx, next.trim())
+}
 
 /**
  * Attempt to split an HTTP header [value] as if it contains a list of HTTP-Date timestamp
  * values separated by commas. The split is aware of the HTTP-Date format and will skip
  * a comma within the timestamp value.
  */
+@InternalApi
 fun splitHttpDateHeaderListValues(value: String): List<String> {
     val n = value.count { it == ',' }
     if (n <= 1) {
@@ -45,3 +108,18 @@ fun splitHttpDateHeaderListValues(value: String): List<String> {
 
     return splits
 }
+
+// chars in an HTTP header value that require quotations
+private const val QUOTABLE_HEADER_VALUE_CHARS = "\",()"
+
+/**
+ * Conditionally quotes and escapes a header value if the header value contains a comma or quote
+ */
+@InternalApi
+fun quoteHeaderValue(value: String): String =
+    if (value.trim().length != value.length || QUOTABLE_HEADER_VALUE_CHARS.any { value.contains(it) }) {
+        val formatted = value.replace("\\", "\\\\").replace("\"", "\\\"")
+        "\"$formatted\""
+    } else {
+        value
+    }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
@@ -57,7 +57,7 @@ private fun String.readNextQuoted(startIdx: Int, delim: Char = ','): Pair<Int, S
     while (endIdx < length) {
         when (this[endIdx]) {
             ' ', '\t' -> endIdx++
-            ',' -> {
+            delim -> {
                 endIdx++
                 break
             }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
@@ -14,7 +14,6 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  */
 @InternalApi
 fun splitHeaderListValues(value: String): List<String> {
-    // value.split(",").map { it.trim() }
     val results = mutableListOf<String>()
     var currIdx = 0
     while (currIdx < value.length) {
@@ -24,7 +23,7 @@ fun splitHeaderListValues(value: String): List<String> {
                 currIdx++
                 continue
             }
-            '\"' -> value.readNextQuoted(currIdx)
+            '"' -> value.readNextQuoted(currIdx)
             else -> value.readNextUnquoted(currIdx)
         }
         currIdx = next.first
@@ -51,7 +50,8 @@ private fun String.readNextQuoted(startIdx: Int, delim: Char = ','): Pair<Int, S
     val next = substring(startIdx + 1, endIdx)
 
     // consume trailing quote
-    if (endIdx < length && this[endIdx] == '"') endIdx++
+    check(endIdx < length && this[endIdx] == '"') { "missing end quote around quoted header value: `$next`" }
+    endIdx++
 
     // consume delim
     if (endIdx < length && this[endIdx] == delim) endIdx++

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
@@ -54,7 +54,16 @@ private fun String.readNextQuoted(startIdx: Int, delim: Char = ','): Pair<Int, S
     endIdx++
 
     // consume delim
-    if (endIdx < length && this[endIdx] == delim) endIdx++
+    while (endIdx < length) {
+        when (this[endIdx]) {
+            ' ', '\t' -> endIdx++
+            ',' -> {
+                endIdx++
+                break
+            }
+            else -> error("Unexpected char `${this[endIdx]}` between header values. Previous header: `$next`")
+        }
+    }
 
     val unescaped = next.replace("\\\"", "\"")
         .replace("\\\\", "\\")

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/util/HeaderListsTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/util/HeaderListsTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.string.shouldContain
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class HeaderListsTest {
 
@@ -41,6 +42,10 @@ class HeaderListsTest {
 
         // empty
         assertEquals(listOf("", "1"), splitHeaderListValues(",1"))
+
+        assertFailsWith<IllegalStateException> {
+            splitHeaderListValues("foo, bar, \"baz")
+        }.message.shouldContain("missing end quote around quoted header value: `baz`")
     }
 
     @Test

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/util/HeaderListsTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/util/HeaderListsTest.kt
@@ -22,6 +22,10 @@ class HeaderListsTest {
         // leading and trailing space
         assertEquals(listOf("  foo  "), splitHeaderListValues("\"  foo  \""))
 
+        // ignore spaces between values
+        assertEquals(listOf("foo", "bar"), splitHeaderListValues("foo  ,  bar"))
+        assertEquals(listOf("foo", "bar"), splitHeaderListValues("\"foo\"  ,  \"bar\""))
+
         // comma in quotes
         assertEquals(listOf("foo,bar", "baz"), splitHeaderListValues("\"foo,bar\",baz"))
 
@@ -46,6 +50,10 @@ class HeaderListsTest {
         assertFailsWith<IllegalStateException> {
             splitHeaderListValues("foo, bar, \"baz")
         }.message.shouldContain("missing end quote around quoted header value: `baz`")
+
+        assertFailsWith<IllegalStateException> {
+            splitHeaderListValues("foo  ,  \"bar\"  \tf,baz")
+        }.message.shouldContain("Unexpected char `f` between header values. Previous header: `bar`")
     }
 
     @Test

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -25,14 +25,18 @@ object RuntimeTypes {
         val QueryParameters = runtimeSymbol("QueryParameters", KotlinDependency.HTTP)
         val QueryParametersBuilder = runtimeSymbol("QueryParametersBuilder", KotlinDependency.HTTP)
         val toQueryParameters = runtimeSymbol("toQueryParameters", KotlinDependency.HTTP)
-        val encodeLabel = runtimeSymbol("encodeLabel", KotlinDependency.HTTP, "util")
         val readAll = runtimeSymbol("readAll", KotlinDependency.HTTP)
         val parameters = runtimeSymbol("parameters", KotlinDependency.HTTP)
         val toByteStream = runtimeSymbol("toByteStream", KotlinDependency.HTTP)
         val toHttpBody = runtimeSymbol("toHttpBody", KotlinDependency.HTTP)
         val isSuccess = runtimeSymbol("isSuccess", KotlinDependency.HTTP)
         val StatusCode = runtimeSymbol("HttpStatusCode", KotlinDependency.HTTP)
-        val splitAsQueryParameters = runtimeSymbol("splitAsQueryParameters", KotlinDependency.HTTP, "util")
+
+        object Util {
+            val encodeLabel = runtimeSymbol("encodeLabel", KotlinDependency.HTTP, "util")
+            val splitAsQueryParameters = runtimeSymbol("splitAsQueryParameters", KotlinDependency.HTTP, "util")
+            val quoteHeaderValue = runtimeSymbol("quoteHeaderValue", KotlinDependency.HTTP, "util")
+        }
 
         object Request {
             val HttpRequest = runtimeSymbol("HttpRequest", KotlinDependency.HTTP, "request")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -285,7 +285,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                             "input.${binding.member.defaultName()}"
                         }
 
-                        val encodeSymbol = RuntimeTypes.Http.encodeLabel
+                        val encodeSymbol = RuntimeTypes.Http.Util.encodeLabel
                         writer.addImport(encodeSymbol)
                         val encodeFn = if (segment.isGreedyLabel) {
                             writer.format("#T(greedy = true)", encodeSymbol)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
@@ -101,12 +101,18 @@ class HttpStringValuesMapSerializer(
                 formatInstant("it", tsFormat, forceString = true)
             }
             ShapeType.STRING -> {
-                if (collectionMemberTarget.isEnum) {
-                    // collections of enums should be mapped to the raw values
-                    "it.value"
-                } else {
-                    // collections of string doesn't need mapped to anything
-                    ""
+                when (binding.location) {
+                    HttpBinding.Location.QUERY -> {
+                        if (collectionMemberTarget.isEnum) "it.value" else ""
+                    }
+                    else -> {
+                        // collections of enums should be mapped to the raw values
+                        val inner = if (collectionMemberTarget.isEnum) "it.value" else "it"
+                        // ensure header values targeting lists are quoted appropriately
+                        val quoteHeaderValue = RuntimeTypes.Http.Util.quoteHeaderValue
+                        writer.addImport(quoteHeaderValue)
+                        "${quoteHeaderValue.name}($inner)"
+                    }
                 }
             }
             // default to "toString"

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
@@ -20,7 +20,8 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
 
 open class JsonParserGenerator(
     // FIXME - we shouldn't need this, it's only required by JsonSerdeDescriptorGenerator because of toRenderingContext
-    private val protocolGenerator: ProtocolGenerator
+    private val protocolGenerator: ProtocolGenerator,
+    private val supportsJsonNameTrait: Boolean = true
 ) : StructuredDataParserGenerator {
 
     open val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
@@ -105,7 +106,7 @@ open class JsonParserGenerator(
         members: List<MemberShape>,
         writer: KotlinWriter,
     ) {
-        JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members).render()
+        JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members, supportsJsonNameTrait).render()
         if (shape.isUnionShape) {
             val name = ctx.symbolProvider.toSymbol(shape).name
             DeserializeUnionGenerator(ctx, name, members, writer, defaultTimestampFormat).render()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
@@ -16,10 +16,12 @@ import software.amazon.smithy.model.traits.JsonNameTrait
 
 /**
  * Field descriptor generator that processes the [jsonName trait](https://awslabs.github.io/smithy/1.0/spec/core/protocol-traits.html#jsonname-trait)
+ * @param supportsJsonNameTrait Flag indicating if the jsonName trait should be used or not, when `false` the member name is used.
  */
 open class JsonSerdeDescriptorGenerator(
     ctx: RenderingContext<Shape>,
-    memberShapes: List<MemberShape>? = null
+    memberShapes: List<MemberShape>? = null,
+    private val supportsJsonNameTrait: Boolean = true
 ) : AbstractSerdeDescriptorGenerator(ctx, memberShapes) {
 
     override fun getFieldDescriptorTraits(
@@ -34,7 +36,11 @@ open class JsonSerdeDescriptorGenerator(
             RuntimeTypes.Serde.SerdeJson.JsonSerialName,
         )
 
-        val serialName = member.getTrait<JsonNameTrait>()?.value ?: member.memberName
+        val serialName = if (supportsJsonNameTrait) {
+            member.getTrait<JsonNameTrait>()?.value ?: member.memberName
+        } else {
+            member.memberName
+        }
         return listOf(SdkFieldDescriptorTrait(RuntimeTypes.Serde.SerdeJson.JsonSerialName, serialName.dq()))
     }
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerializerGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerializerGenerator.kt
@@ -20,7 +20,8 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
 
 open class JsonSerializerGenerator(
     // FIXME - we shouldn't need this, it's only required by JsonSerdeDescriptorGenerator because of toRenderingContext
-    private val protocolGenerator: HttpBindingProtocolGenerator
+    private val protocolGenerator: HttpBindingProtocolGenerator,
+    private val supportsJsonNameTrait: Boolean = true
 ) : StructuredDataSerializerGenerator {
 
     open val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
@@ -86,7 +87,7 @@ open class JsonSerializerGenerator(
         writer: KotlinWriter,
     ) {
         // render the serde descriptors
-        JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members).render()
+        JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members, supportsJsonNameTrait).render()
         if (shape.isUnionShape) {
             SerializeUnionGenerator(ctx, members, writer, defaultTimestampFormat).render()
         } else {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializerTest.kt
@@ -100,8 +100,9 @@ class HttpStringValuesMapSerializerTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedContents = """
-            if (input.enumList?.isNotEmpty() == true) appendAll("x-enumList", input.enumList.map { it.value })
+            if (input.enumList?.isNotEmpty() == true) appendAll("x-enumList", input.enumList.map { quoteHeaderValue(it.value) })
             if (input.intList?.isNotEmpty() == true) appendAll("x-intList", input.intList.map { "${'$'}it" })
+            if (input.strList?.isNotEmpty() == true) appendAll("x-strList", input.strList.map { quoteHeaderValue(it) })
             if (input.tsList?.isNotEmpty() == true) appendAll("x-tsList", input.tsList.map { it.format(TimestampFormat.RFC_5322) })
         """.trimIndent()
         contents.shouldContainOnlyOnceWithDiff(expectedContents)

--- a/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/http-binding-protocol-generator-test.smithy
+++ b/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/http-binding-protocol-generator-test.smithy
@@ -183,6 +183,10 @@ list IntList {
     member: Integer
 }
 
+list StringList {
+    member: String
+}
+
 list StructList {
     member: Nested
 }
@@ -240,6 +244,9 @@ structure HeaderListInputRequest {
 
     @httpHeader("x-intList")
     intList: IntList,
+
+    @httpHeader("x-strList")
+    strList: StringList,
 
     @httpHeader("x-tsList")
     tsList: TimestampList


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #586 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* upgrades smithy dependency to 1.17
* allow JSON serde generation to ignore the `@jsonName` trait (protocol tests were updated, awsJson protocols MUST not interpret these traits)
* fixes quoting of header list values (string and enums) when the value contains a quotation mark or comma
* fixes the header list split function to handle quoted values and escapes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
