### PR TITLE
feat: convert html to markdown for improved dokka readability

### DIFF
--- a/.changes/74cc4273-d134-4b61-9f78-2ed740f3bd9a.json
+++ b/.changes/74cc4273-d134-4b61-9f78-2ed740f3bd9a.json
@@ -1,0 +1,8 @@
+{
+    "id": "74cc4273-d134-4b61-9f78-2ed740f3bd9a",
+    "type": "bugfix",
+    "description": "Convert HTML to Markdown for improved Dokka compatibility.",
+    "issues": [
+        "awslabs/smithy-kotlin#136"
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ coroutinesVersion=1.6.0
 ktorVersion=1.6.7
 atomicFuVersion=0.17.0
 kotlinxSerializationVersion=1.3.0
+jsoupVersion=1.14.1
 
 # codegen
 smithyVersion=1.17.0

--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -20,6 +20,7 @@ val smithyVersion: String by project
 val kotlinVersion: String by project
 val junitVersion: String by project
 val kotestVersion: String by project
+val jsoupVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
@@ -27,7 +28,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
-    implementation("org.jsoup:jsoup:1.14.1")
+    implementation("org.jsoup:jsoup:$jsoupVersion")
 
     // Test dependencies
     // These are not set as test dependencies so they can be shared with other modules

--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    implementation("org.jsoup:jsoup:1.14.1")
 
     // Test dependencies
     // These are not set as test dependencies so they can be shared with other modules

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -194,7 +194,7 @@ class KotlinWriter(
      * Clean/escape any content from the doc that would invalidate the Kotlin output.
      */
     private fun cleanForWriter(doc: String) = doc
-        // Docs can have valid $ characters that shouldn't run through formatters.
+        // Docs can have valid # characters that shouldn't run through formatters.
         .replace("#", "##")
         // Services may have comment string literals embedded in documentation.
         .replace("/*", "&##47;*")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -184,11 +184,21 @@ class KotlinWriter(
     fun dokka(docs: String): KotlinWriter =
         dokka {
             write(
-                formatDocumentation(
-                    sanitizeDocumentation(docs)
+                cleanForWriter(
+                    formatDocumentation(docs)
                 )
             )
         }
+
+    /**
+     * Clean/escape any content from the doc that would invalidate the Kotlin output.
+     */
+    private fun cleanForWriter(doc: String) = doc
+        // Docs can have valid $ characters that shouldn't run through formatters.
+        .replace("#", "##")
+        // Services may have comment string literals embedded in documentation.
+        .replace("/*", "&##47;*")
+        .replace("*/", "*&##47;")
 
     /**
      * Adds appropriate annotations to generated declarations.
@@ -341,36 +351,6 @@ class InlineKotlinWriterFormatter(private val parent: KotlinWriter) : BiFunction
     }
 }
 
-// Most commonly occurring (but not exhaustive) set of HTML tags found in AWS models
-private val commonHtmlTags = setOf(
-    "a",
-    "b",
-    "code",
-    "dd",
-    "dl",
-    "dt",
-    "i",
-    "important",
-    "li",
-    "note",
-    "p",
-    "strong",
-    "ul"
-).map { listOf("<$it>", "</$it>") }.flatten()
-
-// Replace characters in the input documentation to prevent issues in codegen or rendering.
-// NOTE: Currently we look for specific strings of Html tags commonly found in docs
-//       and remove them.  A better solution would be to generally convert from HTML to "pure"
-//       markdown such that formatting is preserved.
-// TODO: https://github.com/awslabs/smithy-kotlin/issues/136
-private fun sanitizeDocumentation(doc: String): String = doc
-    .stripAll(commonHtmlTags)
-    // Docs can have valid $ characters that shouldn't run through formatters.
-    .replace("#", "##")
-    // Services may have comment string literals embedded in documentation.
-    .replace("/*", "&##47;*")
-    .replace("*/", "*&##47;")
-
 // Remove all strings from source string and return the result
 private fun String.stripAll(stripList: List<String>): String {
     var newStr = this
@@ -379,7 +359,6 @@ private fun String.stripAll(stripList: List<String>): String {
     return newStr
 }
 
-// Remove whitespace from the beginning and end of each line of documentation
 // Remove leading, trailing, and consecutive blank lines
 private fun formatDocumentation(doc: String, lineSeparator: String = "\n") =
     doc
@@ -387,7 +366,7 @@ private fun formatDocumentation(doc: String, lineSeparator: String = "\n") =
         .dropWhile { it.isBlank() } // Drop leading blank lines
         .dropLastWhile { it.isBlank() } // Drop trailing blank lines
         .dropConsecutive { it.isBlank() } // Remove consecutive empty lines
-        .joinToString(separator = lineSeparator) { it.trim() } // Trim line
+        .joinToString(separator = lineSeparator)
 
 /**
  * Filters out consecutive items matching the given [predicate].

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -10,6 +10,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import org.jsoup.select.NodeVisitor
+import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.model.Model
@@ -222,7 +223,7 @@ private fun String.applyWithin(start: String, end: String, transform: (String) -
 
     val stringToTransform = substring(substringStart, substringEnd)
     if (stringToTransform.indexOf(start) != -1) {
-        throw RuntimeException("string contains nested start delimiter")
+        throw CodegenException("string contains nested start delimiter")
     }
 
     return substring(0, substringStart) + transform(stringToTransform) + end +

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -11,8 +11,15 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.transform.ModelTransformer
 
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import org.jsoup.select.NodeTraversor
+import org.jsoup.select.NodeVisitor
+
 /**
- * Sanitize all instances of [DocumentationTrait]
+ * Sanitize all instances of [DocumentationTrait] and converts them to KDoc-compliant strings.
  */
 class DocumentationPreprocessor : KotlinIntegration {
 
@@ -21,7 +28,13 @@ class DocumentationPreprocessor : KotlinIntegration {
         return transformer.mapTraits(model) { _, trait ->
             when (trait) {
                 is DocumentationTrait -> {
-                    val docs = sanitize(trait.value)
+                    // There's definitely some improperly escaped HTML characters within preformat blocks in existing
+                    // models. Ensure we strip those now, the parser is VERY forgiving and will mistreat any sequences
+                    // of characters that happen to form tags as such.
+                    val sanitizedDoc = trait.value
+                        .applyWithin("<code>", "</code>", String::escapeHtml)
+                        .applyWithin("<pre>", "</pre>", String::escapeHtml)
+                    val docs = toKdoc(sanitizedDoc)
                     DocumentationTrait(docs, trait.sourceLocation)
                 }
                 else -> trait
@@ -29,9 +42,211 @@ class DocumentationPreprocessor : KotlinIntegration {
         }
     }
 
-    // KDoc comments use inline markdown. Replace square brackets with escaped equivalents so that they
-    // are not rendered as invalid links
-    private fun sanitize(str: String): String =
-        str.replace("[", "&#91;")
-            .replace("]", "&#93;")
+    private fun toKdoc(doc: String): String {
+        val parsed = parseClean(doc)
+
+        val renderer = MarkdownRenderer()
+        parsed.body().traverse(renderer)
+        return renderer.text
+    }
+
+    private fun parseClean(rawDoc: String): Document {
+        val parsed = Jsoup.parse(rawDoc)
+
+        parsed.body().stripBlankTextNodes()
+
+        return parsed
+    }
+
+    private class MarkdownRenderer : NodeVisitor {
+        companion object {
+            const val SUBLIST_INDENT = "   "
+            const val PREFORMAT_MARKER = "`"
+            const val BOLD_MARKER = "**"
+            const val ITALIC_MARKER = "*"
+        }
+
+        var text: String = ""
+            private set
+
+        private var bufferedAnchorHref: String = ""
+        private var bufferedAnchorText: String = ""
+        private var listPrefix: String = ""
+
+        override fun head(node: Node, depth: Int) {
+            if (node is TextNode) {
+                if (node.parentNode()?.nodeName() == "a")
+                    bufferedAnchorText = node.markdownText()
+                else
+                    text += node.markdownText()
+                return
+            }
+
+            when (node.nodeName()) {
+                "a" -> {
+                    if (node.hasAttr(("href"))) {
+                        bufferedAnchorHref = node.attr("href")
+                    }
+                }
+                "li" -> {
+                    // If this list item holds a sublist, then we essentially just want to line break right away and
+                    // render the nested list as normal.
+                    val prefix = if (node.childNode(0).nodeName() == "ul") "\n" else ""
+                    text += "$listPrefix+ $prefix"
+                }
+                "code", "pre" -> {
+                    text += PREFORMAT_MARKER
+                }
+                "b", "strong" -> {
+                    text += BOLD_MARKER
+                }
+                "i", "em" -> {
+                    text += ITALIC_MARKER
+                }
+                "ul", "ol" -> {
+                    if (node.hasAncestor(Node::isList)) {
+                        sublistIndent()
+                    }
+                }
+                "br" -> {
+                    text += "\n"
+                }
+                "dt" -> {
+                    // Definition lists (dl, dt, dd) have a corresponding md syntax, but neither intellij nor dokka will
+                    // render them. Treat definition terms as a "header" and let the descriptions flow out like
+                    // normal markdown content.
+                    text += "## "
+                }
+                "fullname" -> {
+                    // Anecdotally this appears to be used to render a "title" display - it always appears at the start
+                    // of documents.
+                    text += "# "
+                }
+                "body", "p", "note", "important", "dd", "dl", "div" -> {
+                    // Known elements that we can ignore here - they have no bearing on the output.
+                }
+                else -> {
+                    // Occasionally there will be unescaped angle brackets within elements. Those tags will sometimes
+                    // join to form "elements" that will trick the rather forgiving Jsoup parser, eg.
+                    // "<p>specify the URI in the form 's3://<bucket_name>/</p>"
+                    // The safest approach to malformed input like this is just to write out the content as-is, such
+                    // that no information is destroyed. The worst outcome is that some seemingly nonsense HTML tag is
+                    // injected into the output, which a reader can reasonably ignore.
+                    text += "<${node.nodeName()}>"
+                }
+            }
+        }
+
+        override fun tail(node: Node, depth: Int) {
+            when (node.nodeName()) {
+                "p", "div", "dd" -> {
+                    val nextSibling = node.nextSibling()
+                    text += when {
+                        // break to give the upcoming list a new line
+                        (nextSibling != null && nextSibling.isList()) -> "\n"
+                        // if we're inside a list, the outer list item will close out the line for us
+                        (node.hasAncestor(Node::isList)) -> ""
+                        // all other cases: this is a standalone "text block" which should be displayed as its own
+                        // paragraph
+                        else -> "\n\n"
+                    }
+                }
+                "a" -> {
+                    writeBufferedAnchor()
+                }
+                "ul", "ol" -> {
+                    sublistDedent()
+                    text += if (node.parent()?.nodeName()  == "body") "\n\n" else ""
+                }
+                "code", "pre" -> {
+                    text += PREFORMAT_MARKER
+                }
+                "b", "strong" -> {
+                    text += BOLD_MARKER
+                }
+                "i", "em" -> {
+                    text += ITALIC_MARKER
+                }
+                "li", "fullname", "dt" -> {
+                    text += "\n"
+                }
+            }
+        }
+
+        private fun writeBufferedAnchor() {
+            // Model docs will sometimes contain an anchor without the href. At that point there's no real way of
+            // knowing to what it refers, nor can we guarantee a valid link just by bracketing it.
+            text += if (bufferedAnchorHref != "") {
+                "[$bufferedAnchorText]($bufferedAnchorHref)"
+            } else {
+                bufferedAnchorText
+            }
+
+            bufferedAnchorHref = ""
+            bufferedAnchorText = ""
+        }
+
+        private fun sublistIndent() {
+            listPrefix += SUBLIST_INDENT
+        }
+
+        private fun sublistDedent() {
+            listPrefix = listPrefix.dropLast(SUBLIST_INDENT.length)
+        }
+    }
 }
+
+/**
+ * Jsoup will preserve newlines between elements as blank text nodes. These have zero bearing on the content of the
+ * document to begin with and only serve to complicate traversal.
+ */
+private fun Node.stripBlankTextNodes() {
+    if (this is TextNode && this.isBlank) {
+        this.remove()
+        return
+    }
+
+    val childNodes = this.childNodes()
+    if (childNodes.isNotEmpty()) {
+        childNodes.forEach(Node::stripBlankTextNodes)
+    }
+}
+
+private fun Node.hasAncestor(predicate: (Node) -> Boolean): Boolean {
+    if (!this.hasParent()) return false
+
+    val parent = this.parent() as Node
+    return predicate(parent) || parent.hasAncestor(predicate)
+}
+
+private fun Node.isList() =
+    this.nodeName() == "ul" || this.nodeName() == "ol"
+
+private fun TextNode.markdownText() =
+    this.text()
+        // Replace square brackets with escaped equivalents so that they are not rendered as invalid Markdown
+        // links.
+        .replace("[", "&#91;")
+        .replace("]", "&#93;")
+
+/**
+ * Operates on all substrings that fall within the provided section delimiters. Returns a new string where all
+ * substrings enclosed as specified have been modified according to the provided transform.
+ */
+private fun String.applyWithin(start: String, end: String, transform: (String) -> String): String {
+    val substringStart = this.indexOf(start) + start.length
+    if (substringStart == -1) return this
+
+    val substringEnd = this.indexOf(end, substringStart)
+    if (substringEnd == -1) return this
+
+    val stringToTransform = this.substring(substringStart, substringEnd)
+    return this.substring(0, substringStart) + transform(stringToTransform) + end +
+        this.substring(substringEnd + end.length).applyWithin(start, end, transform)
+}
+
+private fun String.escapeHtml() =
+    this
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -45,7 +45,7 @@ class DocumentationPreprocessor : KotlinIntegration {
 
         val renderer = MarkdownRenderer()
         parsed.body().traverse(renderer)
-        return renderer.text
+        return renderer.text()
     }
 
     private fun parseClean(rawDoc: String): Document {
@@ -64,19 +64,20 @@ class DocumentationPreprocessor : KotlinIntegration {
             const val ITALIC_MARKER = "*"
         }
 
-        var text: String = ""
-            private set
+        private var builder: StringBuilder = StringBuilder()
 
         private var bufferedAnchorHref: String = ""
         private var bufferedAnchorText: String = ""
         private var listPrefix: String = ""
+
+        fun text() = builder.toString().trim()
 
         override fun head(node: Node, depth: Int) {
             if (node is TextNode) {
                 if (node.parentNode()?.nodeName() == "a") {
                     bufferedAnchorText = node.markdownText()
                 } else {
-                    text += node.markdownText()
+                    builder.append(node.markdownText())
                 }
                 return
             }
@@ -91,48 +92,38 @@ class DocumentationPreprocessor : KotlinIntegration {
                     // If this list item holds a sublist, then we essentially just want to line break right away and
                     // render the nested list as normal.
                     val prefix = if (node.childNode(0).nodeName() == "ul") "\n" else ""
-                    text += "$listPrefix+ $prefix"
-                }
-                "code", "pre" -> {
-                    text += PREFORMAT_MARKER
-                }
-                "b", "strong" -> {
-                    text += BOLD_MARKER
-                }
-                "i", "em" -> {
-                    text += ITALIC_MARKER
+                    builder.append("$listPrefix+ $prefix")
                 }
                 "ul", "ol" -> {
                     if (node.hasAncestor(Node::isList)) {
                         sublistIndent()
                     }
                 }
-                "br" -> {
-                    text += "\n"
-                }
-                "dt" -> {
-                    // Definition lists (dl, dt, dd) have a corresponding md syntax, but neither intellij nor dokka will
-                    // render them. Treat definition terms as a "header" and let the descriptions flow out like
-                    // normal markdown content.
-                    text += "## "
-                }
-                "fullname" -> {
-                    // Anecdotally this appears to be used to render a "title" display - it always appears at the start
-                    // of documents.
-                    text += "# "
-                }
+                "code", "pre" -> builder.append(PREFORMAT_MARKER)
+                "b", "strong" -> builder.append(BOLD_MARKER)
+                "i", "em" -> builder.append(ITALIC_MARKER)
+                "br" -> builder.ensureLineBreak()
+
+                // Definition lists (dl, dt, dd) have a corresponding md syntax, but neither intellij nor dokka will
+                // render them. Treat definition terms as a "header" and let the descriptions flow out like
+                // normal markdown content.
+                "dt" -> builder.append("## ")
+
+                // Anecdotally this appears to be used to render a "title" display - it always appears at the start
+                // of documents.
+                "fullname" -> builder.append("# ")
+
                 "body", "p", "note", "important", "dd", "dl", "div" -> {
                     // Known elements that we can ignore here - they have no bearing on the output.
                 }
-                else -> {
-                    // Occasionally there will be unescaped angle brackets within elements. Those tags will sometimes
-                    // join to form "elements" that will trick the rather forgiving Jsoup parser, eg.
-                    // "<p>specify the URI in the form 's3://<bucket_name>/</p>"
-                    // The safest approach to malformed input like this is just to write out the content as-is, such
-                    // that no information is destroyed. The worst outcome is that some seemingly nonsense HTML tag is
-                    // injected into the output, which a reader can reasonably ignore.
-                    text += "<${node.nodeName()}>"
-                }
+
+                // Occasionally there will be unescaped angle brackets within elements. Those tags will sometimes
+                // join to form "elements" that will trick the rather forgiving Jsoup parser, eg.
+                // "<p>specify the URI in the form 's3://<bucket_name>/</p>"
+                // The safest approach to malformed input like this is just to write out the content as-is, such
+                // that no information is destroyed. The worst outcome is that some seemingly nonsense HTML tag is
+                // injected into the output, which a reader can reasonably ignore.
+                else -> builder.append("<${node.nodeName()}>")
             }
         }
 
@@ -140,46 +131,40 @@ class DocumentationPreprocessor : KotlinIntegration {
             when (node.nodeName()) {
                 "p", "div", "dd" -> {
                     val nextSibling = node.nextSibling()
-                    text += when {
+                    when {
                         // break to give the upcoming list a new line
-                        (nextSibling != null && nextSibling.isList()) -> "\n"
+                        nextSibling != null && nextSibling.isList() -> builder.ensureLineBreak()
                         // if we're inside a list, the outer list item will close out the line for us
-                        (node.hasAncestor(Node::isList)) -> ""
+                        node.hasAncestor(Node::isList) -> return
                         // all other cases: this is a standalone "text block" which should be displayed as its own
                         // paragraph
-                        else -> "\n\n"
+                        else -> builder.ensureSectionBreak()
                     }
                 }
-                "a" -> {
-                    writeBufferedAnchor()
-                }
+                "a" -> writeBufferedAnchor()
                 "ul", "ol" -> {
                     sublistDedent()
-                    text += if (node.parent()?.nodeName() == "body") "\n\n" else ""
+                    if (node.parent()?.nodeName() == "body") {
+                        builder.ensureSectionBreak()
+                    }
                 }
-                "code", "pre" -> {
-                    text += PREFORMAT_MARKER
-                }
-                "b", "strong" -> {
-                    text += BOLD_MARKER
-                }
-                "i", "em" -> {
-                    text += ITALIC_MARKER
-                }
-                "li", "fullname", "dt" -> {
-                    text += "\n"
-                }
+                "code", "pre" -> builder.append(PREFORMAT_MARKER)
+                "b", "strong" -> builder.append(BOLD_MARKER)
+                "i", "em" -> builder.append(ITALIC_MARKER)
+                "li", "fullname", "dt" -> builder.ensureLineBreak()
             }
         }
 
         private fun writeBufferedAnchor() {
             // Model docs will sometimes contain an anchor without the href. At that point there's no real way of
             // knowing to what it refers, nor can we guarantee a valid link just by bracketing it.
-            text += if (bufferedAnchorHref != "") {
-                "[$bufferedAnchorText]($bufferedAnchorHref)"
-            } else {
-                bufferedAnchorText
-            }
+            builder.append(
+                if (bufferedAnchorHref != "") {
+                    "[$bufferedAnchorText]($bufferedAnchorHref)"
+                } else {
+                    bufferedAnchorText
+                }
+            )
 
             bufferedAnchorHref = ""
             bufferedAnchorText = ""
@@ -200,29 +185,22 @@ class DocumentationPreprocessor : KotlinIntegration {
  * document to begin with and only serve to complicate traversal.
  */
 private fun Node.stripBlankTextNodes() {
-    if (this is TextNode && this.isBlank) {
-        this.remove()
+    if (this is TextNode && isBlank) {
+        remove()
         return
     }
 
-    val childNodes = this.childNodes()
-    if (childNodes.isNotEmpty()) {
-        childNodes.forEach(Node::stripBlankTextNodes)
-    }
+    childNodes().forEach(Node::stripBlankTextNodes)
 }
 
-private fun Node.hasAncestor(predicate: (Node) -> Boolean): Boolean {
-    if (!this.hasParent()) return false
-
-    val parent = this.parent() as Node
-    return predicate(parent) || parent.hasAncestor(predicate)
-}
+private fun Node.hasAncestor(predicate: (Node) -> Boolean): Boolean =
+    parent()?.let { predicate(it) || it.hasAncestor(predicate) } == true
 
 private fun Node.isList() =
-    this.nodeName() == "ul" || this.nodeName() == "ol"
+    nodeName().let { it == "ul" || it == "ol" }
 
 private fun TextNode.markdownText() =
-    this.text()
+    text()
         // Replace square brackets with escaped equivalents so that they are not rendered as invalid Markdown
         // links.
         .replace("[", "&#91;")
@@ -231,21 +209,43 @@ private fun TextNode.markdownText() =
 /**
  * Operates on all substrings that fall within the provided section delimiters. Returns a new string where all
  * substrings enclosed as specified have been modified according to the provided transform.
+ *
+ * This extension is not intended to handle nested sections, and will throw if it encounters any.
  */
 private fun String.applyWithin(start: String, end: String, transform: (String) -> String): String {
-    val substringStart = this.indexOf(start) + start.length
-    if (substringStart == -1) return this
+    val startIndex = indexOf(start)
+    if (startIndex == -1) return this
 
-    val substringEnd = this.indexOf(end, substringStart)
+    val substringStart = indexOf(start) + start.length
+    val substringEnd = indexOf(end, substringStart)
     if (substringEnd == -1) return this
 
-    val stringToTransform = this.substring(substringStart, substringEnd)
-    return this.substring(0, substringStart) + transform(stringToTransform) + end +
-        this.substring(substringEnd + end.length).applyWithin(start, end, transform)
+    val stringToTransform = substring(substringStart, substringEnd)
+    if (stringToTransform.indexOf(start) != -1) {
+        throw RuntimeException("string contains nested start delimiter")
+    }
+
+    return substring(0, substringStart) + transform(stringToTransform) + end +
+        substring(substringEnd + end.length).applyWithin(start, end, transform)
 }
 
 private fun String.escapeHtml() =
-    this
-        .replace("&", "&amp;")
+    replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
+
+private fun StringBuilder.ensureLineBreak() {
+    if (!endsWith("\n")) {
+        appendLine()
+    }
+}
+
+private fun StringBuilder.ensureSectionBreak() {
+    if (endsWith("\n\n")) return
+
+    if (endsWith("\n")) {
+        appendLine()
+    } else {
+        append("\n\n")
+    }
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -5,18 +5,16 @@
 
 package software.amazon.smithy.kotlin.codegen.lang
 
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import org.jsoup.select.NodeVisitor
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.transform.ModelTransformer
-
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Node
-import org.jsoup.nodes.TextNode
-import org.jsoup.select.NodeTraversor
-import org.jsoup.select.NodeVisitor
 
 /**
  * Sanitize all instances of [DocumentationTrait] and converts them to KDoc-compliant strings.
@@ -75,10 +73,11 @@ class DocumentationPreprocessor : KotlinIntegration {
 
         override fun head(node: Node, depth: Int) {
             if (node is TextNode) {
-                if (node.parentNode()?.nodeName() == "a")
+                if (node.parentNode()?.nodeName() == "a") {
                     bufferedAnchorText = node.markdownText()
-                else
+                } else {
                     text += node.markdownText()
+                }
                 return
             }
 
@@ -156,7 +155,7 @@ class DocumentationPreprocessor : KotlinIntegration {
                 }
                 "ul", "ol" -> {
                     sublistDedent()
-                    text += if (node.parent()?.nodeName()  == "body") "\n\n" else ""
+                    text += if (node.parent()?.nodeName() == "body") "\n\n" else ""
                 }
                 "code", "pre" -> {
                     text += PREFORMAT_MARKER

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -124,10 +124,10 @@ class PaginatorGenerator : KotlinIntegration {
         writer
             .dokka(
                 """
-                    $docBody
-                    @param initialRequest A [${inputSymbol.name}] to start pagination
-                    $docReturn
-                """.trimIndent()
+                    |$docBody
+                    |@param initialRequest A [${inputSymbol.name}] to start pagination
+                    |$docReturn
+                """.trimMargin()
             )
             .addImportReferences(cursorSymbol, SymbolReference.ContextOption.DECLARE)
             .withBlock(
@@ -162,10 +162,10 @@ class PaginatorGenerator : KotlinIntegration {
         writer
             .dokka(
                 """
-                    $docBody
-                    @param block A builder block used for DSL-style invocation of the operation
-                    $docReturn
-                """.trimIndent()
+                    |$docBody
+                    |@param block A builder block used for DSL-style invocation of the operation
+                    |$docReturn
+                """.trimMargin()
             )
             .withBlock(
                 "fun #T.#LPaginated(block: #T.Builder.() -> #T): #T<#T> =",

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -48,15 +48,6 @@ class KotlinWriterTest {
     }
 
     @Test
-    fun `it strips html tags from doc strings`() {
-        val unit = KotlinWriter(TestModelDefault.NAMESPACE)
-        val docs = "<p>here is <b>some</b> sweet <i>sweet</i> <a>html</a></p>"
-        unit.dokka(docs)
-        val actual = unit.toString()
-        actual.shouldContainOnlyOnceWithDiff("here is some sweet sweet html")
-    }
-
-    @Test
     fun `it disambiguates type names`() {
         val unit = KotlinWriter(TestModelDefault.NAMESPACE)
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -68,4 +68,493 @@ class DocumentationPreprocessorTest {
             assertEquals(expected, docs)
         }
     }
+
+    @Test
+    fun `it renders paragraphs`() {
+        val input = "<p>this is paragraph</p><div>this too is paragraph</div>"
+        val expected = """
+        this is paragraph
+        
+        this too is paragraph
+        
+        
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it renders lists`() {
+        val input = "<p>the listed items are as follows:</p><ul><li>item 1</li><li><p>item 2<p><ol><li>subitem 1</li></ol></li></ul>"
+        val expected = """
+        the listed items are as follows:
+        + item 1
+        + item 2
+           + subitem 1
+        
+        
+        
+        
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it renders basic formatters`() {
+        val input = "<strong>bold text</strong><br/><em>italic text</em>"
+        val expected = """
+        **bold text**
+        *italic text*
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it renders code block as-is`() {
+        val input = "<code>handleXml(\"<xml><elem1/><elem2>child</elem2></xml>\");</code>"
+        val expected = "`handleXml(\"<xml><elem1/><elem2>child</elem2></xml>\");`"
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it handles anchors with and without href`() {
+        val input = "<p>for more information see <a href=\"link.com\">this link</a></p><p>also reference <a>NoRefAnchor</a>"
+        val expected = """
+        for more information see [this link](link.com)
+        
+        also reference NoRefAnchor
+        
+        
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it renders headers`() {
+        val input = "<fullname>FooService</fullname><p>a service that is itself</p><dt>section 1</dt><dd>section 1 details</dd>"
+        val expected = """
+        # FooService
+        a service that is itself
+        
+        ## section 1
+        section 1 details
+        
+        
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it renders nested structures`() {
+        val input = "<fullname>FooService</fullname>" +
+                "<p>a service that is itself</p>" +
+                "<p>methods are as follows:</p>" +
+                "<ul>" +
+                "<li><strong>IMPORTANT</strong> do not use: <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html\">CreateBucket</a></li>" +
+                "</ul>"
+        val expected = """
+        # FooService
+        a service that is itself
+        
+        methods are as follows:
+        + **IMPORTANT** do not use: [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)
+        
+        
+        
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
+    fun `it fully renders S3 CreateMultipartUpload`() {
+        val input = """
+<p>This action initiates a multipart upload and returns an upload ID. This upload ID is
+used to associate all of the parts in the specific multipart upload. You specify this
+upload ID in each of your subsequent upload part requests (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>). You also include this
+upload ID in the final request to either complete or abort the multipart upload
+request.</p>
+
+<p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a>.</p>
+
+<p>If you have configured a lifecycle rule to abort incomplete multipart uploads, the
+upload must complete within the number of days specified in the bucket lifecycle
+configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort
+action and Amazon S3 aborts the multipart upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
+Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
+
+<p>For information about the permissions required to use the multipart upload API, see
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+Permissions</a>.</p>
+
+<p>For request signing, multipart upload is just a series of regular requests. You initiate
+a multipart upload, send one or more requests to upload parts, and then complete the
+multipart upload process. You sign each request individually. There is nothing special
+about signing multipart upload requests. For more information about signing, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
+Requests (Amazon Web Services Signature Version 4)</a>.</p>
+
+<note>
+<p> After you initiate a multipart upload and upload one or more parts, to stop being
+charged for storing the uploaded parts, you must either complete or abort the multipart
+upload. Amazon S3 frees up the space used to store the parts and stop charging you for
+storing them only after you either complete or abort a multipart upload. </p>
+</note>
+
+<p>You can optionally request server-side encryption. For server-side encryption, Amazon S3
+encrypts your data as it writes it to disks in its data centers and decrypts it when you
+access it. You can provide your own encryption key, or use Amazon Web Services KMS keys or Amazon S3-managed encryption keys. If you choose to provide
+your own encryption key, the request headers you provide in <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> requests must match the headers you used in the request to
+initiate the upload by using <code>CreateMultipartUpload</code>. </p>
+<p>To perform a multipart upload with encryption using an Amazon Web Services KMS key, the requester must
+have permission to the <code>kms:Decrypt</code> and <code>kms:GenerateDataKey*</code>
+actions on the key. These permissions are required because Amazon S3 must decrypt and read data
+from the encrypted file parts before it completes the multipart upload. For more
+information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions">Multipart upload API
+and permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+
+<p>If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account
+as the KMS key, then you must have these permissions on the key policy. If your IAM
+user or role belongs to a different account than the key, then you must have the
+permissions on both the key policy and your IAM user or role.</p>
+
+<p> For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting
+Data Using Server-Side Encryption</a>.</p>
+
+<dl>
+<dt>Access Permissions</dt>
+<dd>
+<p>When copying an object, you can optionally specify the accounts or groups that
+should be granted specific permissions on the new object. There are two ways to
+grant the permissions using the request headers:</p>
+<ul>
+<li>
+<p>Specify a canned ACL with the <code>x-amz-acl</code> request header. For
+more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+</li>
+<li>
+<p>Specify access permissions explicitly with the
+<code>x-amz-grant-read</code>, <code>x-amz-grant-read-acp</code>,
+<code>x-amz-grant-write-acp</code>, and
+<code>x-amz-grant-full-control</code> headers. These parameters map to
+the set of permissions that Amazon S3 supports in an ACL. For more information,
+see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+Overview</a>.</p>
+</li>
+</ul>
+<p>You can use either a canned ACL or specify access permissions explicitly. You
+cannot do both.</p>
+</dd>
+<dt>Server-Side- Encryption-Specific Request Headers</dt>
+<dd>
+<p>You can optionally tell Amazon S3 to encrypt data at rest using server-side
+encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts
+your data as it writes it to disks in its data centers and decrypts it when you
+access it. The option you use depends on whether you want to use Amazon Web Services managed
+encryption keys or provide your own encryption key. </p>
+<ul>
+<li>
+<p>Use encryption keys managed by Amazon S3 or customer managed key stored
+in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys
+used to encrypt data, specify the following headers in the request.</p>
+<ul>
+<li>
+<p>
+<code>x-amz-server-side-encryption</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-server-side-encryption-aws-kms-key-id</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-server-side-encryption-context</code>
+</p>
+</li>
+</ul>
+<note>
+<p>If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but
+don't provide <code>x-amz-server-side-encryption-aws-kms-key-id</code>,
+Amazon S3 uses the Amazon Web Services managed key in Amazon Web Services KMS to protect the data.</p>
+</note>
+<important>
+<p>All GET and PUT requests for an object protected by Amazon Web Services KMS fail if
+you don't make them with SSL or by using SigV4.</p>
+</important>
+<p>For more information about server-side encryption with KMS key (SSE-KMS),
+see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with KMS keys</a>.</p>
+</li>
+<li>
+<p>Use customer-provided encryption keys – If you want to manage your own
+encryption keys, provide all the following headers in the request.</p>
+<ul>
+<li>
+<p>
+<code>x-amz-server-side-encryption-customer-algorithm</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-server-side-encryption-customer-key</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-server-side-encryption-customer-key-MD5</code>
+</p>
+</li>
+</ul>
+<p>For more information about server-side encryption with KMS keys (SSE-KMS),
+see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with KMS keys</a>.</p>
+</li>
+</ul>
+</dd>
+<dt>Access-Control-List (ACL)-Specific Request Headers</dt>
+<dd>
+<p>You also can use the following access control–related headers with this
+operation. By default, all objects are private. Only the owner has full access
+control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added
+to the access control list (ACL) on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. With this
+operation, you can grant access permissions using one of the following two
+methods:</p>
+<ul>
+<li>
+<p>Specify a canned ACL (<code>x-amz-acl</code>) — Amazon S3 supports a set of
+predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
+has a predefined set of grantees and permissions. For more information, see
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
+ACL</a>.</p>
+</li>
+<li>
+<p>Specify access permissions explicitly — To explicitly grant access
+permissions to specific Amazon Web Services accounts or groups, use the following headers.
+Each header maps to specific permissions that Amazon S3 supports in an ACL. For
+more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access
+Control List (ACL) Overview</a>. In the header, you specify a list of
+grantees who get the specific permission. To grant permissions explicitly,
+use:</p>
+<ul>
+<li>
+<p>
+<code>x-amz-grant-read</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-grant-write</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-grant-read-acp</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-grant-write-acp</code>
+</p>
+</li>
+<li>
+<p>
+<code>x-amz-grant-full-control</code>
+</p>
+</li>
+</ul>
+<p>You specify each grantee as a type=value pair, where the type is one of
+the following:</p>
+<ul>
+<li>
+<p>
+<code>id</code> – if the value specified is the canonical user ID
+of an Amazon Web Services account</p>
+</li>
+<li>
+<p>
+<code>uri</code> – if you are granting permissions to a predefined
+group</p>
+</li>
+<li>
+<p>
+<code>emailAddress</code> – if the value specified is the email
+address of an Amazon Web Services account</p>
+<note>
+<p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
+<ul>
+<li>
+<p>US East (N. Virginia)</p>
+</li>
+<li>
+<p>US West (N. California)</p>
+</li>
+<li>
+<p> US West (Oregon)</p>
+</li>
+<li>
+<p> Asia Pacific (Singapore)</p>
+</li>
+<li>
+<p>Asia Pacific (Sydney)</p>
+</li>
+<li>
+<p>Asia Pacific (Tokyo)</p>
+</li>
+<li>
+<p>Europe (Ireland)</p>
+</li>
+<li>
+<p>South America (São Paulo)</p>
+</li>
+</ul>
+<p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+</note>
+</li>
+</ul>
+<p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
+<p>
+<code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
+</p>
+</li>
+</ul>
+
+</dd>
+</dl>
+
+<p>The following operations are related to <code>CreateMultipartUpload</code>:</p>
+<ul>
+<li>
+<p>
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+</p>
+</li>
+<li>
+<p>
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+</p>
+</li>
+<li>
+<p>
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+</p>
+</li>
+<li>
+<p>
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+</p>
+</li>
+<li>
+<p>
+<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+</p>
+</li>
+</ul>
+"""
+val expected = """This action initiates a multipart upload and returns an upload ID. This upload ID is used to associate all of the parts in the specific multipart upload. You specify this upload ID in each of your subsequent upload part requests (see [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)). You also include this upload ID in the final request to either complete or abort the multipart upload request.
+
+For more information about multipart uploads, see [Multipart Upload Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html).
+
+If you have configured a lifecycle rule to abort incomplete multipart uploads, the upload must complete within the number of days specified in the bucket lifecycle configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort action and Amazon S3 aborts the multipart upload. For more information, see [Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config).
+
+For information about the permissions required to use the multipart upload API, see [Multipart Upload and Permissions](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html).
+
+For request signing, multipart upload is just a series of regular requests. You initiate a multipart upload, send one or more requests to upload parts, and then complete the multipart upload process. You sign each request individually. There is nothing special about signing multipart upload requests. For more information about signing, see [Authenticating Requests (Amazon Web Services Signature Version 4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
+
+ After you initiate a multipart upload and upload one or more parts, to stop being charged for storing the uploaded parts, you must either complete or abort the multipart upload. Amazon S3 frees up the space used to store the parts and stop charging you for storing them only after you either complete or abort a multipart upload. 
+
+You can optionally request server-side encryption. For server-side encryption, Amazon S3 encrypts your data as it writes it to disks in its data centers and decrypts it when you access it. You can provide your own encryption key, or use Amazon Web Services KMS keys or Amazon S3-managed encryption keys. If you choose to provide your own encryption key, the request headers you provide in [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html) and [UploadPartCopy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html) requests must match the headers you used in the request to initiate the upload by using `CreateMultipartUpload`. 
+
+To perform a multipart upload with encryption using an Amazon Web Services KMS key, the requester must have permission to the `kms:Decrypt` and `kms:GenerateDataKey*` actions on the key. These permissions are required because Amazon S3 must decrypt and read data from the encrypted file parts before it completes the multipart upload. For more information, see [Multipart upload API and permissions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions) in the *Amazon S3 User Guide*.
+
+If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account as the KMS key, then you must have these permissions on the key policy. If your IAM user or role belongs to a different account than the key, then you must have the permissions on both the key policy and your IAM user or role.
+
+ For more information, see [Protecting Data Using Server-Side Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
+
+## Access Permissions
+When copying an object, you can optionally specify the accounts or groups that should be granted specific permissions on the new object. There are two ways to grant the permissions using the request headers:
++ Specify a canned ACL with the `x-amz-acl` request header. For more information, see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
++ Specify access permissions explicitly with the `x-amz-grant-read`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers. These parameters map to the set of permissions that Amazon S3 supports in an ACL. For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+You can use either a canned ACL or specify access permissions explicitly. You cannot do both.
+
+
+
+## Server-Side- Encryption-Specific Request Headers
+You can optionally tell Amazon S3 to encrypt data at rest using server-side encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts your data as it writes it to disks in its data centers and decrypts it when you access it. The option you use depends on whether you want to use Amazon Web Services managed encryption keys or provide your own encryption key. 
++ Use encryption keys managed by Amazon S3 or customer managed key stored in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys used to encrypt data, specify the following headers in the request.
+   + `x-amz-server-side-encryption`
+   + `x-amz-server-side-encryption-aws-kms-key-id`
+   + `x-amz-server-side-encryption-context`
+If you specify `x-amz-server-side-encryption:aws:kms`, but don't provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3 uses the Amazon Web Services managed key in Amazon Web Services KMS to protect the data.All GET and PUT requests for an object protected by Amazon Web Services KMS fail if you don't make them with SSL or by using SigV4.For more information about server-side encryption with KMS key (SSE-KMS), see [Protecting Data Using Server-Side Encryption with KMS keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
++ Use customer-provided encryption keys – If you want to manage your own encryption keys, provide all the following headers in the request.
+   + `x-amz-server-side-encryption-customer-algorithm`
+   + `x-amz-server-side-encryption-customer-key`
+   + `x-amz-server-side-encryption-customer-key-MD5`
+For more information about server-side encryption with KMS keys (SSE-KMS), see [Protecting Data Using Server-Side Encryption with KMS keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+
+
+## Access-Control-List (ACL)-Specific Request Headers
+You also can use the following access control–related headers with this operation. By default, all objects are private. Only the owner has full access control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added to the access control list (ACL) on the object. For more information, see [Using ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html). With this operation, you can grant access permissions using one of the following two methods:
++ Specify a canned ACL (`x-amz-acl`) — Amazon S3 supports a set of predefined ACLs, known as *canned ACLs*. Each canned ACL has a predefined set of grantees and permissions. For more information, see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
++ Specify access permissions explicitly — To explicitly grant access permissions to specific Amazon Web Services accounts or groups, use the following headers. Each header maps to specific permissions that Amazon S3 supports in an ACL. For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html). In the header, you specify a list of grantees who get the specific permission. To grant permissions explicitly, use:
+   + `x-amz-grant-read`
+   + `x-amz-grant-write`
+   + `x-amz-grant-read-acp`
+   + `x-amz-grant-write-acp`
+   + `x-amz-grant-full-control`
+You specify each grantee as a type=value pair, where the type is one of the following:
+   + `id` – if the value specified is the canonical user ID of an Amazon Web Services account
+   + `uri` – if you are granting permissions to a predefined group
+   + `emailAddress` – if the value specified is the email address of an Amazon Web Services accountUsing email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: 
+      + US East (N. Virginia)
+      + US West (N. California)
+      +  US West (Oregon)
+      +  Asia Pacific (Singapore)
+      + Asia Pacific (Sydney)
+      + Asia Pacific (Tokyo)
+      + Europe (Ireland)
+      + South America (São Paulo)
+For a list of all the Amazon S3 supported Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in the Amazon Web Services General Reference.
+For example, the following `x-amz-grant-read` header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:`x-amz-grant-read: id="11112222333", id="444455556666" `
+
+
+The following operations are related to `CreateMultipartUpload`:
++ [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
++ [CompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)
++ [AbortMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html)
++ [ListParts](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html)
++ [ListMultipartUploads](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html)
+
+
+"""
+        inputTest(input, expected)
+    }
+
+    private fun inputTest(input: String, expected: String) {
+        val sanitizedInput = input
+            .replace("\n", " ")
+            .replace("\"", "\\\"")
+
+        val model = """
+        namespace com.test
+        
+        @documentation("$sanitizedInput")
+        service FooService {
+            version: "1.0.0"
+        }
+        """.toSmithyModel()
+
+        val settings = KotlinSettings(
+            ShapeId.from("com.test#FooService"),
+            KotlinSettings.PackageSettings(
+                "test",
+                "1.0",
+                ""
+            ),
+            "Foo"
+        )
+
+        val integration = DocumentationPreprocessor()
+        val modified = integration.preprocessModel(model, settings)
+
+        val shape = modified.expectShape(ShapeId.from("com.test#FooService"))
+        val docs = shape.expectTrait<DocumentationTrait>().value
+        assertEquals(expected, docs)
+    }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.DocumentationTrait
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class DocumentationPreprocessorTest {
     @Test
@@ -76,8 +77,6 @@ class DocumentationPreprocessorTest {
         this is paragraph
         
         this too is paragraph
-        
-        
         """.trimIndent()
         inputTest(input, expected)
     }
@@ -90,10 +89,6 @@ class DocumentationPreprocessorTest {
         + item 1
         + item 2
            + subitem 1
-        
-        
-        
-        
         """.trimIndent()
         inputTest(input, expected)
     }
@@ -116,14 +111,20 @@ class DocumentationPreprocessorTest {
     }
 
     @Test
+    fun `it throws on nested unescaped code blocks`() {
+        val input = "<code>handleXml(\"<xml> <code></code> </xml>\");</code>"
+        assertFailsWith<RuntimeException> {
+            inputTest(input, "")
+        }
+    }
+
+    @Test
     fun `it handles anchors with and without href`() {
         val input = "<p>for more information see <a href=\"link.com\">this link</a></p><p>also reference <a>NoRefAnchor</a>"
         val expected = """
         for more information see [this link](link.com)
         
         also reference NoRefAnchor
-        
-        
         """.trimIndent()
         inputTest(input, expected)
     }
@@ -137,8 +138,6 @@ class DocumentationPreprocessorTest {
         
         ## section 1
         section 1 details
-        
-        
         """.trimIndent()
         inputTest(input, expected)
     }
@@ -157,9 +156,6 @@ class DocumentationPreprocessorTest {
         
         methods are as follows:
         + **IMPORTANT** do not use: [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html)
-        
-        
-        
         """.trimIndent()
         inputTest(input, expected)
     }
@@ -473,8 +469,6 @@ When copying an object, you can optionally specify the accounts or groups that s
 + Specify access permissions explicitly with the `x-amz-grant-read`, `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers. These parameters map to the set of permissions that Amazon S3 supports in an ACL. For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 You can use either a canned ACL or specify access permissions explicitly. You cannot do both.
 
-
-
 ## Server-Side- Encryption-Specific Request Headers
 You can optionally tell Amazon S3 to encrypt data at rest using server-side encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts your data as it writes it to disks in its data centers and decrypts it when you access it. The option you use depends on whether you want to use Amazon Web Services managed encryption keys or provide your own encryption key. 
 + Use encryption keys managed by Amazon S3 or customer managed key stored in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys used to encrypt data, specify the following headers in the request.
@@ -487,7 +481,6 @@ If you specify `x-amz-server-side-encryption:aws:kms`, but don't provide `x-amz-
    + `x-amz-server-side-encryption-customer-key`
    + `x-amz-server-side-encryption-customer-key-MD5`
 For more information about server-side encryption with KMS keys (SSE-KMS), see [Protecting Data Using Server-Side Encryption with KMS keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
 
 ## Access-Control-List (ACL)-Specific Request Headers
 You also can use the following access control–related headers with this operation. By default, all objects are private. Only the owner has full access control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added to the access control list (ACL) on the object. For more information, see [Using ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html). With this operation, you can grant access permissions using one of the following two methods:
@@ -513,16 +506,12 @@ You specify each grantee as a type=value pair, where the type is one of the foll
 For a list of all the Amazon S3 supported Regions and endpoints, see [Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in the Amazon Web Services General Reference.
 For example, the following `x-amz-grant-read` header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:`x-amz-grant-read: id="11112222333", id="444455556666" `
 
-
 The following operations are related to `CreateMultipartUpload`:
 + [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
 + [CompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html)
 + [AbortMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html)
 + [ListParts](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html)
-+ [ListMultipartUploads](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html)
-
-
-"""
++ [ListMultipartUploads](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html)"""
         inputTest(input, expected)
     }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.lang
 
+import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
@@ -113,7 +114,7 @@ class DocumentationPreprocessorTest {
     @Test
     fun `it throws on nested unescaped code blocks`() {
         val input = "<code>handleXml(\"<xml> <code></code> </xml>\");</code>"
-        assertFailsWith<RuntimeException> {
+        assertFailsWith<CodegenException> {
             inputTest(input, "")
         }
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -146,11 +146,11 @@ class DocumentationPreprocessorTest {
     @Test
     fun `it renders nested structures`() {
         val input = "<fullname>FooService</fullname>" +
-                "<p>a service that is itself</p>" +
-                "<p>methods are as follows:</p>" +
-                "<ul>" +
-                "<li><strong>IMPORTANT</strong> do not use: <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html\">CreateBucket</a></li>" +
-                "</ul>"
+            "<p>a service that is itself</p>" +
+            "<p>methods are as follows:</p>" +
+            "<ul>" +
+            "<li><strong>IMPORTANT</strong> do not use: <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html\">CreateBucket</a></li>" +
+            "</ul>"
         val expected = """
         # FooService
         a service that is itself
@@ -447,7 +447,7 @@ address of an Amazon Web Services account</p>
 </li>
 </ul>
 """
-val expected = """This action initiates a multipart upload and returns an upload ID. This upload ID is used to associate all of the parts in the specific multipart upload. You specify this upload ID in each of your subsequent upload part requests (see [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)). You also include this upload ID in the final request to either complete or abort the multipart upload request.
+        val expected = """This action initiates a multipart upload and returns an upload ID. This upload ID is used to associate all of the parts in the specific multipart upload. You specify this upload ID in each of your subsequent upload part requests (see [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)). You also include this upload ID in the final request to either complete or abort the multipart upload request.
 
 For more information about multipart uploads, see [Multipart Upload Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html).
 


### PR DESCRIPTION
## Issue \#
#136 

## Description of changes
Convert commonmark/html to kdoc/markdown such that formatting of original model docs aren't destroyed in the Kotlin output.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
