### PR TITLE
feat: bytestream support for partial file content

### DIFF
--- a/.changes/53fe3bd1-84b5-47b2-8d75-460ab8437dcc.json
+++ b/.changes/53fe3bd1-84b5-47b2-8d75-460ab8437dcc.json
@@ -1,0 +1,8 @@
+{
+    "id": "53fe3bd1-84b5-47b2-8d75-460ab8437dcc",
+    "type": "feature",
+    "description": "Add partial-file ByteStream support.",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#530"
+    ]
+}

--- a/runtime/runtime-core/build.gradle.kts
+++ b/runtime/runtime-core/build.gradle.kts
@@ -34,6 +34,8 @@ kotlin {
 
                 val kamlVersion: String by project
                 implementation("com.charleskorn.kaml:kaml:$kamlVersion")
+
+                implementation(project(":runtime:testing"))
             }
         }
 

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -21,16 +21,26 @@ fun ByteStream.Companion.fromFile(file: File): ByteStream = file.asByteStream()
 /**
  * Create a [ByteStream] from a file
  */
-fun File.asByteStream(): ByteStream = FileContent(this)
+fun File.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
+    require(start >= 0) { "start index $start cannot be negative" }
+    require(endInclusive == -1L || endInclusive >= start) {
+        "end index $endInclusive must be greater than or equal to start index $start"
+    }
+
+    val len = length()
+    require(endInclusive < len) { "end index $endInclusive must be less than file size $len" }
+
+    return FileContent(this, start, endInclusive)
+}
 
 /**
  * Create a [ByteStream] from a path
  */
-fun Path.asByteStream(): ByteStream {
+fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
     val f = toFile()
     require(f.exists()) { "cannot create ByteStream, file does not exist: $this" }
     require(f.isFile) { "cannot create a ByteStream from a directory: $this" }
-    return f.asByteStream()
+    return f.asByteStream(start, endInclusive)
 }
 
 /**

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -21,7 +21,7 @@ fun ByteStream.Companion.fromFile(file: File): ByteStream = file.asByteStream()
 /**
  * Create a [ByteStream] from a file
  */
