### PR TITLE
chore: add new AWS signer benchmarks

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ include(":runtime:utils")
 include(":smithy-kotlin-codegen")
 
 include(":tests")
+include(":tests:benchmarks:aws-signing-benchmarks")
 include(":tests:benchmarks:serde-benchmarks-codegen")
 include(":tests:benchmarks:serde-benchmarks")
 include(":tests:compile")

--- a/tests/benchmarks/aws-signing-benchmarks/README.md
+++ b/tests/benchmarks/aws-signing-benchmarks/README.md
@@ -1,0 +1,24 @@
+# Serde Benchmarks
+
+This project contains benchmarks for the [AWS signer implementations](../../runtime/auth).
+
+## Testing
+
+```sh
+./gradlew :tests:benchmarks:aws-signing-benchmarks:benchmark
+```
+
+Baseline `0.9.0-beta` on EC2 **[m5.4xlarge](https://aws.amazon.com/ec2/instance-types/m5/)** in **OpenJK 1.8.0_312**:
+
+```
+jvm summary:
+Benchmark                            (signerName)  Mode  Cnt   Score   Error  Units
+AwsSignerBenchmark.signingBenchmark       default  avgt    5  33.592 ± 0.103  us/op
+AwsSignerBenchmark.signingBenchmark           crt  avgt    5  38.919 ± 0.494  us/op
+```
+
+## Test data
+
+The current test data consist of [a synthetic request with a 1KB payload][request-code].
+
+[request-code]: jvm/src/aws/smithy/kotlin/benchmarks/auth/signing/AwsSignerBenchmark.kt#L25-L40

--- a/tests/benchmarks/aws-signing-benchmarks/README.md
+++ b/tests/benchmarks/aws-signing-benchmarks/README.md
@@ -1,6 +1,6 @@
 # Serde Benchmarks
 
-This project contains benchmarks for the [AWS signer implementations](../../runtime/auth).
+This project contains benchmarks for the [AWS signer implementations](../../../runtime/auth).
 
 ## Testing
 

--- a/tests/benchmarks/aws-signing-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/aws-signing-benchmarks/build.gradle.kts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+plugins {
+    kotlin("multiplatform")
+    id("org.jetbrains.kotlinx.benchmark")
+}
+
+extra.set("skipPublish", true)
+
+val platforms = listOf("common", "jvm")
+
+platforms.forEach { platform ->
+    apply(from = rootProject.file("gradle/${platform}.gradle"))
+}
+
+val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.util.InternalApi")
+
+kotlin {
+    sourceSets {
+        all {
+            val srcDir = if (name.endsWith("Main")) "src" else "test"
+            val resourcesPrefix = if (name.endsWith("Test")) "test-" else ""
+            // the name is always the platform followed by a suffix of either "Main" or "Test" (e.g. jvmMain, commonTest, etc)
+            val platform = name.substring(0, name.length - 4)
+            kotlin.srcDir("$platform/$srcDir")
+            resources.srcDir("$platform/${resourcesPrefix}resources")
+            languageSettings.progressiveMode = true
+            optinAnnotations.forEach { languageSettings.optIn(it) }
+        }
+
+        val kotlinxBenchmarkVersion: String by project
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:$kotlinxBenchmarkVersion")
+                implementation(project(":runtime:auth:aws-signing-crt"))
+                implementation(project(":runtime:auth:aws-signing-default"))
+                implementation(project(":runtime:auth:aws-signing-tests"))
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+    }
+
+    configurations {
+        getByName("main") {
+            iterations = 5
+            iterationTime = 3
+            iterationTimeUnit = "s"
+            warmups = 7
+            outputTimeUnit = "us"
+            reportFormat = "text"
+        }
+    }
+}
+
+// Workaround for https://github.com/Kotlin/kotlinx-benchmark/issues/39
+afterEvaluate {
+    tasks.named<org.gradle.jvm.tasks.Jar>("jvmBenchmarkJar") {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+}

--- a/tests/benchmarks/aws-signing-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/auth/signing/AwsSignerBenchmark.kt
+++ b/tests/benchmarks/aws-signing-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/auth/signing/AwsSignerBenchmark.kt
@@ -1,0 +1,60 @@
+package aws.smithy.kotlin.benchmarks.auth.signing
+
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSignedBodyHeader
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningConfig
+import aws.smithy.kotlin.runtime.auth.awssigning.crt.CrtAwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.testCredentialsProvider
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.Protocol
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.headers
+import aws.smithy.kotlin.runtime.http.request.url
+import kotlinx.benchmark.*
+import kotlinx.coroutines.runBlocking
+
+private const val DEFAULT_SIGNER = "default"
+private const val CRT_SIGNER = "crt"
+
+private val signers = mapOf(
+    DEFAULT_SIGNER to DefaultAwsSigner,
+    CRT_SIGNER to CrtAwsSigner,
+)
+
+private val payload = (';'..'z').joinToString("").repeat(16).encodeToByteArray() // 1KB
+
+private val requestToSign = HttpRequest {
+    method = HttpMethod.GET
+    url {
+        scheme = Protocol.HTTPS
+        host = "foo.com"
+        path = "bar/baz/../qux/"
+        port = 8080
+    }
+    headers {
+        append("Content-Type", "application/x-www-form-urlencoded")
+        append("Cache-Control", "no-cache")
+    }
+    body = HttpBody.fromBytes(payload)
+}
+
+private val config = AwsSigningConfig {
+    region = "the-moon"
+    service = "fooservice"
+    signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256
+    credentialsProvider = testCredentialsProvider
+}
+
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Benchmark)
+open class AwsSignerBenchmark {
+    @Param(DEFAULT_SIGNER, CRT_SIGNER)
+    var signerName: String = ""
+
+    @Benchmark
+    fun signingBenchmark() = runBlocking {
+        val signer = signers.getValue(signerName)
+        signer.sign(requestToSign, config)
+    }
+}


### PR DESCRIPTION
## Issue \#

Addresses #617 

## Description of changes

This change adds benchmarks to compare the new default implementation with the classic CRT implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.