### PR TITLE
fix: handle invalid description term headers when generating document…

### DIFF
--- a/.changes/8ca59a5e-f734-4b5f-877e-848740bca124.json
+++ b/.changes/8ca59a5e-f734-4b5f-877e-848740bca124.json
@@ -1,0 +1,5 @@
+{
+    "id": "8ca59a5e-f734-4b5f-877e-848740bca124",
+    "type": "bugfix",
+    "description": "Handle invalid (empty) description term headers when generating documentation."
+}

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/lang/DocumentationPreprocessorTest.kt
@@ -177,6 +177,25 @@ class DocumentationPreprocessorTest {
     }
 
     @Test
+    fun `it renders description list section headers`() {
+        val input = """
+            <dl>
+                <dt>term1</dt>
+                <dd><p>description1</p></dd>
+                <dt/>
+                <dd><p>definition of a nonexistent term...</p></dd>
+            <dl>
+        """.trimIndent()
+        val expected = """
+        ## term1
+        description1
+        
+        definition of a nonexistent term...
+        """.trimIndent()
+        inputTest(input, expected)
+    }
+
+    @Test
     fun `it fully renders S3 CreateMultipartUpload`() {
         val input = """
 <p>This action initiates a multipart upload and returns an upload ID. This upload ID is


### PR DESCRIPTION
## Description of changes
Some docs have nonsensical empty `<dt/>` elements:
```html
<dl>
            <dt/> // ?
            <dd>
               <p>
                  <code>NONE</code> // was this supposed to be the dt? no way to know...
               </p>
               <p>In this mode, <...>
```

which we transform into the corresponding empty header in markdown, which dokka vomits on parsing. Strip those elements before we traverse the HTML tree.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
