### PR TITLE
feat: add support for getting all env vars and system props

### DIFF
--- a/.changes/6b06d640-19b8-4fe7-86b1-cdbebce52b33.json
+++ b/.changes/6b06d640-19b8-4fe7-86b1-cdbebce52b33.json
@@ -1,0 +1,8 @@
+{
+    "id": "6b06d640-19b8-4fe7-86b1-cdbebce52b33",
+    "type": "misc",
+    "description": "Add support for getting all env vars and system properties (i.e., not just by a single key)",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#575"
+    ]
+}

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/EnvironmentProvider.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/EnvironmentProvider.kt
@@ -8,7 +8,13 @@ package aws.smithy.kotlin.runtime.util
 /**
  * Provide a mapping from key to value
  */
-public fun interface EnvironmentProvider {
+public interface EnvironmentProvider {
+    /**
+     * Get a map of all environment variables.
+     * @return A map of string keys to string values.
+     */
+    public fun getAllEnvVars(): Map<String, String>
+
     /**
      * Get an environment variable or null
      *

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/PropertyProvider.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/PropertyProvider.kt
@@ -8,7 +8,13 @@ package aws.smithy.kotlin.runtime.util
 /**
  * Provide a mapping from (JVM) property key to value
  */
-public fun interface PropertyProvider {
+public interface PropertyProvider {
+    /**
+     * Get a map of all JVM system properties.
+     * @return A map of string keys to string values.
+     */
+    public fun getAllProperties(): Map<String, String>
+
     /**
      * Get a system property (on supported platforms)
      *

--- a/runtime/utils/jvm/src/aws/smithy/kotlin/runtime/util/PlatformJVM.kt
+++ b/runtime/utils/jvm/src/aws/smithy/kotlin/runtime/util/PlatformJVM.kt
@@ -13,6 +13,8 @@ import java.nio.file.Path
 import java.util.*
 
 public actual object Platform : PlatformProvider {
+    override fun getAllEnvVars(): Map<String, String> = System.getenv()
+
     /**
      * Get an environment variable or null
      */
@@ -42,6 +44,11 @@ public actual object Platform : PlatformProvider {
 
     suspend fun readFileOrNull(path: Path): ByteArray? = readFileOrNull(path.toAbsolutePath().toString())
     suspend fun readFileOrNull(file: File): ByteArray? = readFileOrNull(file.absolutePath)
+
+    override fun getAllProperties(): Map<String, String> = System
+        .getProperties()
+        .entries
+        .associate { (key, value) -> key.toString() to value.toString() }
 
     /**
      * Get a system property or null

--- a/runtime/utils/jvm/test/aws/smithy/kotlin/runtime/util/PlatformJVMTest.kt
+++ b/runtime/utils/jvm/test/aws/smithy/kotlin/runtime/util/PlatformJVMTest.kt
@@ -32,4 +32,21 @@ class PlatformJVMTest {
         assertNotNull(actual)
         assertEquals(fileContent, actual.decodeToString())
     }
+
+    @Test
+    fun testGetAllEnvVars() {
+        val allEnvVarsFromSystem = System.getenv()
+        val allEnvVarsFromPlatform = Platform.getAllEnvVars()
+        assertEquals(allEnvVarsFromSystem, allEnvVarsFromPlatform)
+    }
+
+    @Test
+    fun testGetAllProperties() {
+        val allPropertiesFromSystem = System
+            .getProperties()
+            .entries
+            .associate { (key, value) -> key.toString() to value.toString() }
+        val allPropertiesFromPlatform = Platform.getAllProperties()
+        assertEquals(allPropertiesFromSystem, allPropertiesFromPlatform)
+    }
 }


### PR DESCRIPTION
## Issue \#

Addresses [aws-sdk-kotlin#575](https://github.com/awslabs/aws-sdk-kotlin/issues/575)

## Description of changes

Adds support for fetching the entire maps of env variables and system properties (previously, only single values by single keys were addressable). This change was necessary to support (...link coming soon...)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.