### PR TITLE
feat: add DSL overloads to paginator methods

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -379,9 +379,23 @@ private fun String.stripAll(stripList: List<String>): String {
 }
 
 // Remove whitespace from the beginning and end of each line of documentation
-// Remove blank lines
+// Remove leading, trailing, and consecutive blank lines
 private fun formatDocumentation(doc: String, lineSeparator: String = "\n") =
     doc
         .split('\n') // Break the doc into lines
-        .filter { it.isNotBlank() } // Remove empty lines
+        .dropWhile { it.isBlank() } // Drop leading blank lines
+        .dropLastWhile { it.isBlank() } // Drop trailing blank lines
+        .filter(NoConsecutivesFilter { it.isBlank() }) // Remove consecutive empty lines
         .joinToString(separator = lineSeparator) { it.trim() } // Trim line
+
+/**
+ * A filtering predicate for removing consecutive lines matching some condition. When passed to a `filter` method, it
+ * will remove any item matching the [predicate] if the previous item also matched the [predicate]. (Single instances of
+ * items matching the predicate will not be removed.)
+ */
+private class NoConsecutivesFilter<T>(private val predicate: (T) -> Boolean): (T) -> Boolean {
+    var lastItemMatched = false
+
+    override operator fun invoke(item: T): Boolean =
+        !lastItemMatched or !predicate(item).also { lastItemMatched = it }
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.defaultName
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.SymbolProperty
 import software.amazon.smithy.kotlin.codegen.model.expectShape
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
@@ -121,11 +122,13 @@ class PaginatorGenerator : KotlinIntegration {
 
         writer.write("")
         writer
-            .dokka("""
-                $docBody
-                @param initialRequest A [${inputSymbol.name}] to start pagination
-                $docReturn
-            """.trimIndent())
+            .dokka(
+                """
+                    $docBody
+                    @param initialRequest A [${inputSymbol.name}] to start pagination
+                    $docReturn
+                """.trimIndent()
+            )
             .addImportReferences(cursorSymbol, SymbolReference.ContextOption.DECLARE)
             .withBlock(
                 "fun #T.#LPaginated(initialRequest: #T): #T<#T> =",
@@ -157,17 +160,20 @@ class PaginatorGenerator : KotlinIntegration {
 
         writer.write("")
         writer
-            .dokka("""
-                $docBody
-                @param block A builder block used for DSL-style invocation of the operation
-                $docReturn
-            """.trimIndent())
+            .dokka(
+                """
+                    $docBody
+                    @param block A builder block used for DSL-style invocation of the operation
+                    $docReturn
+                """.trimIndent()
+            )
             .withBlock(
-                "fun #T.#LPaginated(block: #T.Builder.() -> Unit): #T<#T> =",
+                "fun #T.#LPaginated(block: #T.Builder.() -> #T): #T<#T> =",
                 "",
                 serviceSymbol,
                 operationShape.defaultName(),
                 inputSymbol,
+                KotlinTypes.Unit,
                 ExternalTypes.KotlinxCoroutines.Flow,
                 outputSymbol,
             ) {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -74,7 +74,9 @@ class Config private constructor(builder: Builder): HttpClientConfig, Idempotenc
         /**
          * Configure events that will be logged. By default clients will not output
          * raw requests or responses. Use this setting to opt-in to additional debug logging.
+         *
          * This can be used to configure logging of requests, responses, retries, etc of SDK clients.
+         *
          * **NOTE**: Logging of raw requests or responses may leak sensitive information! It may also have
          * performance considerations when dumping the request/response body. This is primarily a tool for
          * debug purposes.

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -142,11 +142,12 @@ class PaginatorGeneratorTest {
         val expected = """
             /**
              * Paginate over [ListFunctionsResponse] results.
-             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service calls are
-             * made until the flow is collected. This also means there is no guarantee that the request is valid until then. Once
-             * you start collecting the flow, the SDK will lazily load response pages by making service calls until there are no
-             * pages left or the flow is cancelled. If there are errors in your request, you will see the failures only after you start
-             * collection.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
              * @param initialRequest A [ListFunctionsRequest] to start pagination
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
@@ -165,6 +166,20 @@ class PaginatorGeneratorTest {
                         emit(result)
                     }
                 }
+            
+            /**
+             * Paginate over [ListFunctionsResponse] results.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
+             * @param block A builder block used for DSL-style invocation of the operation
+             * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
+             */
+            fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
+                listFunctionsPaginated(ListFunctionsRequest.Builder().apply(block).build())
         """.trimIndent()
 
         actual.shouldContainOnlyOnceWithDiff(expected)
@@ -182,11 +197,12 @@ class PaginatorGeneratorTest {
         val expectedCode = """
             /**
              * Paginate over [ListFunctionsResponse] results.
-             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service calls are
-             * made until the flow is collected. This also means there is no guarantee that the request is valid until then. Once
-             * you start collecting the flow, the SDK will lazily load response pages by making service calls until there are no
-             * pages left or the flow is cancelled. If there are errors in your request, you will see the failures only after you start
-             * collection.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
              * @param initialRequest A [ListFunctionsRequest] to start pagination
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
@@ -205,6 +221,20 @@ class PaginatorGeneratorTest {
                         emit(result)
                     }
                 }
+            
+            /**
+             * Paginate over [ListFunctionsResponse] results.
+             *
+             * When this operation is called, a [kotlinx.coroutines.Flow] is created. Flows are lazy (cold) so no service
+             * calls are made until the flow is collected. This also means there is no guarantee that the request is valid
+             * until then. Once you start collecting the flow, the SDK will lazily load response pages by making service
+             * calls until there are no pages left or the flow is cancelled. If there are errors in your request, you will
+             * see the failures only after you start collection.
+             * @param block A builder block used for DSL-style invocation of the operation
+             * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
+             */
+            fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
+                listFunctionsPaginated(ListFunctionsRequest.Builder().apply(block).build())
             
             /**
              * This paginator transforms the flow returned by [listFunctionsPaginated]


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change adds DSL overloads to paginator methods. Previously, the only way to call paginators was with explicit request objects:

```kotlin
val client = SomeClient(…)
val initialRequest = ListItemsRequest {
    foo = …
    bar = …
}
val result = client.listItemsPaginated(initialRequest)
```

With this new change, paginators can now be called using DSL overloads that create request objects internally:

```kotlin
val client = SomeClient(…)
val result = client.listItemsPaginated {
    foo = …
    bar = …
}
```

This brings parity with the invocation options available for regular service operations, waiters, config, etc.

A minor change alongside this is an update to the KDoc formatting done in codegen. Previously, all blank lines were removed. Now, only leading, trailing, and consecutive blank lines are removed. This allows KDocs to contain empty lines which denote paragraph breaks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
