### PR TITLE
feat(rt): add additional telemetry for HTTP requests

### DIFF
--- a/.changes/f7cf3370-ccb2-4e68-91e9-a4e61a06731b.json
+++ b/.changes/f7cf3370-ccb2-4e68-91e9-a4e61a06731b.json
@@ -1,0 +1,5 @@
+{
+    "id": "f7cf3370-ccb2-4e68-91e9-a4e61a06731b",
+    "type": "feature",
+    "description": "add additional trace logging to default HTTP client engine"
+}

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
@@ -64,7 +64,7 @@ abstract class MiddlewareSigningTestBase : HasSigner {
         unsigned: Boolean = false,
     ): HttpRequest {
         val mockEngine = object : HttpClientEngineBase("test") {
-            override suspend fun roundTrip(request: HttpRequest): HttpCall {
+            override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
                 val now = Instant.now()
                 val resp = HttpResponse(HttpStatusCode.fromValue(200), Headers.Empty, HttpBody.Empty)
                 return HttpCall(request, resp, now, now)

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -168,7 +168,7 @@ actual abstract class SigningSuiteTestBase : HasSigner {
         operation: SdkHttpOperation<Unit, HttpResponse>
     ): HttpRequest {
         val mockEngine = object : HttpClientEngineBase("test") {
-            override suspend fun roundTrip(request: HttpRequest): HttpCall {
+            override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
                 val now = Instant.now()
                 val resp = HttpResponse(HttpStatusCode.fromValue(200), Headers.Empty, HttpBody.Empty)
                 return HttpCall(request, resp, now, now)

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -13,6 +13,7 @@ import aws.smithy.kotlin.runtime.crt.SdkDefaultIO
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
 import aws.smithy.kotlin.runtime.http.engine.callContext
+import aws.smithy.kotlin.runtime.http.operation.withContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.logging.Logger
@@ -74,6 +75,7 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
 
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         val callContext = callContext()
+        val reqLogger = logger.withContext(context)
         val manager = getManagerForUri(request.uri)
 
         // LIFETIME: connection will be released back to the pool/manager when
@@ -85,7 +87,7 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
 
         val respHandler = SdkStreamResponseHandler(conn)
         callContext.job.invokeOnCompletion {
-            logger.trace { "completing handler; cause=$it" }
+            reqLogger.trace { "completing handler; cause=$it" }
             // ensures the stream is driven to completion regardless of what the downstream consumer does
             respHandler.complete()
         }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.http.engine.crt
 import aws.sdk.kotlin.crt.http.*
 import aws.sdk.kotlin.crt.io.*
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.crt.SdkDefaultIO
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
@@ -71,7 +72,7 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
     private val connManagers = mutableMapOf<String, HttpClientConnectionManager>()
     private val mutex = Mutex()
 
-    override suspend fun roundTrip(request: HttpRequest): HttpCall {
+    override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         val callContext = callContext()
         val manager = getManagerForUri(request.uri)
 

--- a/runtime/protocol/http-client-engines/http-client-engine-default/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":runtime:protocol:http"))
+                implementation(project(":runtime:logging"))
             }
         }
         jvmMain {

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -18,8 +18,8 @@ internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpCl
         config {
             connectTimeout(config.connectTimeout.toJavaDuration())
             readTimeout(config.socketReadTimeout.toJavaDuration())
-            // writeTimeout(config.socketWriteTimeout.toJavaDuration())
-            writeTimeout((0.seconds).toJavaDuration())
+            writeTimeout(config.socketWriteTimeout.toJavaDuration())
+            // writeTimeout((0.seconds).toJavaDuration())
             val pool = ConnectionPool(
                 maxIdleConnections = config.maxConnections.toInt(),
                 keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -10,6 +10,7 @@ import io.ktor.client.engine.okhttp.*
 import okhttp3.ConnectionPool
 import okhttp3.Protocol
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpClientEngine {
@@ -17,7 +18,8 @@ internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpCl
         config {
             connectTimeout(config.connectTimeout.toJavaDuration())
             readTimeout(config.socketReadTimeout.toJavaDuration())
-            writeTimeout(config.socketWriteTimeout.toJavaDuration())
+            // writeTimeout(config.socketWriteTimeout.toJavaDuration())
+            writeTimeout((0.seconds).toJavaDuration())
             val pool = ConnectionPool(
                 maxIdleConnections = config.maxConnections.toInt(),
                 keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -25,6 +25,8 @@ internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpCl
             )
             connectionPool(pool)
 
+            eventListener(HttpEngineEventListener(pool))
+
             if (config.alpn.isNotEmpty()) {
                 val protocols = config.alpn.mapNotNull {
                     when (it) {

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -10,7 +10,6 @@ import io.ktor.client.engine.okhttp.*
 import okhttp3.ConnectionPool
 import okhttp3.Protocol
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpClientEngine {

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -18,7 +18,6 @@ internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpCl
             connectTimeout(config.connectTimeout.toJavaDuration())
             readTimeout(config.socketReadTimeout.toJavaDuration())
             writeTimeout(config.socketWriteTimeout.toJavaDuration())
-            // writeTimeout((0.seconds).toJavaDuration())
             val pool = ConnectionPool(
                 maxIdleConnections = config.maxConnections.toInt(),
                 keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package aws.smithy.kotlin.runtime.http.engine
+
+import aws.smithy.kotlin.runtime.logging.Logger
+import okhttp3.*
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+// TODO - propagate call metadata (e.g. sdkRequestId) using Request.tag. Requires more direct integration with okhttp
+
+internal class HttpEngineEventListener(
+    private val pool: ConnectionPool
+) : EventListener() {
+    private val logger = Logger.getLogger<HttpEngineEventListener>()
+
+    override fun callStart(call: Call) {
+        logger.trace { "call started" }
+    }
+
+    override fun callEnd(call: Call) {
+        logger.trace { "call complete" }
+    }
+
+    override fun callFailed(call: Call, ioe: IOException) {
+        logger.trace(ioe) { "call failed" }
+    }
+
+    override fun canceled(call: Call) {
+        logger.trace { "call cancelled" }
+    }
+
+    override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
+        logger.trace { "starting connection: addr=$inetSocketAddress; proxy=$proxy" }
+    }
+
+    override fun connectEnd(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy, protocol: Protocol?) {
+        logger.trace { "connection established: addr=$inetSocketAddress; proxy=$proxy; protocol=$protocol" }
+    }
+
+    override fun connectFailed(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?,
+        ioe: IOException
+    ) {
+        logger.trace(ioe) { "connect failed: addr=$inetSocketAddress; proxy=$proxy; protocol=$protocol" }
+    }
+
+    override fun connectionAcquired(call: Call, connection: Connection) {
+        logger.trace { "connection acquired: conn=$connection; connPool: total=${pool.connectionCount()}, idle=${pool.idleConnectionCount()}" }
+    }
+
+    override fun connectionReleased(call: Call, connection: Connection) {
+        logger.trace { "connection released: conn=$connection; connPool: total=${pool.connectionCount()}, idle=${pool.idleConnectionCount()}" }
+    }
+
+    override fun dnsStart(call: Call, domainName: String) {
+        logger.trace { "dns query: domain=$domainName" }
+    }
+
+    override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
+        logger.trace { "dns resolved: domain=$domainName; records=$inetAddressList" }
+    }
+
+    override fun proxySelectStart(call: Call, url: HttpUrl) {
+        logger.trace { "proxy select start: url=$url" }
+    }
+
+    override fun proxySelectEnd(call: Call, url: HttpUrl, proxies: List<Proxy>) {
+        logger.trace { "proxy select end: url=$url" }
+    }
+
+    override fun requestBodyStart(call: Call) {
+        logger.trace { "sending request body" }
+    }
+
+    override fun requestBodyEnd(call: Call, byteCount: Long) {
+        logger.trace { "finished sending request body: bytesSent=$byteCount" }
+    }
+
+    override fun requestFailed(call: Call, ioe: IOException) {
+        logger.trace(ioe) { "request failed" }
+    }
+
+    override fun requestHeadersStart(call: Call) {
+        logger.trace { "sending request headers" }
+    }
+
+    override fun requestHeadersEnd(call: Call, request: Request) {
+        logger.trace { "finished sending request headers" }
+    }
+
+    override fun responseBodyStart(call: Call) {
+        logger.trace { "response body available" }
+    }
+
+    override fun responseBodyEnd(call: Call, byteCount: Long) {
+        logger.trace { "response body finished: bytesConsumed=$byteCount" }
+    }
+
+    override fun responseFailed(call: Call, ioe: IOException) {
+        logger.trace(ioe) { "response failed" }
+    }
+
+    override fun responseHeadersStart(call: Call) {
+        logger.trace { "response headers start" }
+    }
+
+    override fun responseHeadersEnd(call: Call, response: Response) {
+        val contentLength = response.body?.contentLength()
+        logger.trace { "response headers end: contentLengthHeader=$contentLength" }
+    }
+
+    override fun secureConnectStart(call: Call) {
+        logger.trace { "initiating TLS connection" }
+    }
+
+    override fun secureConnectEnd(call: Call, handshake: Handshake?) {
+        logger.trace { "TLS connect end: handshake=$handshake" }
+    }
+
+    // NOTE: we don't configure a cache and should never get the rest of these events,
+    // seeing these messages logged means we configured something wrong
+
+    override fun satisfactionFailure(call: Call, response: Response) {
+        logger.trace { "cache satisfaction failure" }
+    }
+
+    override fun cacheConditionalHit(call: Call, cachedResponse: Response) {
+        logger.trace { "cache conditional hit" }
+    }
+
+    override fun cacheHit(call: Call, response: Response) {
+        logger.trace { "cache hit" }
+    }
+
+    override fun cacheMiss(call: Call) {
+        logger.trace { "cache miss" }
+    }
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
@@ -29,7 +29,7 @@ internal class HttpEngineEventListener(
     }
 
     override fun callStart(call: Call) {
-        traceCall(call){ "call started" }
+        traceCall(call) { "call started" }
     }
 
     override fun callEnd(call: Call) {

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.http.engine
 
-import aws.smithy.kotlin.runtime.http.middleware.AMZ_SDK_INVOCATION_ID_HEADER
 import aws.smithy.kotlin.runtime.logging.Logger
 import okhttp3.*
 import java.io.IOException
@@ -12,7 +11,8 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
 
-// TODO - propagate call metadata (e.g. sdkRequestId) using Request.tag instead of abusing AMZ_SDK_INVOCATION_ID. Requires more direct integration with okhttp though.
+// FIXME - propagate call metadata (e.g. sdkRequestId) using Request.tag instead of abusing AMZ_SDK_INVOCATION_ID. Requires more direct integration with okhttp though.
+private const val AMZ_SDK_INVOCATION_ID_HEADER = "amz-sdk-invocation-id"
 
 internal class HttpEngineEventListener(
     private val pool: ConnectionPool

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/HttpEngineEventListener.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.engine
 
+import aws.smithy.kotlin.runtime.http.middleware.AMZ_SDK_INVOCATION_ID_HEADER
 import aws.smithy.kotlin.runtime.logging.Logger
 import okhttp3.*
 import java.io.IOException
@@ -11,7 +12,7 @@ import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
 
-// TODO - propagate call metadata (e.g. sdkRequestId) using Request.tag. Requires more direct integration with okhttp
+// TODO - propagate call metadata (e.g. sdkRequestId) using Request.tag instead of abusing AMZ_SDK_INVOCATION_ID. Requires more direct integration with okhttp though.
 
 internal class HttpEngineEventListener(
     private val pool: ConnectionPool
@@ -19,12 +20,12 @@ internal class HttpEngineEventListener(
     private val logger = Logger.getLogger<HttpEngineEventListener>()
 
     private inline fun traceCall(call: Call, crossinline msg: () -> Any) {
-        val sdkRequestId = call.request().header("__sdkRequestId")
+        val sdkRequestId = call.request().header(AMZ_SDK_INVOCATION_ID_HEADER)
         logger.trace { "[sdkRequestId=$sdkRequestId] ${msg()}" }
     }
 
     private inline fun traceCall(call: Call, throwable: Throwable, crossinline msg: () -> Any) {
-        val sdkRequestId = call.request().header("__sdkRequestId")
+        val sdkRequestId = call.request().header(AMZ_SDK_INVOCATION_ID_HEADER)
         logger.trace(throwable) { "[sdkRequestId=$sdkRequestId] ${msg()}" }
     }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.ktor
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.engine.*
@@ -57,7 +58,7 @@ class KtorEngine(
 
     private val logger = Logger.getLogger<KtorEngine>()
 
-    override suspend fun roundTrip(request: HttpRequest): HttpCall {
+    override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         val callContext = callContext()
         val sdkRequestId = request.headers["__sdkRequestId"]
 
@@ -85,7 +86,7 @@ class KtorEngine(
             logger.trace("[sdkRequestId=$sdkRequestId] response is available continuing")
             return resp
         } catch (ex: Exception) {
-            logger.trace(ex){ "[sdkRequestId=$sdkRequestId] failed to receive response" }
+            logger.trace(ex) { "[sdkRequestId=$sdkRequestId] failed to receive response" }
             throw ex
         }
     }
@@ -131,7 +132,7 @@ class KtorEngine(
         }
     }
 
-    override fun close() {
+    override fun shutdown() {
         client.close()
         engine.close()
     }

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.httptest
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
@@ -41,11 +42,11 @@ class RecordingEngine(private val wrapped: HttpClientEngine) : HttpClientEngine 
         }
     }
 
-    override suspend fun roundTrip(request: HttpRequest): HttpCall {
+    override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         // copy request and response bodies to bytes content so that it can be read multiple times
         val reqBody = copyHttpBody("request", request.body)
         val requestCopy = request.copy(body = reqBody)
-        val call = wrapped.roundTrip(request)
+        val call = wrapped.roundTrip(context, request)
         val respBody = copyHttpBody("response", call.response.body)
         val responseCopy = call.response.copy(body = respBody)
         val copy = call.copy(request = requestCopy, response = responseCopy)

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.httptest
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -112,7 +113,7 @@ class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) : 
         fun fromJson(payload: String): TestConnection = parseHttpTraffic(payload)
     }
 
-    override suspend fun roundTrip(request: HttpRequest): HttpCall {
+    override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         check(iter.hasNext()) { "TestConnection has no remaining expected requests" }
         val next = iter.next()
         calls.add(CallAssertion(next.expected, request))

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
@@ -9,6 +9,7 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.operation.deepCopy
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.request.header
 import aws.smithy.kotlin.runtime.io.Handler
 import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
@@ -16,6 +17,16 @@ import aws.smithy.kotlin.runtime.retries.getOrThrow
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.util.InternalApi
+import aws.smithy.kotlin.runtime.util.get
+
+/**
+ * The per/operation unique client side ID header name. This will match
+ * the [HttpOperationContext.SdkRequestId]
+ */
+@InternalApi
+const val AMZ_SDK_INVOCATION_ID_HEADER = "amz-sdk-invocation-id"
+
+internal const val AMZ_SDK_REQUEST_HEADER = "amz-sdk-request"
 
 /**
  * Retry requests with the given strategy and policy
@@ -28,8 +39,9 @@ class Retry<O>(
     private val policy: RetryPolicy<Any?>
 ) : MutateMiddleware<O> {
 
-    override suspend fun <H : Handler<SdkHttpRequest, O>> handle(request: SdkHttpRequest, next: H): O =
-        if (request.subject.isRetryable) {
+    override suspend fun <H : Handler<SdkHttpRequest, O>> handle(request: SdkHttpRequest, next: H): O {
+        request.subject.header(AMZ_SDK_INVOCATION_ID_HEADER, request.context[HttpOperationContext.SdkRequestId])
+        return if (request.subject.isRetryable) {
             var attempt = 1
             val logger = request.context.getLogger("Retry")
             val wrappedPolicy = PolicyLogger(policy, logger)
@@ -41,6 +53,9 @@ class Retry<O>(
                 // Deep copy the request because later middlewares (e.g., signing) mutate it
                 val requestCopy = request.deepCopy()
 
+                // we don't know max attempts, it comes from the strategy and setting ttl would never be accurate
+                // set attempt which is the only additional metadata we know
+                requestCopy.subject.header(AMZ_SDK_REQUEST_HEADER, "attempt=$attempt")
                 when (val body = requestCopy.subject.body) {
                     // Reset streaming bodies back to beginning
                     is HttpBody.Streaming -> body.reset()
@@ -54,6 +69,7 @@ class Retry<O>(
         } else {
             next.call(request)
         }
+    }
 }
 
 /**

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -91,4 +91,4 @@ fun ExecutionContext.getLogger(name: String): Logger {
 }
 
 @InternalApi
-fun Logger.withContext(context: ExecutionContext): Logger = withContext(context[HttpOperationContext.LoggingContext])
+fun Logger.withContext(context: ExecutionContext): Logger = withContext(context.getOrNull(HttpOperationContext.LoggingContext) ?: emptyMap())

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationRequest.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationRequest.kt
@@ -17,7 +17,9 @@ import aws.smithy.kotlin.runtime.http.util.CanDeepCopy
  * @param context The operation context
  * @param subject The input type
  */
-data class OperationRequest<T>(val context: ExecutionContext, val subject: T)
+data class OperationRequest<T>(val context: ExecutionContext, val subject: T) {
+    constructor(subject: T) : this(ExecutionContext(), subject)
+}
 
 /**
  * Deep copy an [OperationRequest] to a new request. Note that, because [context] is...well, context...it's considered

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -20,7 +20,6 @@ import aws.smithy.kotlin.runtime.io.middleware.Middleware
 import aws.smithy.kotlin.runtime.io.middleware.Phase
 import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.util.InternalApi
-import aws.smithy.kotlin.runtime.util.get
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 import aws.smithy.kotlin.runtime.io.middleware.decorate as decorateHandler

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -16,7 +16,6 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.http.response.dumpResponse
 import aws.smithy.kotlin.runtime.io.*
-import aws.smithy.kotlin.runtime.io.middleware.MapRequest
 import aws.smithy.kotlin.runtime.io.middleware.Middleware
 import aws.smithy.kotlin.runtime.io.middleware.Phase
 import aws.smithy.kotlin.runtime.logging.Logger
@@ -73,15 +72,11 @@ internal fun <Request, Response> SdkOperationExecution<Request, Response>.decora
     serializer: HttpSerialize<Request>,
     deserializer: HttpDeserialize<Response>,
 ): Handler<OperationRequest<Request>, Response> {
-    val inner = MapRequest(handler) { sdkRequest: SdkHttpRequest ->
-        sdkRequest.subject
-    }
-
     // ensure http calls are tracked
     receive.register(HttpCallMiddleware())
     receive.intercept(Phase.Order.After, ::httpTraceMiddleware)
 
-    val receiveHandler = decorateHandler(inner, receive)
+    val receiveHandler = decorateHandler(handler, receive)
     val deserializeHandler = deserializer.decorate(receiveHandler)
     val finalizeHandler = decorateHandler(FinalizeHandler(deserializeHandler), finalize)
     val mutateHandler = decorateHandler(MutateHandler(finalizeHandler), mutate)

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -180,8 +180,6 @@ private suspend fun httpTraceMiddleware(request: SdkHttpRequest, next: Handler<S
     val logMode = request.context.sdkLogMode
     val logger by lazy { request.context.getLogger("httpTraceMiddleware") }
 
-    request.subject.headers["__sdkRequestId"] = request.context[HttpOperationContext.SdkRequestId]
-
     if (logMode.isEnabled(SdkLogMode.LogRequest) || logMode.isEnabled(SdkLogMode.LogRequestWithBody)) {
         val formattedReq = dumpRequest(request.subject, logMode.isEnabled(SdkLogMode.LogRequestWithBody))
         logger.debug { "HttpRequest:\n$formattedReq" }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -21,6 +21,7 @@ import aws.smithy.kotlin.runtime.io.middleware.Middleware
 import aws.smithy.kotlin.runtime.io.middleware.Phase
 import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.util.InternalApi
+import aws.smithy.kotlin.runtime.util.get
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 import aws.smithy.kotlin.runtime.io.middleware.decorate as decorateHandler
@@ -183,6 +184,8 @@ private class HttpCallMiddleware : Middleware<SdkHttpRequest, HttpCall> {
 private suspend fun httpTraceMiddleware(request: SdkHttpRequest, next: Handler<SdkHttpRequest, HttpCall>): HttpCall {
     val logMode = request.context.sdkLogMode
     val logger by lazy { request.context.getLogger("httpTraceMiddleware") }
+
+    request.subject.headers["__sdkRequestId"] = request.context[HttpOperationContext.SdkRequestId]
 
     if (logMode.isEnabled(SdkLogMode.LogRequest) || logMode.isEnabled(SdkLogMode.LogRequestWithBody)) {
         val formattedReq = dumpRequest(request.subject, logMode.isEnabled(SdkLogMode.LogRequestWithBody))

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponseTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponseTest.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -27,7 +28,7 @@ class DefaultValidateResponseTest {
     @Test
     fun itThrowsExceptionOnNon200Response() = runTest {
         val mockEngine = object : HttpClientEngineBase("test") {
-            override suspend fun roundTrip(request: HttpRequest): HttpCall {
+            override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
                 val resp = HttpResponse(
                     HttpStatusCode.BadRequest,
                     Headers.Empty,
@@ -52,7 +53,7 @@ class DefaultValidateResponseTest {
     @Test
     fun itPassesSuccessResponses() = runTest {
         val mockEngine = object : HttpClientEngineBase("test") {
-            override suspend fun roundTrip(request: HttpRequest): HttpCall {
+            override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
                 val resp = HttpResponse(
                     HttpStatusCode.Accepted,
                     Headers.Empty,

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/Md5ChecksumTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/Md5ChecksumTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -30,7 +31,7 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalCoroutinesApi::class)
 class Md5ChecksumTest {
     private val mockEngine = object : HttpClientEngineBase("test") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val resp = HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.Empty)
             return HttpCall(request, resp, Instant.now(), Instant.now())
         }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/MutateHeadersTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/MutateHeadersTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -29,7 +30,7 @@ import kotlin.test.assertEquals
 class MutateHeadersTest {
 
     private val mockEngine = object : HttpClientEngineBase("test") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val resp = HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.Empty)
             return HttpCall(request, resp, Instant.now(), Instant.now())
         }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -31,7 +32,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class ResolveEndpointTest {
     private val mockEngine = object : HttpClientEngineBase("test") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val resp = HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.Empty)
             return HttpCall(request, resp, Instant.now(), Instant.now())
         }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -35,7 +36,7 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalCoroutinesApi::class)
 class RetryTest {
     private val mockEngine = object : HttpClientEngineBase("test") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val resp = HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.Empty)
             return HttpCall(request, resp, Instant.now(), Instant.now())
         }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
@@ -12,6 +12,11 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
  */
 interface RetryStrategy {
     /**
+     * Common retry strategy options
+     */
+    val options: RetryOptions
+
+    /**
      * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
      * outcomes from retrying.
      * @param policy A [RetryPolicy] that can be used to evaluate the outcome of each retry attempt.
@@ -19,4 +24,12 @@ interface RetryStrategy {
      * @return The successful [Outcome] of the final retry attempt.
      */
     suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R>
+}
+
+interface RetryOptions {
+    /**
+     * Maximum retry attempts allowed by a strategy
+     */
+    val maxAttempts: Int?
+        get() = null
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CancellationException
  * @param delayProvider A delayer that can back off after the initial try to spread out the retries.
  */
 class StandardRetryStrategy(
-    val options: StandardRetryStrategyOptions = StandardRetryStrategyOptions.Default,
+    override val options: StandardRetryStrategyOptions = StandardRetryStrategyOptions.Default,
     private val tokenBucket: RetryTokenBucket = StandardRetryTokenBucket(),
     private val delayProvider: DelayProvider = ExponentialBackoffWithJitter()
 ) : RetryStrategy {
@@ -145,7 +145,7 @@ class StandardRetryStrategy(
  * Defines configuration for a [StandardRetryStrategy].
  * @param maxAttempts The maximum number of attempts to make (including the first attempt).
  */
-data class StandardRetryStrategyOptions(val maxAttempts: Int) {
+data class StandardRetryStrategyOptions(override val maxAttempts: Int) : RetryOptions {
     companion object {
         /**
          * The default retry strategy configuration.

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
@@ -6,6 +6,7 @@
 
 package aws.smithy.kotlin.runtime.smithy.test
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.HeadersBuilder
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod
@@ -56,7 +57,7 @@ fun httpRequestTest(block: HttpRequestTestBuilder.() -> Unit) = runTest {
     // provide the mock engine
     lateinit var actual: HttpRequest
     val mockEngine = object : HttpClientEngineBase("smithy-test-mock-engine") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val testHeaders = HeadersBuilder().apply {
                 appendAll(request.headers)
             }

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.smithy.test
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
@@ -81,7 +82,7 @@ fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit) = runTest
 
     // provide the mock engine
     val mockEngine = object : HttpClientEngineBase("smithy-test-resp-mock-engine") {
-        override suspend fun roundTrip(request: HttpRequest): HttpCall {
+        override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
             val headers = Headers {
                 testBuilder.expected.headers.forEach { (key, value) ->
                     append(key, value)

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTestBuilderTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTestBuilderTest.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.smithy.test
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.HttpMethod
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
@@ -14,6 +15,7 @@ import kotlin.test.assertFails
 
 class HttpRequestTestBuilderTest {
 
+    private val execContext = ExecutionContext()
     @Test
     fun itAssertsHttpMethod() {
         val ex = assertFails {
@@ -25,7 +27,7 @@ class HttpRequestTestBuilderTest {
                     val builder = HttpRequest {
                         method = HttpMethod.GET
                     }
-                    mockEngine.roundTrip(builder)
+                    mockEngine.roundTrip(execContext, builder)
                 }
             }
         }
@@ -45,7 +47,7 @@ class HttpRequestTestBuilderTest {
                         method = HttpMethod.POST
                         url.path = "/bar"
                     }
-                    mockEngine.roundTrip(builder)
+                    mockEngine.roundTrip(execContext, builder)
                 }
             }
         }
@@ -68,7 +70,7 @@ class HttpRequestTestBuilderTest {
                         url.parameters.append("baz", "quux")
                         url.parameters.append("Hi", "Hello")
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -93,7 +95,7 @@ class HttpRequestTestBuilderTest {
                         url.parameters.append("Hi", "Hello there")
                         url.parameters.append("foobar", "i am forbidden")
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -119,7 +121,7 @@ class HttpRequestTestBuilderTest {
                         url.parameters.append("Hi", "Hello there")
                         url.parameters.append("foobar2", "i am not forbidden")
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -154,7 +156,7 @@ class HttpRequestTestBuilderTest {
                             append("k1", "v1")
                         }
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -182,7 +184,7 @@ class HttpRequestTestBuilderTest {
                             appendAll("k2", listOf("v3", "v4"))
                         }
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -220,7 +222,7 @@ class HttpRequestTestBuilderTest {
                             append("forbiddenHeader", "i am forbidden")
                         }
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -259,7 +261,7 @@ class HttpRequestTestBuilderTest {
                             append("forbiddenHeader2", "i am not forbidden")
                         }
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -277,7 +279,7 @@ class HttpRequestTestBuilderTest {
                     // no actual body should not make it to our assertEquals but it should still fail (invalid test setup)
                     val request = HttpRequest {
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -298,7 +300,7 @@ class HttpRequestTestBuilderTest {
                     val request = HttpRequest {
                         body = ByteArrayContent("do not pass go".encodeToByteArray())
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }
@@ -318,7 +320,7 @@ class HttpRequestTestBuilderTest {
                         method = HttpMethod.POST
                         url.host = "bar.example.com"
                     }
-                    mockEngine.roundTrip(request)
+                    mockEngine.roundTrip(execContext, request)
                 }
             }
         }

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTestBuilderTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTestBuilderTest.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.smithy.test
 
+import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
@@ -29,7 +30,7 @@ class HttpResponseTestBuilderTest {
             }
 
             test { _, mockEngine ->
-                val mockedCall = mockEngine.roundTrip(HttpRequestBuilder().build())
+                val mockedCall = mockEngine.roundTrip(ExecutionContext(), HttpRequestBuilder().build())
                 val mockedResp = mockedCall.response
 
                 mockedResp.headers.contains("bar", "1")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

* Implement retry header SEP which propagates `amz-sdk-invocation-id` header with our existing client side SdkRequestId value.
* Implement `okhttp::EventListener` interface and register it with the engine. This logs every event from the engine at trace level. Currently this pulls out the (new) invocation ID header to propagate sdk request ID into the logs for correlation with the rest of the logging messages related to that operation. When we implement #629 we can use the `tags` functionality of an okhttp request to propagate whatever context we want.
* Refactor `HttpClientEngine` interface to take `ExecutionContext`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
