### PR TITLE
chore: bump 0.8.6-SNAPSHOT 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.8.5] - 04/21/2022
+
+### Fixes
+* set Content-Type header on empty bodies with Ktor if canonical request includes it [#630](https://github.com/awslabs/smithy-kotlin/pull/630)
+* coroutine leak in ktor engine [#628](https://github.com/awslabs/smithy-kotlin/pull/628)
+
+## [0.8.4] - 04/21/2022
+
+NOTE: Do not use. No difference from 0.8.3
+
 ## [0.8.3] - 04/14/2022
 
 ### Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
 # SDK
-sdkVersion=0.8.4-SNAPSHOT
+sdkVersion=0.8.5
 
 # kotlin
 kotlinVersion=1.6.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
 # SDK
-sdkVersion=0.8.5
+sdkVersion=0.8.6-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.6.10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Why 0.8.5? Glad you asked...0.8.4 was accidentally released without a refresh from `main` so 0.8.4 and 0.8.3 are the same.

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
