### PR TITLE
chore: add convenience function for decoding URL components

### DIFF
--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
@@ -129,3 +129,13 @@ public fun String.splitAsQueryString(): Map<String, List<String>> {
         }
     return entries
 }
+
+private val percentEncodedParam = """%([A-Fa-f0-9]{2})""".toRegex()
+
+/**
+ * Decode a URL's query string, resolving percent-encoding (e.g., "%3B" → ";").
+ */
+@InternalApi
+public fun String.urlDecodeComponent(): String = this
+    .replace('+', ' ')
+    .replace(percentEncodedParam) { it.groupValues[1].toInt(radix = 16).toChar().toString() }

--- a/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
+++ b/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
@@ -112,4 +112,11 @@ class TextTest {
             actualValueWithEquals.shouldContain(entry.key, entry.value)
         }
     }
+
+    @Test
+    fun decodeUrlComponent() {
+        val component = "a%3Bb+c%7Ed%20e%2Bf"
+        val expected = "a;b c~d e+f"
+        assertEquals(expected, component.urlDecodeComponent())
+    }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adds a convenience function for decoding strings as URL components, necessary for a new unit test in [aws-sdk-kotlin#556](https://github.com/awslabs/aws-sdk-kotlin/pull/556).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
