### PR TITLE
fix: correct signing for query parameters containing '+' and '%'

### DIFF
--- a/.changes/922b32ef-f194-4e5f-9ff2-9eca98246755.json
+++ b/.changes/922b32ef-f194-4e5f-9ff2-9eca98246755.json
@@ -1,0 +1,8 @@
+{
+    "id": "922b32ef-f194-4e5f-9ff2-9eca98246755",
+    "type": "bugfix",
+    "description": "Fix bugs with signing for query parameters containing '+' and '%'",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#619"
+    ]
+}

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
@@ -170,7 +170,7 @@ public fun String.splitAsQueryString(): Map<String, List<String>> {
  * Decode a URL's query string, resolving percent-encoding (e.g., "%3B" → ";").
  */
 @InternalApi
-public fun String.urlDecodeComponent(): String {
+public fun String.urlDecodeComponent(formUrlDecode: Boolean = false): String {
     val orig = this
     return buildString(orig.length) {
         var byteBuffer: ByteArray? = null // Do not initialize unless needed
@@ -178,29 +178,32 @@ public fun String.urlDecodeComponent(): String {
         var c: Char
         while (i < orig.length) {
             c = orig[i]
-            when (c) {
-                '+' -> {
+            when {
+                c == '+' && formUrlDecode -> {
                     append(' ')
                     i++
                 }
 
-                '%' -> {
+                c == '%' -> {
                     if (byteBuffer == null) {
                         byteBuffer = ByteArray((orig.length - i) / 3) // Max remaining percent-encoded bytes
                     }
 
                     var byteCount = 0
                     while ((i + 2) < orig.length && c == '%') {
-                        val byte = orig.substring(i + 1, i + 3).toInt(radix = 16).toByte()
+                        val byte = orig.substring(i + 1, i + 3).toIntOrNull(radix = 16)?.toByte() ?: break
                         byteBuffer[byteCount++] = byte
 
                         i += 3
                         if (i < orig.length) c = orig[i]
                     }
 
-                    require(i == orig.length || c != '%') { "Incomplete escape pattern at end of string" }
-
                     append(byteBuffer.decodeToString(endIndex = byteCount))
+
+                    if (i != orig.length && c == '%') {
+                        append(c)
+                        i++
+                    }
                 }
 
                 else -> {
@@ -213,5 +216,5 @@ public fun String.urlDecodeComponent(): String {
 }
 
 @InternalApi
-public fun String.urlReencodeComponent(formUrlEncode: Boolean = false): String =
-    urlDecodeComponent().urlEncodeComponent(formUrlEncode)
+public fun String.urlReencodeComponent(formUrlDecode: Boolean = false, formUrlEncode: Boolean = false): String =
+    urlDecodeComponent(formUrlDecode).urlEncodeComponent(formUrlEncode)

--- a/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
+++ b/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
@@ -149,7 +149,7 @@ class TextTest {
     @Test
     fun decodeUrlComponent() {
         val component = "a%3Bb+c%7Ed%20e%2Bf+g%3D%E1%88%B4"
-        val expected = "a;b c~d e+f+g=ሴ"
+        val expected = "a;b+c~d e+f+g=ሴ"
         assertEquals(expected, component.urlDecodeComponent())
     }
 

--- a/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
+++ b/runtime/utils/common/test/aws/smithy/kotlin/runtime/util/text/TextTest.kt
@@ -149,7 +149,21 @@ class TextTest {
     @Test
     fun decodeUrlComponent() {
         val component = "a%3Bb+c%7Ed%20e%2Bf+g%3D%E1%88%B4"
+        val expected = "a;b c~d e+f+g=ሴ"
+        assertEquals(expected, component.urlDecodeComponent())
+    }
+
+    @Test
+    fun decodeUrlComponentWithFormUrl() {
+        val component = "a%3Bb+c%7Ed%20e%2Bf+g%3D%E1%88%B4"
         val expected = "a;b c~d e+f g=ሴ"
+        assertEquals(expected, component.urlDecodeComponent(true))
+    }
+
+    @Test
+    fun decodeUrlComponentInvalidSequence() {
+        val component = "%20%&'%%%f"
+        val expected = " %&'%%%f" // Only the %20 was valid
         assertEquals(expected, component.urlDecodeComponent())
     }
 


### PR DESCRIPTION
## Issue \#

Closes aws-sdk-kotlin#619

## Description of changes

Two issues with our signer's canonicalization of query string parameters:

* During canonicalization, we decode and reencode query params but don't handle `+` and `%` the way services expect. Namely, we _decode_ `+` to `' '` and then _reencode_ to `%20`. The `+` character shouldn't be handled specially in this case and should not be altered when decoding so that it's (correctly) encoded to `%2B`.
* We also throw an error on query string parameters that contain `%` followed by invalid escape sequences. This is consistent with the RFC detailing URI format but is too inflexible for our E2E test case. We should percent-decode what we can and pass through the rest unmodified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
