### PR TITLE
feat: enhance generic codegen to be more KMP-friendly

### DIFF
--- a/.changes/08a2127b-379a-43e5-902d-14325cdf933b.json
+++ b/.changes/08a2127b-379a-43e5-902d-14325cdf933b.json
@@ -1,0 +1,8 @@
+{
+    "id": "08a2127b-379a-43e5-902d-14325cdf933b",
+    "type": "feature",
+    "description": "Enhance generic codegen to be more KMP-friendly",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#460"
+    ]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/ExternalTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/ExternalTypes.kt
@@ -10,6 +10,12 @@ import software.amazon.smithy.kotlin.codegen.model.toSymbol
  * Commonly used external types.
  */
 object ExternalTypes {
+    object Kotlin {
+        object Jvm {
+            val JvmName = "kotlin.jvm.JvmName".toSymbol()
+        }
+    }
+
     // https://github.com/Kotlin/kotlinx.coroutines
     object KotlinxCoroutines {
         val Flow = "kotlinx.coroutines.flow.Flow".toSymbol()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinDependency.kt
@@ -36,22 +36,31 @@ const val RUNTIME_GROUP: String = "aws.smithy.kotlin"
 val RUNTIME_VERSION: String = System.getProperty("smithy.kotlin.codegen.clientRuntimeVersion", getDefaultRuntimeVersion())
 val KOTLIN_COMPILER_VERSION: String = System.getProperty("smithy.kotlin.codegen.kotlinCompilerVersion", "1.6.10")
 
+enum class SourceSet {
+    CommonMain,
+    CommonTest,
+    ;
+
+    override fun toString(): String = StringUtils.uncapitalize(name)
+}
+
 // See: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
-enum class GradleConfiguration {
+enum class GradleConfiguration(val sourceSet: SourceSet) {
     // purely internal and not meant to be exposed to consumers.
-    Implementation,
+    Implementation(SourceSet.CommonMain),
     // transitively exported to consumers, for compile.
-    Api,
+    Api(SourceSet.CommonMain),
     // only required at compile time, but should not leak into the runtime
-    CompileOnly,
+    CompileOnly(SourceSet.CommonMain),
     // only required at runtime
-    RuntimeOnly,
+    RuntimeOnly(SourceSet.CommonMain),
     // internal test
-    TestImplementation,
+    TestImplementation(SourceSet.CommonTest),
     // compile time test only
-    TestCompileOnly,
+    TestCompileOnly(SourceSet.CommonTest),
     // compile time runtime only
-    TestRuntimeOnly;
+    TestRuntimeOnly(SourceSet.CommonTest),
+    ;
 
     override fun toString(): String = StringUtils.uncapitalize(this.name)
 
@@ -59,7 +68,13 @@ enum class GradleConfiguration {
      * Return true if the dependency is in the test scope
      */
     val isTestScope
-        get() = this == TestImplementation || this == TestCompileOnly || this == TestRuntimeOnly
+        get() = sourceSet == SourceSet.CommonTest
+
+    val kmpName
+        get() = when {
+            isTestScope -> name.removePrefix("Test")
+            else -> name
+        }.let(StringUtils::uncapitalize)
 }
 
 data class KotlinDependency(

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -205,7 +205,8 @@ class PaginatorGenerator : KotlinIntegration {
             // Multiple functions may have the same name and the generic does not disambiguate the type in Java.
             // NOTE: This does not mean these functions are callable from Java.
             .write(
-                """@JvmName("#L#L")""",
+                """@#T("#L#L")""",
+                ExternalTypes.Kotlin.Jvm.JvmName,
                 outputSymbol.name.replaceFirstChar(Char::lowercaseChar),
                 itemDesc.targetMember.defaultName(serviceShape)
             )

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
@@ -160,7 +160,7 @@ class UnionGenerator(
         writer.write("")
         writer.withBlock("override fun equals(other: #Q?): #Q {", "}", KotlinTypes.Any, KotlinTypes.Boolean) {
             write("if (this === other) return true")
-            write("if (javaClass != other?.javaClass) return false")
+            write("if (other == null || this::class != other::class) return false")
             write("")
             write("other as $typeName")
             write("")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerializerGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerializerGenerator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.toRenderingConte
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 
 open class JsonSerializerGenerator(
@@ -93,10 +94,9 @@ open class JsonSerializerGenerator(
     ) {
         // render the serde descriptors
         JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members, supportsJsonNameTrait).render()
-        if (shape.isUnionShape) {
-            SerializeUnionGenerator(ctx, members, writer, defaultTimestampFormat).render()
-        } else {
-            SerializeStructGenerator(ctx, members, writer, defaultTimestampFormat).render()
+        when (shape) {
+            is UnionShape -> SerializeUnionGenerator(ctx, shape, members, writer, defaultTimestampFormat).render()
+            else -> SerializeStructGenerator(ctx, members, writer, defaultTimestampFormat).render()
         }
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerializerGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/XmlSerializerGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.toRenderingConte
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlAttributeTrait
 
@@ -103,10 +104,9 @@ open class XmlSerializerGenerator(
         val sortedMembers = sortMembersForSerialization(members)
         descriptorGenerator(ctx, shape, sortedMembers, writer).render()
         // render the serde descriptors
-        if (shape.isUnionShape) {
-            SerializeUnionGenerator(ctx, sortedMembers, writer, defaultTimestampFormat).render()
-        } else {
-            SerializeStructGenerator(ctx, sortedMembers, writer, defaultTimestampFormat).render()
+        when (shape) {
+            is UnionShape -> SerializeUnionGenerator(ctx, shape, sortedMembers, writer, defaultTimestampFormat).render()
+            else -> SerializeStructGenerator(ctx, sortedMembers, writer, defaultTimestampFormat).render()
         }
     }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -256,6 +256,7 @@ class PaginatorGeneratorTest {
             import com.test.model.FunctionConfiguration
             import com.test.model.ListFunctionsRequest
             import com.test.model.ListFunctionsResponse
+            import kotlin.jvm.JvmName
             import kotlinx.coroutines.flow.Flow
             import kotlinx.coroutines.flow.flow
             import kotlinx.coroutines.flow.transform

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
@@ -57,7 +57,7 @@ class UnionGeneratorTest {
             
                     override fun equals(other: kotlin.Any?): kotlin.Boolean {
                         if (this === other) return true
-                        if (javaClass != other?.javaClass) return false
+                        if (other == null || this::class != other::class) return false
             
                         other as Blz
             

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeUnionGeneratorTest.kt
@@ -38,6 +38,7 @@ class SerializeUnionGeneratorTest {
                     is FooUnion.IntVal -> field(INTVAL_DESCRIPTOR, input.value)
                     is FooUnion.StrVal -> field(STRVAL_DESCRIPTOR, input.value)
                     is FooUnion.Timestamp4 -> field(TIMESTAMP4_DESCRIPTOR, input.value, TimestampFormat.ISO_8601)
+                    is FooUnion.SdkUnknown -> throw SerializationException("Cannot serialize SdkUnknown")
                 }
             }
         """.trimIndent()
@@ -117,6 +118,7 @@ class SerializeUnionGeneratorTest {
                             input.value.forEach { (key, value) -> entry(key, value) }
                         }
                     }
+                    is FooUnion.SdkUnknown -> throw SerializationException("Cannot serialize SdkUnknown")
                 }
             }
         """.trimIndent()
@@ -149,6 +151,7 @@ class SerializeUnionGeneratorTest {
             serializer.serializeStruct(OBJ_DESCRIPTOR) {
                 when (input) {
                     is MyAggregateUnion.Nested3 -> field(NESTED3_DESCRIPTOR, input.value, ::serializeNestedDocument)
+                    is MyAggregateUnion.SdkUnknown -> throw SerializationException("Cannot serialize SdkUnknown")
                 }
             }
         """.trimIndent()
@@ -202,6 +205,7 @@ class SerializeUnionGeneratorTest {
                             }
                         }
                     }
+                    is FooUnion.SdkUnknown -> throw SerializationException("Cannot serialize SdkUnknown")
                 }
             }
         """.trimIndent()


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#460](https://github.com/awslabs/aws-sdk-kotlin/issues/460)

## Description of changes

Support for KMP codegen:
* Stop using `javaClass` for equality comparisons in array-containing union subtypes
* Import the correct `@JvmName` annotation
* Provide exhaustive `when` branches in union serializer code

**Companion PR**: (link coming soon)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
