### PR TITLE
fix: respect hostname immutability in endpoints to disable host prefixing

### DIFF
--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -31,7 +31,12 @@ class ResolveEndpoint(
 @InternalApi
 fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
     val hostPrefix = req.context.getOrNull(HttpOperationContext.HostPrefix)
-    val hostname = if (hostPrefix != null) "${hostPrefix}${endpoint.uri.host}" else endpoint.uri.host
+    val hostname = if (hostPrefix != null && !endpoint.isHostnameImmutable) {
+        "$hostPrefix${endpoint.uri.host}"
+    } else {
+        endpoint.uri.host
+    }
+
     req.subject.url.scheme = endpoint.uri.scheme
     req.subject.url.host = hostname
     req.subject.url.port = endpoint.uri.port

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -101,6 +101,22 @@ class ResolveEndpointTest {
     }
 
     @Test
+    fun testSkipHostPrefixForImmutableHostnames() = runTest {
+        val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
+        val endpoint = Endpoint(uri = Url.parse("http://api.test.com"), isHostnameImmutable = true)
+        val resolver = EndpointResolver { endpoint }
+        op.install(ResolveEndpoint(resolver))
+        op.context[HttpOperationContext.HostPrefix] = "prefix."
+
+        op.roundTrip(client, Unit)
+        val actual = op.context[HttpOperationContext.HttpCallList].first().request
+
+        assertEquals("api.test.com", actual.url.host)
+        assertEquals(Protocol.HTTP, actual.url.scheme)
+        assertEquals("/operation", actual.url.path)
+    }
+
+    @Test
     fun testEndpointPathPrefixWithNonEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix/"))


### PR DESCRIPTION
## Issue \#

Closes #609 

## Description of changes

[`Endpoint`](https://github.com/awslabs/smithy-kotlin/blob/58d464299e33e7e3c44e0ae563ce033c4e85ca01/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/Endpoint.kt#L32) has an `isHostnameImmutable` flag but its value is never used anywhere. This PR updates endpoint resolution to skip hostname prefixing if this flag is set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