-fun File.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
+fun File.asByteStream(start: Long = 0, endInclusive: Long = length() - 1): ByteStream {
     require(start >= 0) { "start index $start cannot be negative" }
     require(endInclusive == -1L || endInclusive >= start) {
         "end index $endInclusive must be greater than or equal to start index $start"
@@ -32,6 +32,11 @@ fun File.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
 
     return FileContent(this, start, endInclusive)
 }
+
+/**
+ * Create a [ByteStream] from a file with the given range
+ */
+fun File.asByteStream(range: LongRange) = asByteStream(range.first, range.last)
 
 /**
  * Create a [ByteStream] from a path

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -49,6 +49,11 @@ fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
 }
 
 /**
+ * Create a [ByteStream] from a path with the given range
+ */
+fun Path.asByteStream(range: LongRange) = asByteStream(range.first, range.last)
+
+/**
  * Write the contents of this ByteStream to file and close it
  * @return the number of bytes written
  */

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
@@ -19,11 +19,7 @@ public class FileContent(
 ) : ByteStream.ReplayableStream() {
 
     override val contentLength: Long
-        get() = if (isPartial()) partialContentLength() else file.length()
-
-    private fun isPartial() = start != 0L || endInclusive != file.length() - 1
-
-    private fun partialContentLength() = endInclusive - start + 1
+        get() = endInclusive - start + 1
 
     override fun newReader(): SdkByteReadChannel = file.readChannel(start, endInclusive)
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
@@ -15,16 +15,15 @@ import java.io.File
 public class FileContent(
     public val file: File,
     public val start: Long = 0,
-    public val endInclusive: Long = -1
+    public val endInclusive: Long = file.length() - 1
 ) : ByteStream.ReplayableStream() {
 
     override val contentLength: Long
         get() = if (isPartial()) partialContentLength() else file.length()
 
-    private fun isPartial() = start != 0L || endInclusive != -1L
+    private fun isPartial() = start != 0L || endInclusive != file.length() - 1
 
-    private fun partialContentLength() =
-        if (endInclusive == -1L) file.length() - start else endInclusive - start + 1
+    private fun partialContentLength() = endInclusive - start + 1
 
     override fun newReader(): SdkByteReadChannel = file.readChannel(start, endInclusive)
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
@@ -14,10 +14,17 @@ import java.io.File
  */
 public class FileContent(
     public val file: File,
+    public val start: Long = 0,
+    public val endInclusive: Long = -1
 ) : ByteStream.ReplayableStream() {
 
     override val contentLength: Long
-        get() = file.length()
+        get() = if (isPartial()) partialContentLength() else file.length()
 
-    override fun newReader(): SdkByteReadChannel = file.readChannel()
+    private fun isPartial() = start != 0L || endInclusive != -1L
+
+    private fun partialContentLength() =
+        if (endInclusive == -1L) file.length() - start else endInclusive - start + 1
+
+    override fun newReader(): SdkByteReadChannel = file.readChannel(start, endInclusive)
 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.content
+
+import aws.smithy.kotlin.runtime.testing.RandomTempFile
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ByteStreamJVMTest {
+    @Test
+    fun `file as byte stream validates start`() = runTest {
+        val file = RandomTempFile(1024)
+        val e = assertFailsWith<Throwable> {
+            file.asByteStream(-1)
+        }
+        assertEquals("start index -1 cannot be negative", e.message)
+    }
+
+    @Test
+    fun `file as byte stream validates end`() = runTest {
+        val file = RandomTempFile(1024)
+        val e = assertFailsWith<Throwable> {
+            file.asByteStream(endInclusive = 1024)
+        }
+        assertEquals("end index 1024 must be less than file size 1024", e.message)
+    }
+
+    @Test
+    fun `file as byte stream validates start and end`() = runTest {
+        val file = RandomTempFile(1024)
+        val e = assertFailsWith<Throwable> {
+            file.asByteStream(5, 1)
+        }
+        assertEquals("end index 1 must be greater than or equal to start index 5", e.message)
+    }
+
+    @Test
+    fun `file as byte stream has contentLength`() = runTest {
+        val file = RandomTempFile(1024)
+        val stream = file.asByteStream()
+
+        assertEquals(1024, stream.contentLength)
+    }
+
+    @Test
+    fun `partial file as byte stream has contentLength`() = runTest {
+        val file = RandomTempFile(1024)
+        val stream = file.asByteStream(1, 1023)
+
+        assertEquals(1023, stream.contentLength)
+    }
+
+    @Test
+    fun `partial file as byte stream has contentLength with implicit end`() = runTest {
+        val file = RandomTempFile(1024)
+        val stream = file.asByteStream(1)
+
+        assertEquals(1023, stream.contentLength)
+    }
+
+    @Test
+    fun `file as byte stream matches read`() = runTest {
+        val file = RandomTempFile(1024)
+
+        val expected = file.readBytes()
+        val actual = file.asByteStream().toByteArray()
+
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun `partial file as byte stream matches read`() = runTest {
+        val file = RandomTempFile(1024)
+
+        val expected = file.readBytes()
+        val part0 = file.asByteStream(endInclusive = 255).toByteArray()
+        val part1 = file.asByteStream(256, 511).toByteArray()
+        val part2 = file.asByteStream(512).toByteArray()
+
+        assertContentEquals(expected, part0 + part1 + part2)
+    }
+}

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
@@ -84,4 +84,16 @@ class ByteStreamJVMTest {
 
         assertContentEquals(expected, part0 + part1 + part2)
     }
+
+    @Test
+    fun `partial file as byte stream using range`() = runTest {
+        val file = RandomTempFile(1024)
+
+        val expected = file.readBytes()
+        val part0 = file.asByteStream(0L..255L).toByteArray()
+        val part1 = file.asByteStream(256L..511L).toByteArray()
+        val part2 = file.asByteStream(512L until file.length()).toByteArray()
+
+        assertContentEquals(expected, part0 + part1 + part2)
+    }
 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
@@ -96,4 +96,30 @@ class ByteStreamJVMTest {
 
         assertContentEquals(expected, part0 + part1 + part2)
     }
+
+    @Test
+    fun `partial path as byte stream`() = runTest {
+        val file = RandomTempFile(1024)
+        val path = file.toPath()
+
+        val expected = file.readBytes()
+        val part0 = path.asByteStream(endInclusive = 255).toByteArray()
+        val part1 = path.asByteStream(256, 511).toByteArray()
+        val part2 = path.asByteStream(512).toByteArray()
+
+        assertContentEquals(expected, part0 + part1 + part2)
+    }
+
+    @Test
+    fun `partial path as byte stream using range`() = runTest {
+        val file = RandomTempFile(1024)
+        val path = file.toPath()
+
+        val expected = file.readBytes()
+        val part0 = path.asByteStream(0L..255L).toByteArray()
+        val part1 = path.asByteStream(256L..511L).toByteArray()
+        val part2 = path.asByteStream(512L until file.length()).toByteArray()
+
+        assertContentEquals(expected, part0 + part1 + part2)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
https://github.com/awslabs/aws-sdk-kotlin/issues/530

## Description of changes
Add bytestream support for partial file content eg.
```kotlin
val File = // ...
val part0 = file.asByteStream(endInclusive = 255) // implicit start index 0
val part1 = file.asByteStream(256, 511)
val part2 = file.asByteStream(512) // implicit endInclusive index file.length()-1
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
