### PR TITLE
chore: add additional XML escaping test to verify correct serialization of non-ASCII characters

### DIFF
--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
@@ -96,6 +96,23 @@ class XmlStreamWriterTest {
         }
     }
 
+    @Test
+    fun itHandlesNonAsciiCharacters() {
+        val tag = "textTest"
+        val payload = (0..1023).map(Int::toChar).joinToString("")
+
+        val writer = xmlStreamWriter()
+        writer.startTag(tag)
+        writer.text(payload)
+        writer.endTag(tag)
+        val serialized = writer.bytes
+
+        val reader = xmlStreamReader(serialized)
+        reader.nextToken() // opening tag
+        val textToken = reader.nextToken() as XmlToken.Text
+        assertEquals(payload, textToken.value)
+    }
+
     /**
      * The set of EOL characters and their corresponding escaped form are:
      *


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#547](https://github.com/awslabs/aws-sdk-kotlin/issues/547).

## Description of changes

This change adds an explicit test to verify the handling of non-ASCII characters. This was previously a problem when using XmlPull for serialization but has since been fixed by the completely rewritten parser.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
