### PR TITLE
feat: usability enhancements for no required inputs

### DIFF
--- a/.changes/114d9286-0fe0-4d31-891b-fe0e8f1c9dcd.json
+++ b/.changes/114d9286-0fe0-4d31-891b-fe0e8f1c9dcd.json
@@ -1,0 +1,8 @@
+{
+    "id": "114d9286-0fe0-4d31-891b-fe0e8f1c9dcd",
+    "type": "feature",
+    "description": "Allow omission of input in service method calls where no parameters are required.",
+    "issues": [
+        "awslabs/smithy-kotlin#129"
+    ]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -108,14 +108,17 @@ fun ServiceShape.hasIdempotentTokenMember(model: Model): Boolean {
 /**
  * Return the formatted (Kotlin) function signature for the given operation
  */
-fun OperationIndex.operationSignature(model: Model, symbolProvider: SymbolProvider, op: OperationShape): String {
+fun OperationIndex.operationSignature(
+    model: Model, symbolProvider: SymbolProvider, op: OperationShape, includeOptionalDefault: Boolean = false): String {
     val inputShape = this.getInput(op)
     val outputShape = this.getOutput(op)
     val input = inputShape.map { symbolProvider.toSymbol(it).name }
     val output = outputShape.map { symbolProvider.toSymbol(it).name }
 
     val hasOutputStream = outputShape.map { it.hasStreamingMember(model) }.orElse(false)
-    val inputParam = input.map { "input: $it" }.orElse("")
+    val inputParam = input.map {
+        if (includeOptionalDefault && inputShape.get().isOptional()) "input: $it = $it{}" else "input: $it"
+    }.orElse("")
     val outputParam = output.map { ": $it" }.orElse("")
 
     val operationName = op.defaultName()
@@ -220,3 +223,8 @@ fun UnionShape.filterEventStreamErrors(model: Model): Collection<MemberShape> {
         target.isError
     }
 }
+
+/**
+ * Test if a shape is optional.
+ */
+fun Shape.isOptional(): Boolean = members().none { it.isRequired }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
@@ -153,7 +153,7 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.write("")
         writer.renderDocumentation(op)
         writer.renderAnnotations(op)
-        writer.write(opIndex.operationSignature(ctx.model, ctx.symbolProvider, op))
+        writer.write(opIndex.operationSignature(ctx.model, ctx.symbolProvider, op, true))
 
         // Add DSL overload (if appropriate)
         opIndex.getInput(op).ifPresent { inputShape ->

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -50,11 +50,13 @@ class ServiceGeneratorTest {
     fun `it renders signatures correctly`() {
         val expectedSignatures = listOf(
             "suspend fun getFoo(input: GetFooRequest): GetFooResponse",
-            "suspend fun getFooNoInput(input: GetFooNoInputRequest): GetFooNoInputResponse",
+            "suspend fun getFooNoRequired(input: GetFooNoRequiredRequest = GetFooNoRequiredRequest{}): GetFooNoRequiredResponse",
+            "suspend fun getFooSomeRequired(input: GetFooSomeRequiredRequest): GetFooSomeRequiredResponse",
+            "suspend fun getFooNoInput(input: GetFooNoInputRequest = GetFooNoInputRequest{}): GetFooNoInputResponse",
             "suspend fun getFooNoOutput(input: GetFooNoOutputRequest): GetFooNoOutputResponse",
             "suspend fun getFooStreamingInput(input: GetFooStreamingInputRequest): GetFooStreamingInputResponse",
             "suspend fun <T> getFooStreamingOutput(input: GetFooStreamingOutputRequest, block: suspend (GetFooStreamingOutputResponse) -> T): T",
-            "suspend fun <T> getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputRequest, block: suspend (GetFooStreamingOutputNoInputResponse) -> T): T",
+            "suspend fun <T> getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputRequest = GetFooStreamingOutputNoInputRequest{}, block: suspend (GetFooStreamingOutputNoInputResponse) -> T): T",
             "suspend fun getFooStreamingInputNoOutput(input: GetFooStreamingInputNoOutputRequest): GetFooStreamingInputNoOutputResponse"
         )
         expectedSignatures.forEach {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -177,6 +177,36 @@ class HttpProtocolClientGeneratorTest {
         op.install(MockMiddleware(configurationField1 = "testing"))
         return op.roundTrip(client, input)
     }
+""",
+"""
+    override suspend fun getFooNoRequired(input: GetFooNoRequiredRequest): GetFooNoRequiredResponse {
+        val op = SdkHttpOperation.build<GetFooNoRequiredRequest, GetFooNoRequiredResponse> {
+            serializer = GetFooNoRequiredOperationSerializer()
+            deserializer = GetFooNoRequiredOperationDeserializer()
+            context {
+                expectedHttpStatus = 200
+                service = serviceName
+                operationName = "GetFooNoRequired"
+            }
+        }
+        op.install(MockMiddleware(configurationField1 = "testing"))
+        return op.roundTrip(client, input)
+    }
+""",
+"""
+    override suspend fun getFooSomeRequired(input: GetFooSomeRequiredRequest): GetFooSomeRequiredResponse {
+        val op = SdkHttpOperation.build<GetFooSomeRequiredRequest, GetFooSomeRequiredResponse> {
+            serializer = GetFooSomeRequiredOperationSerializer()
+            deserializer = GetFooSomeRequiredOperationDeserializer()
+            context {
+                expectedHttpStatus = 200
+                service = serviceName
+                operationName = "GetFooSomeRequired"
+            }
+        }
+        op.install(MockMiddleware(configurationField1 = "testing"))
+        return op.roundTrip(client, input)
+    }
 """
         )
         expectedBodies.forEach {

--- a/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/service-generator-deprecated.smithy
+++ b/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/service-generator-deprecated.smithy
@@ -20,6 +20,7 @@ operation YeOldeOperation {
 
 @deprecated
 structure YeOldeOperationRequest {
+    @required
     @deprecated
     @httpQuery("yeOldeParam")
     yeOldParameter: String,

--- a/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/service-generator-test-operations.smithy
+++ b/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/service-generator-test-operations.smithy
@@ -8,6 +8,8 @@ service Test {
     version: "1.0.0",
     operations: [
         GetFoo,
+        GetFooNoRequired,
+        GetFooSomeRequired,
         GetFooNoInput,
         GetFooNoOutput,
         GetFooStreamingInput,
@@ -25,12 +27,41 @@ operation GetFoo {
     errors: [GetFooError]
 }
 
-structure GetFooRequest {}
+structure GetFooRequest {
+    @required
+    @httpQuery("q")
+    query: String
+}
 structure GetFooResponse {}
 
 @error("client")
 structure GetFooError {}
 
+@http(method: "GET", uri: "/foo-no-required")
+operation GetFooNoRequired {
+    input: GetFooNoRequiredRequest,
+    output: GetFooResponse
+}
+
+structure GetFooNoRequiredRequest {
+    @httpQuery("q0")
+    q0: String,
+    @httpQuery("q1")
+    q1: String
+}
+
+@http(method: "GET", uri: "/foo-some-required")
+operation GetFooSomeRequired {
+    input: GetFooSomeRequiredRequest,
+    output: GetFooResponse
+}
+
+structure GetFooSomeRequiredRequest {
+    @required @httpQuery("q0")
+    q0: String,
+    @httpQuery("q1")
+    q1: String
+}
 
 @http(method: "GET", uri: "/foo-no-input")
 operation GetFooNoInput {
@@ -46,6 +77,7 @@ operation GetFooNoOutput {
 blob BodyStream
 
 structure GetFooStreamingRequest {
+    @required
     body: BodyStream
 }
 


### PR DESCRIPTION
## Issue \#
(https://github.com/awslabs/smithy-kotlin/issues/129)

## Description of changes
Add convenience overload for methods with no required inputs, eg.
```kotlin
S3Client.fromEnvironment().use {
  it.listBuckets().buckets?.forEach {
    println(it.name)
  }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
