### PR TITLE
refactor(codegen): allow payload serializer and deserializer for any shape

### DIFF
--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -28,6 +28,7 @@ private const val BUILD_SETTINGS = "build"
 // Optional specification of sdkId for models that provide them, otherwise Service's shape id name is used
 private const val SDK_ID = "sdkId"
 
+// FIXME - service should not be required
 /**
  * Settings used by [KotlinCodegenPlugin]
  */

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -28,7 +28,6 @@ private const val BUILD_SETTINGS = "build"
 // Optional specification of sdkId for models that provide them, otherwise Service's shape id name is used
 private const val SDK_ID = "sdkId"
 
-// FIXME - service should not be required
 /**
  * Settings used by [KotlinCodegenPlugin]
  */

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -54,7 +54,7 @@ fun Shape.changeNameSuffix(fromTo: Pair<String, String>): String {
  * If is member shape returns target, otherwise returns self.
  * @param model for loading the target shape
  */
-internal fun Shape.targetOrSelf(model: Model) = when (this) {
+fun Shape.targetOrSelf(model: Model): Shape = when (this) {
     is MemberShape -> model.expectShape(this.target)
     else -> this
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.knowledge.SerdeIndex
+import software.amazon.smithy.kotlin.codegen.model.targetOrSelf
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.toRenderingContext
 import software.amazon.smithy.model.shapes.MemberShape
@@ -115,28 +116,14 @@ open class JsonParserGenerator(
         }
     }
 
-    // FIXME - we should just update the interface to accept any Shape and branch on member shape as necessary
-    override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol {
+    override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol {
         // re-use document deserializer (for the target shape!)
-        val symbol = ctx.symbolProvider.toSymbol(member)
-        val target = ctx.model.expectShape(member.target)
+        val target = shape.targetOrSelf(ctx.model)
+        val symbol = ctx.symbolProvider.toSymbol(shape)
         val deserializeFn = documentDeserializer(ctx, target)
         val fnName = symbol.payloadDeserializerName()
         return symbol.payloadDeserializer(ctx.settings) { writer ->
             addNestedDocumentDeserializers(ctx, target, writer)
-            writer.withBlock("internal fun #L(payload: ByteArray): #T {", "}", fnName, symbol) {
-                write("val deserializer = #T(payload)", RuntimeTypes.Serde.SerdeJson.JsonDeserializer)
-                write("return #T(deserializer)", deserializeFn)
-            }
-        }
-    }
-
-    fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol {
-        val symbol = ctx.symbolProvider.toSymbol(shape)
-        val deserializeFn = documentDeserializer(ctx, shape)
-        val fnName = symbol.payloadDeserializerName()
-        return symbol.payloadDeserializer(ctx.settings) { writer ->
-            addNestedDocumentDeserializers(ctx, shape, writer)
             writer.withBlock("internal fun #L(payload: ByteArray): #T {", "}", fnName, symbol) {
                 write("val deserializer = #T(payload)", RuntimeTypes.Serde.SerdeJson.JsonDeserializer)
                 write("return #T(deserializer)", deserializeFn)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/StructuredDataParserGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/StructuredDataParserGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
 
 /**
@@ -51,10 +52,10 @@ interface StructuredDataParserGenerator {
      * Implementations are expected to deserialize from the specific data format and return the result
      *
      * @param ctx the protocol generator context
-     * @param member the member to deserialize
+     * @param shape the shape or member to deserialize
      * @return the generated symbol which should be a function matching the expected signature
      */
-    fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol
+    fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol
 
     /**
      * Render function responsible for deserializing members bound to the payload for the given error shape.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/StructuredDataSerializerGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/StructuredDataSerializerGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 
 /**
  * Responsible for rendering serialization of structured data (e.g. json, yaml, xml).
@@ -46,8 +47,8 @@ interface StructuredDataSerializerGenerator {
      * Implementations are expected to serialize to the specific data format and return the contents as a byte array.
      *
      * @param ctx the protocol generator context
-     * @param member the member to serialize
+     * @param shape the shape or member to serialize
      * @return the generated symbol which should be a function matching the expected signature
      */
-    fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol
+    fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlParserGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.knowledge.SerdeIndex
+import software.amazon.smithy.kotlin.codegen.model.targetOrSelf
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.toRenderingContext
 import software.amazon.smithy.model.shapes.MemberShape
@@ -130,10 +131,10 @@ open class XmlParserGenerator(
         }
     }
 
-    override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol {
+    override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol {
         // re-use document deserializer
-        val symbol = ctx.symbolProvider.toSymbol(member)
-        val target = ctx.model.expectShape(member.target)
+        val target = shape.targetOrSelf(ctx.model)
+        val symbol = ctx.symbolProvider.toSymbol(shape)
         val deserializeFn = documentDeserializer(ctx, target)
         val fnName = symbol.payloadDeserializerName()
         return symbol.payloadDeserializer(ctx.settings) { writer ->

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerializerGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerializerGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
 import software.amazon.smithy.kotlin.codegen.model.knowledge.SerdeIndex
+import software.amazon.smithy.kotlin.codegen.model.targetOrSelf
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.toRenderingContext
 import software.amazon.smithy.model.shapes.MemberShape
@@ -116,10 +117,10 @@ open class XmlSerializerGenerator(
         return attributes + elements
     }
 
-    override fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol {
+    override fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol {
         // re-use document serializer
-        val symbol = ctx.symbolProvider.toSymbol(member)
-        val target = ctx.model.expectShape(member.target)
+        val target = shape.targetOrSelf(ctx.model)
+        val symbol = ctx.symbolProvider.toSymbol(shape)
         val serializeFn = documentSerializer(ctx, target)
         val fnName = symbol.payloadSerializerName()
         return symbol.payloadSerializer(ctx.settings) { writer ->

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/CodegenTestUtils.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/CodegenTestUtils.kt
@@ -165,8 +165,8 @@ internal class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
                 name = errSymbol.errorDeserializerName()
             }
 
-            override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol = buildSymbol {
-                val symbol = ctx.symbolProvider.toSymbol(member)
+            override fun payloadDeserializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol = buildSymbol {
+                val symbol = ctx.symbolProvider.toSymbol(shape)
                 name = symbol.payloadDeserializerName()
             }
         }
@@ -177,8 +177,8 @@ internal class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
                 name = op.bodySerializerName()
             }
 
-            override fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, member: MemberShape): Symbol = buildSymbol {
-                val symbol = ctx.symbolProvider.toSymbol(member)
+            override fun payloadSerializer(ctx: ProtocolGenerator.GenerationContext, shape: Shape): Symbol = buildSymbol {
+                val symbol = ctx.symbolProvider.toSymbol(shape)
                 name = symbol.payloadSerializerName()
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Remove restriction that a payload serializer or deserializer can only be used for `MemberShape`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
