### PR TITLE
test: bootstrap common http engine test suite

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -43,7 +43,6 @@ subprojects {
     // don't configure anything
     if (!needsConfigure) return@subprojects
 
-    // TODO - the group to publish under needs negotiated still
     group = "aws.smithy.kotlin"
     version = sdkVersion
 

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -15,6 +15,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.request.request
 import io.ktor.client.statement.HttpStatement
+import io.ktor.http.*
 import io.ktor.util.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -122,8 +123,7 @@ actual class KtorEngine actual constructor(
             // completes, at which point we signal it's safe to exit the block and release the underlying resources.
             callContext.job.invokeOnCompletion { waiter.signal() }
 
-            val contentLength = httpResp.headers["content-length"]?.toLong()
-            val body = KtorHttpBody(contentLength, httpResp.content)
+            val body = KtorHttpBody(httpResp.contentLength(), httpResp.content)
 
             // copy the headers so that we no longer depend on the underlying ktor HttpResponse object
             // outside of the body content (which will signal once read that it is safe to exit the block)

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -122,7 +122,8 @@ actual class KtorEngine actual constructor(
             // completes, at which point we signal it's safe to exit the block and release the underlying resources.
             callContext.job.invokeOnCompletion { waiter.signal() }
 
-            val body = KtorHttpBody(httpResp.content)
+            val contentLength = httpResp.headers["content-length"]?.toLong()
+            val body = KtorHttpBody(contentLength, httpResp.content)
 
             // copy the headers so that we no longer depend on the underlying ktor HttpResponse object
             // outside of the body content (which will signal once read that it is safe to exit the block)

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
@@ -107,5 +107,5 @@ internal class KtorHttpBody(
 fun HttpResponse.toSdkHttpResponse(): SdkHttpResponse = SdkHttpResponse(
     HttpStatusCode.fromValue(status.value),
     KtorHeaders(headers),
-    KtorHttpBody(channel = content)
+    KtorHttpBody(contentLength(), channel = content)
 )

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtils.kt
@@ -95,7 +95,10 @@ internal class KtorContentStream(private val channel: ByteReadChannel) : SdkByte
 }
 
 // wrapper around a ByteReadChannel that implements the content as an SDK (streaming) HttpBody
-internal class KtorHttpBody(channel: ByteReadChannel) : HttpBody.Streaming() {
+internal class KtorHttpBody(
+    override val contentLength: Long? = null,
+    channel: ByteReadChannel
+) : HttpBody.Streaming() {
     private val source = KtorContentStream(channel)
     override fun readFrom(): SdkByteReadChannel = source
 }
@@ -104,5 +107,5 @@ internal class KtorHttpBody(channel: ByteReadChannel) : HttpBody.Streaming() {
 fun HttpResponse.toSdkHttpResponse(): SdkHttpResponse = SdkHttpResponse(
     HttpStatusCode.fromValue(status.value),
     KtorHeaders(headers),
-    KtorHttpBody(content)
+    KtorHttpBody(channel = content)
 )

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
@@ -55,7 +55,7 @@ class KtorRequestAdapterTest {
         val content = "testing".toByteArray()
         val sdkSource = ByteReadChannel(content)
 
-        sdkBuilder.body = KtorHttpBody(sdkSource)
+        sdkBuilder.body = KtorHttpBody(content.size.toLong(), sdkSource)
         val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()
         val convertedBody = actual.body as OutgoingContent.ReadChannelContent
         assertEquals(ContentType.Application.OctetStream, convertedBody.contentType)
@@ -69,7 +69,7 @@ class KtorRequestAdapterTest {
         val content = "testing".toByteArray()
 
         val sdkSource = ByteReadChannel(content)
-        sdkBuilder.body = KtorHttpBody(sdkSource)
+        sdkBuilder.body = KtorHttpBody(content.size.toLong(), sdkSource)
         val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()
         val convertedBody = actual.body as OutgoingContent.ReadChannelContent
 
@@ -88,7 +88,7 @@ class KtorRequestAdapterTest {
         val content = "testing".toByteArray()
 
         val sdkSource = ByteReadChannel(content)
-        sdkBuilder.body = KtorHttpBody(sdkSource)
+        sdkBuilder.body = KtorHttpBody(content.size.toLong(), sdkSource)
         val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()
         val convertedBody = actual.body as OutgoingContent.ReadChannelContent
 
@@ -118,7 +118,7 @@ class KtorRequestAdapterTest {
         val content = ByteArray(8192) { (it % 128).toByte() }
 
         val sdkSource = ByteReadChannel(content)
-        sdkBuilder.body = KtorHttpBody(sdkSource)
+        sdkBuilder.body = KtorHttpBody(content.size.toLong(), sdkSource)
         val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()
         val convertedBody = actual.body as OutgoingContent.ReadChannelContent
 
@@ -145,7 +145,7 @@ class KtorRequestAdapterTest {
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/octet-stream")
         val sdkSource = ByteChannel()
-        sdkBuilder.body = KtorHttpBody(sdkSource)
+        sdkBuilder.body = KtorHttpBody(0L, sdkSource)
 
         val job = launch {
             val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtilsTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorUtilsTest.kt
@@ -25,15 +25,15 @@ import kotlin.test.*
 @OptIn(InternalAPI::class)
 class MockHttpResponse : HttpResponse() {
     override val call: HttpClientCall
-        get() = TODO("Not yet implemented")
+        get() = error("not needed for test")
     override val content: ByteReadChannel = ByteReadChannel.Empty
     override val coroutineContext: CoroutineContext
-        get() = TODO("Not yet implemented")
+        get() = error("not needed for test")
     override val headers: Headers = Headers.build { append("x-foo", "bar") }
     override val requestTime: GMTDate
-        get() = TODO("Not yet implemented")
+        get() = error("not needed for test")
     override val responseTime: GMTDate
-        get() = TODO("Not yet implemented")
+        get() = error("not needed for test")
     override val status: HttpStatusCode = HttpStatusCode.OK
     override val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_1_1
 }

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+import java.io.*
+import java.net.*
+
+description = "Common HTTP Client Engine Test Suite"
+extra["moduleName"] = "aws.smithy.kotlin.http.test"
+
+extra["skipPublish"] = true
+
+val coroutinesVersion: String by project
+val ktorVersion: String by project
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(project(":runtime:protocol:http"))
+                implementation(project(":runtime:protocol:http-test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+            }
+        }
+
+        jvmMain {
+            dependencies {
+                implementation("io.ktor:ktor-server-cio:$ktorVersion")
+
+                implementation(project(":runtime:protocol:http-client-engines:http-client-engine-ktor"))
+            }
+        }
+
+        all {
+            languageSettings.optIn("aws.smithy.kotlin.runtime.util.InternalApi")
+        }
+    }
+}
+
+open class LocalTestServer : DefaultTask() {
+    @Internal
+    var server: Closeable? = null
+        private set
+
+    @Internal
+    lateinit var main: String
+
+    @Internal
+    lateinit var classpath: FileCollection
+
+    @TaskAction
+    fun exec() {
+        try {
+            println("[TestServer] start")
+            val urlClassLoaderSource = classpath.map { file -> file.toURI().toURL() }.toTypedArray()
+            val loader = URLClassLoader(urlClassLoaderSource, ClassLoader.getSystemClassLoader())
+
+            val mainClass = loader.loadClass(main)
+            val main = mainClass.getMethod("startServer")
+            server = main.invoke(null) as Closeable
+            println("[TestServer] started")
+        } catch (cause: Throwable) {
+            println("[TestServer] failed: ${cause.message}")
+            cause.printStackTrace()
+        }
+    }
+}
+
+val osName = System.getProperty("os.name")
+
+val startTestServer = task<LocalTestServer>("startTestServer") {
+    dependsOn(tasks["jvmJar"])
+
+    main = "aws.smithy.kotlin.runtime.http.test.util.TestServerKt"
+    val kotlinCompilation = kotlin.targets.getByName("jvm").compilations["test"]
+    classpath = (kotlinCompilation as org.jetbrains.kotlin.gradle.plugin.KotlinCompilationToRunnableFiles<*>).runtimeDependencyFiles
+}
+
+val testTasks = listOf("allTests", "jvmTest")
+    .forEach {
+        tasks.named(it) {
+            dependsOn(startTestServer)
+        }
+    }
+
+gradle.buildFinished {
+    if (startTestServer.server != null) {
+        startTestServer.server?.close()
+        println("[TestServer] stop")
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -61,7 +61,14 @@ open class LocalTestServer : DefaultTask() {
             println("[TestServer] started")
         } catch (cause: Throwable) {
             println("[TestServer] failed: ${cause.message}")
-            cause.printStackTrace()
+            throw cause
+        }
+    }
+
+    fun stop() {
+        if (server != null) {
+            server?.close()
+            println("[TestServer] stop")
         }
     }
 }
@@ -84,8 +91,5 @@ val testTasks = listOf("allTests", "jvmTest")
     }
 
 gradle.buildFinished {
-    if (startTestServer.server != null) {
-        startTestServer.server?.close()
-        println("[TestServer] stop")
-    }
+    startTestServer.stop()
 }

--- a/runtime/protocol/http-client-engines/test-suite/common/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.util
+
+import aws.smithy.kotlin.runtime.http.SdkHttpClient
+import aws.smithy.kotlin.runtime.http.Url
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+private val TEST_SERVER = Url.parse("http://127.0.0.1:8082")
+
+/**
+ * Abstract base class that all engine test suite test classes should inherit from.
+ */
+expect abstract class AbstractEngineTest() {
+
+    /**
+     * Build a test that will run against each engine in the test suite.
+     *
+     * Concrete implementations for each KMP target are responsible for loading the engines
+     * supported by that platform and executing the test
+     */
+    fun testEngines(block: EngineTestBuilder.() -> Unit)
+}
+
+/**
+ * Container for current engine test environment
+ *
+ * @param testServer the URL to the local running test server
+ * @param coroutineId unique ID for current coroutine/job (concurrency > 1)
+ * @param attempt the current attempt number when repeat > 1
+ */
+data class TestEnvironment(val testServer: Url, val coroutineId: Int, val attempt: Int)
+
+/**
+ * Configure the test
+ */
+class EngineTestBuilder {
+    /**
+     * Lambda function that is invoked with the current test environment and an [SdkHttpClient]
+     * configured with an engine loaded by [AbstractEngineTest]. Invoke calls against test routes and make
+     * assertions here
+     */
+    var test: (suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) = { _, _ -> Unit }
+
+    /**
+     * Number of times to repeat [test]
+     */
+    var repeat: Int = 1
+
+    /**
+     * The number of coroutines to launch. Each coroutine will invoke [test]
+     */
+    var concurrency: Int = 1
+}
+
+/**
+ * Shared entry point usable by implementations of [AbstractEngineTest.testEngines]
+ */
+fun testWithClient(
+    client: SdkHttpClient,
+    timeout: Duration = 60.seconds,
+    block: suspend EngineTestBuilder.() -> Unit
+): Unit = runBlockingTest(timeout = timeout) {
+    val builder = EngineTestBuilder().apply { block() }
+    concurrency(builder.concurrency) { coroutineId ->
+        repeat(builder.repeat) { attempt ->
+            val env = TestEnvironment(TEST_SERVER, coroutineId, attempt)
+            builder.test(env, client)
+        }
+    }
+    client.close()
+}
+
+// Use a real dispatcher rather than `runTest` (e.g. runBlocking for JVM/Native) which more appropriately matches
+// a real environment
+expect fun runBlockingTest(
+    context: CoroutineContext = EmptyCoroutineContext,
+    timeout: Duration? = null,
+    block: suspend CoroutineScope.() -> Unit
+): Unit
+
+private suspend fun concurrency(level: Int, block: suspend (Int) -> Unit) {
+    coroutineScope {
+        List(level) {
+            async {
+                block(it)
+            }
+        }.awaitAll()
+    }
+}
+
+fun EngineTestBuilder.test(block: suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) {
+    test = block
+}

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test
+
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.readAll
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.http.response.complete
+import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
+import aws.smithy.kotlin.runtime.http.test.util.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AsyncStressTest : AbstractEngineTest() {
+
+    @Test
+    fun testConcurrentRequests() = testEngines {
+        // https://github.com/awslabs/aws-sdk-kotlin/issues/170
+        concurrency = 1_000
+
+        test { env, client ->
+            val req = HttpRequest {
+                url(env.testServer)
+                url.path = "concurrent"
+            }
+
+            val call = client.call(req)
+            assertEquals(HttpStatusCode.OK, call.response.status)
+
+            try {
+                call.response.body.readAll()
+            } finally {
+                call.complete()
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
@@ -32,7 +32,12 @@ class AsyncStressTest : AbstractEngineTest() {
             assertEquals(HttpStatusCode.OK, call.response.status)
 
             try {
-                call.response.body.readAll()
+                val resp = call.response.body.readAll() ?: error("expected response body")
+
+                val contentLength = call.response.body.contentLength ?: 0L
+                val text = "testing"
+                val expectedText = text.repeat(contentLength.toInt() / text.length)
+                assertEquals(expectedText, resp.decodeToString())
             } finally {
                 call.complete()
             }

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test
+
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.http.response.complete
+import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
+import aws.smithy.kotlin.runtime.http.test.util.test
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.util.Sha256
+import aws.smithy.kotlin.runtime.util.encodeToHex
+import aws.smithy.kotlin.runtime.util.sha256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.fail
+
+class DownloadTest : AbstractEngineTest() {
+
+    // These download integrity tests assert behavior on various SdkByteReadChannel.read* functions (specifically
+    // that reading doesn't lose any bytes due to erroneous handling of buffers). The server
+    // side will insert random delays and ensures that the reader will suspend while reading
+
+    @Test
+    fun testReadFullyIntegrity() =
+        // see https://github.com/awslabs/aws-sdk-kotlin/issues/526
+        runReadSuspendIntegrityTest { channel, totalSize ->
+            val dest = ByteArray(totalSize)
+            channel.readFully(dest)
+            dest.sha256().encodeToHex()
+        }
+
+    @Test
+    fun testReadAvailableIntegrity() =
+        runReadSuspendIntegrityTest { channel, totalSize ->
+            val checksum = Sha256()
+            var totalRead = 0
+            while (!channel.isClosedForRead) {
+                val chunk = ByteArray(8 * 1024)
+                val rc = channel.readAvailable(chunk)
+                if (rc < 0) break
+
+                totalRead += rc
+                val slice = if (rc != chunk.size) chunk.sliceArray(0 until rc) else chunk
+                checksum.update(slice)
+            }
+
+            assertEquals(totalSize, totalRead)
+            checksum.digest().encodeToHex()
+        }
+
+    @Test
+    fun testReadRemainingIntegrity() =
+        runReadSuspendIntegrityTest { channel, totalSize ->
+            val data = channel.readRemaining()
+            assertEquals(totalSize, data.size)
+            data.sha256().encodeToHex()
+        }
+
+    private fun runReadSuspendIntegrityTest(reader: suspend (SdkByteReadChannel, Int) -> String) = testEngines {
+        test { env, client ->
+            val req = HttpRequest {
+                url(env.testServer)
+                url.path = "/download/integrity"
+            }
+
+            val call = client.call(req)
+            try {
+                assertEquals(HttpStatusCode.OK, call.response.status)
+
+                val expectedSha256 = call.response.headers["expected-sha256"] ?: fail("missing expected-sha256 header")
+                val contentLength = call.response.body.contentLength ?: fail("expected Content-Length")
+                check(contentLength < Int.MAX_VALUE)
+
+                val body = call.response.body
+                assertIs<HttpBody.Streaming>(body)
+                val chan = body.readFrom()
+
+                val readSha256 = reader(chan, contentLength.toInt())
+                assertEquals(expectedSha256, readSha256)
+            } finally {
+                call.complete()
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/RedirectTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/RedirectTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test
+
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.http.response.complete
+import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
+import aws.smithy.kotlin.runtime.http.test.util.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RedirectTest : AbstractEngineTest() {
+
+    @Test
+    fun testDoNotFollow301() = testDoNotFollow(HttpStatusCode.MovedPermanently, "/redirect/permanent")
+
+    @Test
+    fun testDoNotFollow302() = testDoNotFollow(HttpStatusCode.Found, "/redirect/found")
+
+    private fun testDoNotFollow(expectedStatus: HttpStatusCode, path: String) = testEngines {
+        test { env, client ->
+            val req = HttpRequest {
+                url(env.testServer)
+                url.path = path
+            }
+
+            val call = client.call(req)
+            call.complete()
+            assertEquals(expectedStatus, call.response.status)
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test
+
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.http.response.complete
+import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
+import aws.smithy.kotlin.runtime.http.test.util.test
+import aws.smithy.kotlin.runtime.io.SdkByteChannel
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.util.encodeToHex
+import aws.smithy.kotlin.runtime.util.sha256
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UploadTest : AbstractEngineTest() {
+    @Test
+    fun testUploadIntegrity() = testEngines {
+        // test that what we write the entire contents given to us
+        test { env, client ->
+            val data = ByteArray(16 * 1024 * 1023) { it.toByte() }
+            val sha = data.sha256().encodeToHex()
+
+            val req = HttpRequest {
+                method = HttpMethod.POST
+                url(env.testServer)
+                url.path = "/upload/content"
+                body = ByteArrayContent(data)
+            }
+
+            val call = client.call(req)
+            call.complete()
+            assertEquals(HttpStatusCode.OK, call.response.status)
+            assertEquals(sha, call.response.headers["content-sha256"])
+        }
+    }
+
+    @Test
+    fun testUploadWithDelay() = testEngines {
+        test { env, client ->
+            val data = ByteArray(16 * 1024 * 1023) { it.toByte() }
+            val sha = data.sha256().encodeToHex()
+            val ch = SdkByteChannel(autoFlush = true)
+            val content = object : HttpBody.Streaming() {
+                override val contentLength: Long = data.size.toLong()
+                override fun readFrom(): SdkByteReadChannel = ch
+            }
+
+            val req = HttpRequest {
+                method = HttpMethod.POST
+                url(env.testServer)
+                url.path = "/upload/content"
+                body = content
+            }
+
+            coroutineScope {
+                launch {
+                    val end = data.size / 3
+                    val slice = data.sliceArray(0 until end)
+                    ch.writeFully(slice, 0, end)
+                    delay(1000)
+                    ch.writeFully(data, offset = end)
+                    ch.close()
+                }
+                val call = client.call(req)
+                call.complete()
+                assertEquals(HttpStatusCode.OK, call.response.status)
+                assertEquals(sha, call.response.headers["content-sha256"])
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -49,7 +49,7 @@ class UploadTest : AbstractEngineTest() {
     @Test
     fun testUploadWithDelay() = testEngines {
         test { env, client ->
-            val data = ByteArray(16 * 1024 * 1023) { it.toByte() }
+            val data = ByteArray(16 * 1024 * 1024) { it.toByte() }
             val sha = data.sha256().encodeToHex()
             val ch = SdkByteChannel(autoFlush = true)
             val content = object : HttpBody.Streaming() {

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Concurrency.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Concurrency.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.suite
+
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+
+internal fun Application.concurrentTests() {
+    routing {
+        route("concurrent") {
+            get {
+                val respSize = 32 * 1024
+                val text = "testing"
+                call.respondText(text.repeat(respSize / text.length))
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Downloads.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Downloads.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.suite
+
+import aws.smithy.kotlin.runtime.util.encodeToHex
+import aws.smithy.kotlin.runtime.util.sha256
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.random.Random
+
+internal fun Application.downloadTests() {
+    routing {
+        route("/download") {
+            get("/integrity") {
+                // writer is setup to write random lengths and delay to cause the reader to enter a suspend loop
+                val data = ByteArray(16 * 1024 * 1024) { it.toByte() }
+                val writeSha = data.sha256().encodeToHex()
+                call.response.header("expected-sha256", writeSha)
+
+                val ch = ByteChannel(autoFlush = true)
+                val content = object : OutgoingContent.ReadChannelContent() {
+                    override val contentLength: Long = data.size.toLong()
+                    override fun readFrom(): ByteReadChannel = ch
+                    override val contentType: ContentType = ContentType.Application.OctetStream
+                }
+
+                launch {
+                    var wcRemaining = data.size
+                    var offset = 0
+                    while (wcRemaining > 0) {
+                        // random write sizes
+                        val wc = minOf(wcRemaining, Random.nextInt(256, 8 * 1024))
+                        val slice = data.sliceArray(offset until offset + wc)
+                        ch.writeFully(slice)
+                        offset += wc
+                        wcRemaining -= wc
+
+                        if (wcRemaining % 256 == 0) {
+                            delay(Random.nextLong(0, 10))
+                        }
+                    }
+                }.invokeOnCompletion { cause ->
+                    ch.close(cause)
+                }
+
+                call.respond(content)
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Redirects.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Redirects.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+import io.ktor.application.*
+import io.ktor.response.*
+import io.ktor.routing.*
+
+internal fun Application.redirectTests() {
+    routing {
+        route("/redirect") {
+            get("/permanent") {
+                call.respondRedirect("/redirect/moved", permanent = true)
+            }
+
+            get("/found") {
+                call.respondRedirect("/redirect/moved", permanent = false)
+            }
+
+            get("/moved") {
+                call.respondText("OK")
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Uploads.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Uploads.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.suite
+
+import aws.smithy.kotlin.runtime.util.Sha256
+import aws.smithy.kotlin.runtime.util.encodeToHex
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+
+private const val CHUNK_SIZE = 1024 * 8
+
+internal fun Application.uploadTests() {
+    routing {
+        route("upload") {
+            post("content") {
+                val contentSha = Sha256()
+                val ch = call.request.receiveChannel()
+
+                val buffer = ByteArray(CHUNK_SIZE)
+                while (!ch.isClosedForRead || ch.availableForRead > 0) {
+                    val rc = ch.readAvailable(buffer, 0, buffer.size)
+                    if (rc <= 0) break
+
+                    val slice = if (rc == buffer.size) buffer else buffer.sliceArray(0 until rc)
+                    contentSha.update(slice)
+                }
+
+                call.response.header("content-sha256", contentSha.digest().encodeToHex())
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTestJVM.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTestJVM.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.util
+
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.ktor.KtorEngine
+import aws.smithy.kotlin.runtime.http.sdkHttpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+
+actual abstract class AbstractEngineTest actual constructor() {
+    actual fun testEngines(block: EngineTestBuilder.() -> Unit) {
+        engines().forEach { engine ->
+            val client = sdkHttpClient(engine)
+            testWithClient(client, block = block)
+        }
+    }
+
+    private fun engines(): List<HttpClientEngine> = listOf(
+        KtorEngine()
+    )
+}
+
+actual fun runBlockingTest(
+    context: CoroutineContext,
+    timeout: Duration?,
+    block: suspend CoroutineScope.() -> Unit
+) {
+    runBlocking(context) {
+        if (timeout != null) {
+            withTimeout(timeout) {
+                block()
+            }
+        } else {
+            block()
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTestJVM.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTestJVM.kt
@@ -7,27 +7,18 @@ package aws.smithy.kotlin.runtime.http.test.util
 
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.engine.ktor.KtorEngine
-import aws.smithy.kotlin.runtime.http.sdkHttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 
-actual abstract class AbstractEngineTest actual constructor() {
-    actual fun testEngines(block: EngineTestBuilder.() -> Unit) {
-        engines().forEach { engine ->
-            val client = sdkHttpClient(engine)
-            testWithClient(client, block = block)
-        }
-    }
-
-    private fun engines(): List<HttpClientEngine> = listOf(
+internal actual fun engines(): List<HttpClientEngine> =
+    listOf(
         KtorEngine()
     )
-}
 
-actual fun runBlockingTest(
+internal actual fun runBlockingTest(
     context: CoroutineContext,
     timeout: Duration?,
     block: suspend CoroutineScope.() -> Unit

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.test.util
 
+import aws.smithy.kotlin.runtime.http.test.suite.downloadTests
 import io.ktor.application.*
 import io.ktor.request.*
 import io.ktor.response.*
@@ -55,6 +56,7 @@ internal fun startServer(): Closeable {
 // configure the test server routes
 internal fun Application.testRoutes() {
     redirectTests()
+    downloadTests()
 
     routing {
         post("/echo") {

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.test.util
+
+import io.ktor.application.*
+import io.ktor.request.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import redirectTests
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+private const val DEFAULT_PORT = 8082
+
+private class Resources : Closeable {
+    private val resources = mutableListOf<Closeable>()
+
+    fun add(resource: Closeable) {
+        resources.add(resource)
+    }
+
+    override fun close() {
+        resources.forEach(Closeable::close)
+    }
+}
+
+/**
+ * Entry point used by Gradle to startup the shared local test server
+ */
+internal fun startServer(): Closeable {
+    val servers = Resources()
+    println("starting local server for HTTP client engine test suite")
+
+    try {
+        val server = embeddedServer(CIO, DEFAULT_PORT) {
+            testRoutes()
+        }.start()
+
+        servers.add(Closeable { server.stop(0L, 0L, TimeUnit.MILLISECONDS) })
+
+        // ensure server is up and listening before tests run
+        Thread.sleep(500)
+    } catch (ex: Exception) {
+        servers.close()
+    }
+
+    return servers
+}
+
+// configure the test server routes
+internal fun Application.testRoutes() {
+    redirectTests()
+
+    routing {
+        post("/echo") {
+            val response = call.receiveText()
+            call.respond(response)
+        }
+    }
+}

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
@@ -50,6 +50,7 @@ internal fun startServer(): Closeable {
         Thread.sleep(500)
     } catch (ex: Exception) {
         servers.close()
+        throw ex
     }
 
     return servers
@@ -61,11 +62,4 @@ internal fun Application.testRoutes() {
     downloadTests()
     uploadTests()
     concurrentTests()
-
-    routing {
-        post("/echo") {
-            val response = call.receiveText()
-            call.respond(response)
-        }
-    }
 }

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.test.util
 
+import aws.smithy.kotlin.runtime.http.test.suite.concurrentTests
 import aws.smithy.kotlin.runtime.http.test.suite.downloadTests
 import aws.smithy.kotlin.runtime.http.test.suite.uploadTests
 import io.ktor.application.*
@@ -59,6 +60,7 @@ internal fun Application.testRoutes() {
     redirectTests()
     downloadTests()
     uploadTests()
+    concurrentTests()
 
     routing {
         post("/echo") {

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/util/TestServer.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.http.test.util
 
 import aws.smithy.kotlin.runtime.http.test.suite.downloadTests
+import aws.smithy.kotlin.runtime.http.test.suite.uploadTests
 import io.ktor.application.*
 import io.ktor.request.*
 import io.ktor.response.*
@@ -57,6 +58,7 @@ internal fun startServer(): Closeable {
 internal fun Application.testRoutes() {
     redirectTests()
     downloadTests()
+    uploadTests()
 
     routing {
         post("/echo") {

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/SdkHttpClient.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/SdkHttpClient.kt
@@ -11,6 +11,7 @@ import aws.smithy.kotlin.runtime.http.engine.createCallContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpCall
+import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.io.Handler
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
@@ -35,7 +36,7 @@ fun sdkHttpClient(
 class SdkHttpClient(
     val engine: HttpClientEngine,
     private val manageEngine: Boolean = false
-) : HttpHandler {
+) : HttpHandler, Closeable {
     private val closed = atomic(false)
 
     suspend fun call(request: HttpRequest): HttpCall = executeWithCallContext(request)
@@ -54,7 +55,7 @@ class SdkHttpClient(
     /**
      * Shutdown this HTTP client and close any resources. The client will no longer be capable of making requests.
      */
-    fun close() {
+    override fun close() {
         if (!closed.compareAndSet(false, true)) return
         if (manageEngine) {
             engine.close()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(":runtime:serde:serde-form-url")
 include(":runtime:protocol:http")
 include(":runtime:protocol:http-test")
 include(":runtime:protocol:http-client-engines:http-client-engine-ktor")
+include(":runtime:protocol:http-client-engines:test-suite")
 
 include(":tests")
 include(":tests:benchmarks:serde-benchmarks-codegen")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #552 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Provide a common HTTP client engine test suite that all supported engines can test against. These tests run against a real local server that is spun up (from Gradle) before the tests run. Each KMP target will have to provide an instance of `AbstractEngineTest` that iterates over supported engines for that target. 

This initial set of tests is based on adapting tests we already have spread out over the Ktor and CRT engine tests. I expect that over time we will expand this test suite as we find more behaviors that we want to ensure are upheld across different engines. 

Possible future expansions:
* TLS / H2 tests
* Proxy tests
Both require quite a bit more thought/work to provide the necessary local test server instances. We may be better off writing TLS tests against e.g. badssl.com (which CRT uses FWIW).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
