### PR TITLE
fix: don't escape markdown within preformat blocks

### DIFF
--- a/.changes/88581b9f-34b0-4509-8eaf-481efd2cbdf1.json
+++ b/.changes/88581b9f-34b0-4509-8eaf-481efd2cbdf1.json
@@ -1,0 +1,5 @@
+{
+    "id": "88581b9f-34b0-4509-8eaf-481efd2cbdf1",
+    "type": "bugfix",
+    "description": "Don't escape markdown within preformat blocks in documentation."
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessor.kt
@@ -200,12 +200,19 @@ private fun Node.hasAncestor(predicate: (Node) -> Boolean): Boolean =
 private fun Node.isList() =
     nodeName().let { it == "ul" || it == "ol" }
 
-private fun TextNode.markdownText() =
-    text()
+private fun Node.isPreformat() =
+    nodeName().let { it == "code" || it == "pre" }
+
+private fun TextNode.markdownText(): String {
+    // If we're inside a preformat block, everything is literal, ie. no escapes required.
+    if (hasAncestor(Node::isPreformat)) return text()
+
+    return text()
         // Replace square brackets with escaped equivalents so that they are not rendered as invalid Markdown
         // links.
         .replace("[", "&#91;")
         .replace("]", "&#93;")
+}
 
 /**
  * Operates on all substrings that fall within the provided section delimiters. Returns a new string where all

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -162,6 +162,21 @@ class DocumentationPreprocessorTest {
     }
 
     @Test
+    fun `it renders markdown text`() {
+        val input = "<p>This [should be escaped because it's in formatland].</p>" +
+            "<p><code>this should [not]</code></p>" +
+            "<p><pre>nor [should] this</pre></p>"
+        val expected = """
+        This &#91;should be escaped because it's in formatland&#93;.
+        
+        `this should [not]`
+        
+        `nor [should] this`
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
     fun `it fully renders S3 CreateMultipartUpload`() {
         val input = """
 <p>This action initiates a multipart upload and returns an upload ID. This upload ID is


### PR DESCRIPTION
## Description of changes
Markdown characters inside of preformat (code/pre) HTML shouldn't be escaped.

eg. the square brackets within
`<code> bracket_list = [1,2,3] </code>`
should be rendered as-is in the final markdown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
