### PR TITLE
fix: set Content-Type header on empty bodies with Ktor if canonical request includes it

### DIFF
--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
@@ -45,16 +45,21 @@ internal class KtorRequestAdapter(
         // strip content type header which Ktor doesn't allow set this way for some reason
         val contentHeaders = builder.headers["Content-Type"]
         builder.headers.remove("Content-Type")
-        val contentType: ContentType? = contentHeaders?.let { ContentType.parse(it) }
+        val contentType: ContentType? = contentHeaders?.let(ContentType::parse)
 
         // convert the request body
-        when (val body = sdkRequest.body) {
-            is HttpBody.Empty -> builder.body = EmptyContent
-            is HttpBody.Bytes -> builder.body = ByteArrayContent(body.bytes(), contentType)
-            is HttpBody.Streaming -> builder.body = proxyRequestStream(body, contentType)
+        builder.body = when (val body = sdkRequest.body) {
+            is HttpBody.Empty -> emptyContent(contentType)
+            is HttpBody.Bytes -> ByteArrayContent(body.bytes(), contentType)
+            is HttpBody.Streaming -> proxyRequestStream(body, contentType)
         }
 
         return builder
+    }
+
+    private fun emptyContent(contentType: ContentType?) = object : OutgoingContent.NoContent() {
+        override val contentLength: Long = 0
+        override val contentType = contentType
     }
 
     @OptIn(ExperimentalStdlibApi::class)

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.http.engine.ktor
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
-import io.ktor.client.utils.EmptyContent
 import io.ktor.http.*
 import io.ktor.http.content.ByteArrayContent
 import io.ktor.http.content.OutgoingContent

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/test/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapterTest.kt
@@ -16,9 +16,7 @@ import io.ktor.utils.io.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 import io.ktor.content.ByteArrayContent as KtorByteArrayContent
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -29,7 +27,11 @@ class KtorRequestAdapterTest {
         sdkBuilder.url { host = "test.aws.com" }
         sdkBuilder.header("Content-Type", "application/json")
         val actual = KtorRequestAdapter(sdkBuilder, coroutineContext).toBuilder()
-        actual.headers.contains("Content-Type").shouldBeFalse()
+        assertFalse("Content-Type" in actual.headers)
+
+        val body = actual.body
+        assertIs<OutgoingContent.NoContent>(body)
+        assertEquals(ContentType.parse("application/json"), body.contentType)
     }
 
     @Test

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Uploads.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Uploads.kt
@@ -31,6 +31,7 @@ internal fun Application.uploadTests() {
                 }
 
                 call.response.header("content-sha256", contentSha.digest().encodeToHex())
+                call.request.headers["Content-Type"]?.let { call.response.header("request-content-type", it) }
                 call.respond(HttpStatusCode.OK)
             }
         }


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#588](https://github.com/awslabs/aws-sdk-kotlin/issues/588)

## Description of changes

This change fixes a bug that omitted `Content-Type` (when set) from empty-body requests for the Ktor engine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
