### PR TITLE
fix: remove maxTime from StandardRetryStrategy

### DIFF
--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter.kt
@@ -25,7 +25,9 @@ import kotlin.time.DurationUnit
  *
  * @param options The configuration to use for this delayer.
  */
-class ExponentialBackoffWithJitter(val options: ExponentialBackoffWithJitterOptions) : DelayProvider {
+class ExponentialBackoffWithJitter(
+    val options: ExponentialBackoffWithJitterOptions = ExponentialBackoffWithJitterOptions.Default
+) : DelayProvider {
     private val random = Random.Default
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -23,7 +23,7 @@ private const val MS_PER_S = 1_000
  * @param clock A clock to use for time calculations.
  */
 class StandardRetryTokenBucket(
-    val options: StandardRetryTokenBucketOptions,
+    val options: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions.Default,
     private val clock: Clock = Clock.System,
 ) : RetryTokenBucket {
     internal var capacity = options.maxCapacity

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.*
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 class StandardRetryIntegrationTest {
@@ -30,7 +29,7 @@ class StandardRetryIntegrationTest {
         val testCases = standardRetryIntegrationTestCases
             .mapValues { Yaml.default.decodeFromString(TestCase.serializer(), it.value) }
         testCases.forEach { (name, tc) ->
-            val options = StandardRetryStrategyOptions(maxTime = Duration.INFINITE, maxAttempts = tc.given.maxAttempts)
+            val options = StandardRetryStrategyOptions(maxAttempts = tc.given.maxAttempts)
             val tokenBucket = StandardRetryTokenBucket(
                 StandardRetryTokenBucketOptions.Default.copy(
                     maxCapacity = tc.given.initialRetryTokens,

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
@@ -263,24 +263,9 @@ object KotlinClientRuntimeConfigProperty {
                 strategy.
             """.trimIndent()
 
-            val retryStrategyBlock = """
-                run {
-                    val strategyOptions = StandardRetryStrategyOptions.Default
-                    val tokenBucket = StandardRetryTokenBucket(StandardRetryTokenBucketOptions.Default)
-                    val delayer = ExponentialBackoffWithJitter(ExponentialBackoffWithJitterOptions.Default)
-                    StandardRetryStrategy(strategyOptions, tokenBucket, delayer)
-                }
-            """.trimIndent()
-            propertyType = ClientConfigPropertyType.ConstantValue(retryStrategyBlock)
+            propertyType = ClientConfigPropertyType.ConstantValue("StandardRetryStrategy()")
 
-            additionalImports = listOf(
-                RuntimeTypes.Core.Retries.StandardRetryStrategy,
-                RuntimeTypes.Core.Retries.StandardRetryStrategyOptions,
-                RuntimeTypes.Core.Retries.Delay.StandardRetryTokenBucket,
-                RuntimeTypes.Core.Retries.Delay.StandardRetryTokenBucketOptions,
-                RuntimeTypes.Core.Retries.Delay.ExponentialBackoffWithJitter,
-                RuntimeTypes.Core.Retries.Delay.ExponentialBackoffWithJitterOptions,
-            )
+            additionalImports = listOf(RuntimeTypes.Core.Retries.StandardRetryStrategy)
         }
 
         SdkLogMode = ClientConfigProperty {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGenerator.kt
@@ -34,7 +34,7 @@ private fun KotlinWriter.renderRetryStrategy(wi: WaiterInfo, asValName: String) 
         }
         write("val delay = ExponentialBackoffWithJitter(delayOptions)")
         write("")
-        write("val waiterOptions = StandardRetryStrategyOptions(maxTime = 300.#T, maxAttempts = 20)", KotlinTypes.Time.seconds)
+        write("val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)")
         write("StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)")
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -43,12 +43,7 @@ class Config private constructor(builder: Builder): HttpClientConfig, Idempotenc
     val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
-    val retryStrategy: RetryStrategy = run {
-        val strategyOptions = StandardRetryStrategyOptions.Default
-        val tokenBucket = StandardRetryTokenBucket(StandardRetryTokenBucketOptions.Default)
-        val delayer = ExponentialBackoffWithJitter(ExponentialBackoffWithJitterOptions.Default)
-        StandardRetryStrategy(strategyOptions, tokenBucket, delayer)
-    }
+    val retryStrategy: RetryStrategy = StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
 """
         contents.shouldContainWithDiff(expectedProps)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -87,7 +87,7 @@ class ServiceWaitersGeneratorTest {
                 )
                 val delay = ExponentialBackoffWithJitter(delayOptions)
             
-                val waiterOptions = StandardRetryStrategyOptions(maxTime = 300.seconds, maxAttempts = 20)
+                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
                 StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
             }
         """.formatForTest()

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
@@ -37,7 +37,7 @@ class WaiterGeneratorTest {
                 )
                 val delay = ExponentialBackoffWithJitter(delayOptions)
 
-                val waiterOptions = StandardRetryStrategyOptions(maxTime = 300.seconds, maxAttempts = 20)
+                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
                 StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
             }
         """.formatForTest()
@@ -56,7 +56,7 @@ class WaiterGeneratorTest {
                 )
                 val delay = ExponentialBackoffWithJitter(delayOptions)
 
-                val waiterOptions = StandardRetryStrategyOptions(maxTime = 300.seconds, maxAttempts = 20)
+                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
                 StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
             }
         """.formatForTest()


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes: https://github.com/awslabs/aws-sdk-kotlin/issues/572

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Removes a maximum per/operation timeout from the StandardRetryStrategy. There is no sensible default for this timeout since an operation could involve a large request stream. It also subjected operations to timeout in highly concurrent environments with lots of coroutines if the coroutine was starved and just didn't get a chance to run.

Users can still impose timeouts for any given operation with the built-in `withTimeout` functionality, e.g.

```kotlin

// timeout for the whole operation to complete (including all retries)
withTimeout(myTimeout) {
    client.fooOperation(...)
}


// timeout for a waiter to complete
withTimeout(myTimeout) {
    client.waitForFooExist(...)
}
```

Waiters were previously hard coded to 5 min as an absolute timeout. This appears to be arbitrary and nothing in the waiter spec dictates a maximum timeout configuration option. Waiters will still be bounded by maximum attempts (which transitively places an upper bound on time).

I also did a minor cleanup and set defaults for the `StandardRetryStrategy` such that we don't have to codegen the options, token bucket, and delay provider when they don't need to deviate from the default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
