### PR TITLE
feat: add convenience getters for union members

### DIFF
--- a/.changes/02852edb-3c2d-4f29-a1ad-5f7e1b884268.json
+++ b/.changes/02852edb-3c2d-4f29-a1ad-5f7e1b884268.json
@@ -1,0 +1,8 @@
+{
+    "id": "02852edb-3c2d-4f29-a1ad-5f7e1b884268",
+    "type": "feature",
+    "description": "Add convenience getters for union members",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#393"
+    ]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
@@ -59,6 +59,17 @@ class UnionGenerator(
         // generate the unknown which will always be last
         writer.write("object SdkUnknown : #Q()", symbol)
         writer.closeBlock("}").write("")
+
+        members.sortedBy { it.memberName }.forEach {
+            val variantName = it.unionVariantName()
+            val variantSymbol = symbolProvider.toSymbol(it)
+
+            writer.write("")
+            writer.dokka {
+                write("Casts this [#T] as a [#L] and retrieves its [#Q] value.", symbol, variantName, variantSymbol)
+            }
+            writer.write("val #T.#L get() = (this as #T.#L).value", symbol, variantName, symbol, variantName)
+        }
     }
 
     // generate a `hashCode()` implementation

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
@@ -73,6 +73,31 @@ class UnionGeneratorTest {
                 data class MyStruct(val value: test.model.MyStruct) : test.model.MyUnion()
                 object SdkUnknown : test.model.MyUnion()
             }
+            
+            /**
+             * Casts this [MyUnion] as a [Bar] and retrieves its [kotlin.Int] value.
+             */
+            val MyUnion.Bar get() = (this as MyUnion.Bar).value
+            
+            /**
+             * Casts this [MyUnion] as a [Baz] and retrieves its [kotlin.Int] value.
+             */
+            val MyUnion.Baz get() = (this as MyUnion.Baz).value
+            
+            /**
+             * Casts this [MyUnion] as a [Blz] and retrieves its [kotlin.ByteArray] value.
+             */
+            val MyUnion.Blz get() = (this as MyUnion.Blz).value
+            
+            /**
+             * Casts this [MyUnion] as a [Foo] and retrieves its [kotlin.String] value.
+             */
+            val MyUnion.Foo get() = (this as MyUnion.Foo).value
+            
+            /**
+             * Casts this [MyUnion] as a [MyStruct] and retrieves its [test.model.MyStruct] value.
+             */
+            val MyUnion.MyStruct get() = (this as MyUnion.MyStruct).value
         """.trimIndent()
 
         contents.shouldContainWithDiff(expectedClassDecl)
@@ -167,6 +192,11 @@ class UnionGeneratorTest {
                 data class Foo(val value: test.model.MyStruct) : test.model.MyUnion()
                 object SdkUnknown : test.model.MyUnion()
             }
+            
+            /**
+             * Casts this [MyUnion] as a [Foo] and retrieves its [test.model.MyStruct] value.
+             */
+            val MyUnion.Foo get() = (this as MyUnion.Foo).value
         """.trimIndent()
 
         contents.shouldContainWithDiff(expectedClassDecl)

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/SmithySdkTest.kt
@@ -31,7 +31,7 @@ class SmithySdkTest {
         val compilationResult = compileSdkAndTest(model = model, outputSink = compileOutputStream, emitSourcesToTmp = Debug.emitSourcesToTemp)
         compileOutputStream.flush()
 
-        assertEquals(compilationResult.exitCode, KotlinCompilation.ExitCode.OK, compileOutputStream.toString())
+        assertEquals(KotlinCompilation.ExitCode.OK, compilationResult.exitCode, compileOutputStream.toString())
     }
 
     // FIXME - disabled until we invest time into improving the extraneous warnings we get for things like parameter never used, etc


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#393](https://github.com/awslabs/aws-sdk-kotlin/issues/393)

## Description of changes

This change adds extension getters to unions for retrieving member values. This is useful to reduce boilerplate when working with known subtypes at compile time. For example, DDB's `AttributeValue` has subtypes `S`, `N`, `B`, etc., Users that knew the subtype at compile time needed to cast and retrieve the value like so:

```kotlin
val attr: AttributeValue = TODO()
val stringValue = (attr as AttributeValue.S).value
```

With this PR, users can now retrieve that same value with:

```kotlin
val stringValue = attr.S
```

Note that union members are title-cased in our codegen. I opted to use the same capitalization in the extension getters' names for consistency. An alternative implementation may use camel-cased names instead (e.g., `attr.s` instead of `attr.S`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.