### PR TITLE
HTTP Engine Benchmarks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ dependencies {
 val lintPaths = listOf(
     "smithy-kotlin-codegen/src/**/*.kt",
     "runtime/**/*.kt",
-    "benchmarks/**/jvm/*.kt",
+    "tests/**/**/jvm/*.kt",
 )
 
 tasks.register<JavaExec>("ktlint") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ dependencies {
 val lintPaths = listOf(
     "smithy-kotlin-codegen/src/**/*.kt",
     "runtime/**/*.kt",
-    "tests/**/**/jvm/*.kt",
+    "tests/**/jvm/**/*.kt",
 )
 
 tasks.register<JavaExec>("ktlint") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ dokkaVersion=1.6.21
 # kotlin libraries
 coroutinesVersion=1.6.1
 ktorVersion=2.0.2
-atomicFuVersion=0.17.2
+atomicFuVersion=0.17.3
 kotlinxSerializationVersion=1.3.3
 jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.7

--- a/runtime/protocol/http-client-engines/http-client-engine-default/common/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/common/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngine.kt
@@ -8,13 +8,6 @@ package aws.smithy.kotlin.runtime.http.engine
 /**
  * Factory function to create a new HTTP client engine using the default for the current KMP target
  */
-fun DefaultHttpEngine(config: HttpClientEngineConfig = HttpClientEngineConfig.Default): HttpClientEngine =
-    newDefaultHttpEngine(config)
+fun DefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)? = null): HttpClientEngine = newDefaultHttpEngine(block)
 
-fun DefaultHttpEngine(block: HttpClientEngineConfig.Builder.() -> Unit): HttpClientEngine {
-    val builder = HttpClientEngineConfig.Builder().apply(block)
-    val config = HttpClientEngineConfig(builder)
-    return DefaultHttpEngine(config)
-}
-
-internal expect fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpClientEngine
+internal expect fun newDefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)?): HttpClientEngine

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineJVM.kt
@@ -7,4 +7,8 @@ package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
 
-internal actual fun newDefaultHttpEngine(config: HttpClientEngineConfig): HttpClientEngine = OkHttpEngine(config)
+internal actual fun newDefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)?): HttpClientEngine = if (block != null) {
+    OkHttpEngine(block)
+} else {
+    OkHttpEngine()
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
@@ -26,7 +26,7 @@ internal class HttpEngineEventListener(
 
     private inline fun traceCall(call: Call, throwable: Throwable, crossinline msg: () -> Any) {
         val sdkRequestTag = call.request().tag<SdkRequestTag>()
-        val sdkRequestId = sdkRequestTag?.execContext?.get(HttpOperationContext.SdkRequestId)
+        val sdkRequestId = sdkRequestTag?.execContext?.getOrNull(HttpOperationContext.SdkRequestId)
         logger.trace(throwable) { "[sdkRequestId=$sdkRequestId] ${msg()}" }
     }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.runtime.http.engine.okhttp
+
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
+
+public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClientEngineConfig(builder) {
+    public companion object {
+        /**
+         * The default engine config. Most clients should use this.
+         */
+        public val Default: OkHttpEngineConfig = OkHttpEngineConfig(Builder())
+
+        public operator fun invoke(block: Builder.() -> Unit): OkHttpEngineConfig =
+            Builder().apply(block).build()
+    }
+
+    public class Builder : HttpClientEngineConfig.Builder() {
+
+        internal fun build(): OkHttpEngineConfig = OkHttpEngineConfig(this)
+    }
+}

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
@@ -129,7 +129,13 @@ suspend fun HttpBody.readAll(): ByteArray? = when (this) {
         // the stream is closed and no more bytes remain.
         // This is usually sufficient to consume the stream but technically that's not what it's doing.
         // Save us a painful debug session later in the very rare chance this were to occur.
-        check(readChan.isClosedForRead) { "failed to read all HttpBody bytes from stream" }
+        val isClosedForRead = readChan.isClosedForRead
+        val isClosedForWrite = readChan.isClosedForWrite
+        val availableForRead = readChan.availableForRead
+        check(readChan.isClosedForRead) {
+            "failed to read all HttpBody bytes from stream: isClosedForRead: $isClosedForRead/${readChan.isClosedForRead}; isClosedForWrite: $isClosedForWrite/${readChan.isClosedForWrite}; availableForRead: $availableForRead/${readChan.availableForRead}: ${bytes.decodeToString()}"
+        }
+
         bytes
     }
 }

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Annotations.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Annotations.kt
@@ -6,8 +6,8 @@
 package aws.smithy.kotlin.runtime.util
 
 /**
- * API marked with this annotation is internal to the client runtime and it is not intended to be used outside.
- * It could be modified or removed without any notice. Using it outside of the client-runtime could cause undefined behaviour and/or
+ * API marked with this annotation is internal to the client runtime, and it is not intended to be used outside.
+ * It could be modified or removed without any notice. Using it outside the client-runtime could cause undefined behaviour and/or
  * any strange effects.
  *
  * We strongly recommend to not use such API.
@@ -15,7 +15,7 @@ package aws.smithy.kotlin.runtime.util
 @Suppress("DEPRECATION")
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
-    message = "This API is internal to smithy-client-rt and should not be used. It could be removed or changed without notice."
+    message = "This API is internal to the smithy-kotlin runtime and should not be used. It could be removed or changed without notice."
 )
 @Target(
     AnnotationTarget.CLASS,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,7 @@ include(":smithy-kotlin-codegen")
 
 include(":tests")
 include(":tests:benchmarks:aws-signing-benchmarks")
+include(":tests:benchmarks:http-benchmarks")
 include(":tests:benchmarks:serde-benchmarks-codegen")
 include(":tests:benchmarks:serde-benchmarks")
 include(":tests:compile")

--- a/tests/benchmarks/aws-signing-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/auth/signing/AwsSignerBenchmark.kt
+++ b/tests/benchmarks/aws-signing-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/auth/signing/AwsSignerBenchmark.kt
@@ -1,9 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
 package aws.smithy.kotlin.benchmarks.auth.signing
 
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSignedBodyHeader
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningConfig
-import aws.smithy.kotlin.runtime.auth.awssigning.crt.CrtAwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.crt.CrtAwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.testCredentialsProvider
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod

--- a/tests/benchmarks/http-benchmarks/README.md
+++ b/tests/benchmarks/http-benchmarks/README.md
@@ -10,6 +10,8 @@ This project contains benchmarks for the [HTTP engine implementations](../../../
 
 Baseline `0.10.3-SNAPSHOT` on EC2 **[m5.4xlarge](https://aws.amazon.com/ec2/instance-types/m5/)** with **Corretto-11.0.15.9.1**:
 
+The download/upload throughput benchmarks are an approximation of how much data in MB/s we are able to process.
+
 ```
 jvm summary:
 Benchmark                                      (httpClientName)   Mode  Cnt      Score     Error  Units

--- a/tests/benchmarks/http-benchmarks/README.md
+++ b/tests/benchmarks/http-benchmarks/README.md
@@ -15,18 +15,18 @@ The download/upload throughput benchmarks are an approximation of how much data 
 ```
 jvm summary:
 Benchmark                                      (httpClientName)   Mode  Cnt      Score     Error  Units
-HttpEngineBenchmarks.downloadThroughputNoTls             OkHttp  thrpt    5     10.728 ±   0.199  ops/s
-HttpEngineBenchmarks.downloadThroughputNoTls                CRT  thrpt    5     31.411 ±   0.958  ops/s
-HttpEngineBenchmarks.downloadThroughputNoTls        Ktor_OkHttp  thrpt    5     14.030 ±   0.190  ops/s
-HttpEngineBenchmarks.roundTripConcurrentNoTls            OkHttp  thrpt    5  32295.186 ± 139.197  ops/s
-HttpEngineBenchmarks.roundTripConcurrentNoTls               CRT  thrpt    5  28419.745 ± 375.215  ops/s
-HttpEngineBenchmarks.roundTripConcurrentNoTls       Ktor_OkHttp  thrpt    5  15025.216 ± 486.722  ops/s
-HttpEngineBenchmarks.roundTripSequentialNoTls            OkHttp  thrpt    5   7912.345 ± 352.180  ops/s
-HttpEngineBenchmarks.roundTripSequentialNoTls               CRT  thrpt    5   8890.362 ± 711.467  ops/s
-HttpEngineBenchmarks.roundTripSequentialNoTls       Ktor_OkHttp  thrpt    5   4410.282 ± 102.291  ops/s
-HttpEngineBenchmarks.uploadThroughputNoTls               OkHttp  thrpt    5     16.458 ±   0.531  ops/s
-HttpEngineBenchmarks.uploadThroughputNoTls                  CRT  thrpt    5     17.432 ±   0.533  ops/s
-HttpEngineBenchmarks.uploadThroughputNoTls          Ktor_OkHttp  thrpt    5     16.343 ±   0.449  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls             OkHttp  thrpt    5    129.300 ±   1.796  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls                CRT  thrpt    5    377.234 ±  10.801  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls        Ktor_OkHttp  thrpt    5    169.366 ±   2.480  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls            OkHttp  thrpt    5  33225.814 ± 209.392  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls               CRT  thrpt    5  28013.919 ± 455.085  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls       Ktor_OkHttp  thrpt    5  14736.287 ± 867.559  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls            OkHttp  thrpt    5   7801.946 ± 527.743  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls               CRT  thrpt    5   8712.930 ± 800.754  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls       Ktor_OkHttp  thrpt    5   4373.179 ±  90.326  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls               OkHttp  thrpt    5    198.005 ±   5.032  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls                  CRT  thrpt    5    206.829 ±   5.680  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls          Ktor_OkHttp  thrpt    5    194.655 ±   4.665  ops/s
 ```
 
 The `Ktor_OkHttp` engine is the Ktor wrapped OkHttp engine whereas the `OkHttp` engine is the raw binding to OkHttp

--- a/tests/benchmarks/http-benchmarks/README.md
+++ b/tests/benchmarks/http-benchmarks/README.md
@@ -1,0 +1,31 @@
+# HTTP Client Engine Benchmarks
+
+This project contains benchmarks for the [HTTP engine implementations](../../../runtime/protocol/http-client-engines).
+
+## Testing
+
+```sh
+./gradlew :tests:benchmarks:http-benchmarks:benchmark
+```
+
+Baseline `0.10.3-SNAPSHOT` on EC2 **[m5.4xlarge](https://aws.amazon.com/ec2/instance-types/m5/)** with **Corretto-11.0.15.9.1**:
+
+```
+jvm summary:
+Benchmark                                      (httpClientName)   Mode  Cnt      Score     Error  Units
+HttpEngineBenchmarks.downloadThroughputNoTls             OkHttp  thrpt    5     10.728 ±   0.199  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls                CRT  thrpt    5     31.411 ±   0.958  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls        Ktor_OkHttp  thrpt    5     14.030 ±   0.190  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls            OkHttp  thrpt    5  32295.186 ± 139.197  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls               CRT  thrpt    5  28419.745 ± 375.215  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls       Ktor_OkHttp  thrpt    5  15025.216 ± 486.722  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls            OkHttp  thrpt    5   7912.345 ± 352.180  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls               CRT  thrpt    5   8890.362 ± 711.467  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls       Ktor_OkHttp  thrpt    5   4410.282 ± 102.291  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls               OkHttp  thrpt    5     16.458 ±   0.531  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls                  CRT  thrpt    5     17.432 ±   0.533  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls          Ktor_OkHttp  thrpt    5     16.343 ±   0.449  ops/s
+```
+
+The `Ktor_OkHttp` engine is the Ktor wrapped OkHttp engine whereas the `OkHttp` engine is the raw binding to OkHttp
+without Ktor.

--- a/tests/benchmarks/http-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/http-benchmarks/build.gradle.kts
@@ -45,6 +45,9 @@ kotlin {
                 val ktorVersion: String by project
                 implementation(project(":runtime:protocol:http-client-engines:http-client-engine-ktor"))
                 implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
+
+                // mock/embedded server
+                implementation("io.ktor:ktor-server-netty:$ktorVersion")
             }
         }
     }

--- a/tests/benchmarks/http-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/http-benchmarks/build.gradle.kts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+plugins {
+    kotlin("multiplatform")
+    id("org.jetbrains.kotlinx.benchmark")
+}
+
+extra.set("skipPublish", true)
+
+val platforms = listOf("common", "jvm")
+
+platforms.forEach { platform ->
+    apply(from = rootProject.file("gradle/${platform}.gradle"))
+}
+
+val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.util.InternalApi")
+
+kotlin {
+    sourceSets {
+        all {
+            val srcDir = if (name.endsWith("Main")) "src" else "test"
+            val resourcesPrefix = if (name.endsWith("Test")) "test-" else ""
+            // the name is always the platform followed by a suffix of either "Main" or "Test" (e.g. jvmMain, commonTest, etc)
+            val platform = name.substring(0, name.length - 4)
+            kotlin.srcDir("$platform/$srcDir")
+            resources.srcDir("$platform/${resourcesPrefix}resources")
+            languageSettings.progressiveMode = true
+            optinAnnotations.forEach { languageSettings.optIn(it) }
+        }
+
+        val kotlinxBenchmarkVersion: String by project
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:$kotlinxBenchmarkVersion")
+            }
+        }
+
+        val jvmMain by getting {
+            dependencies {
+                implementation(project(":runtime:protocol:http-client-engines:http-client-engine-okhttp"))
+                implementation(project(":runtime:protocol:http-client-engines:http-client-engine-crt"))
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+    }
+
+    configurations {
+        getByName("main") {
+            iterations = 5
+            iterationTime = 3
+            iterationTimeUnit = "s"
+            warmups = 3
+            outputTimeUnit = "s"
+            reportFormat = "text"
+            advanced("jvmForks", "1")
+        }
+    }
+}
+
+// Workaround for https://github.com/Kotlin/kotlinx-benchmark/issues/39
+afterEvaluate {
+    tasks.named<org.gradle.jvm.tasks.Jar>("jvmBenchmarkJar") {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+}

--- a/tests/benchmarks/http-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/http-benchmarks/build.gradle.kts
@@ -54,7 +54,7 @@ benchmark {
     configurations {
         getByName("main") {
             iterations = 5
-            iterationTime = 3
+            iterationTime = 5
             iterationTimeUnit = "s"
             warmups = 3
             outputTimeUnit = "s"

--- a/tests/benchmarks/http-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/http-benchmarks/build.gradle.kts
@@ -41,6 +41,10 @@ kotlin {
             dependencies {
                 implementation(project(":runtime:protocol:http-client-engines:http-client-engine-okhttp"))
                 implementation(project(":runtime:protocol:http-client-engines:http-client-engine-crt"))
+
+                val ktorVersion: String by project
+                implementation(project(":runtime:protocol:http-client-engines:http-client-engine-ktor"))
+                implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
             }
         }
     }

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -45,7 +45,7 @@ private val engines = mapOf(
 )
 
 // 12MB
-private val largeData = ByteArray(MB_PER_THROUGHPUT_OP*1024*1024)
+private val largeData = ByteArray(MB_PER_THROUGHPUT_OP * 1024 * 1024)
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
@@ -55,7 +55,6 @@ open class HttpEngineBenchmarks {
     var httpClientName: String = ""
 
     lateinit var httpClient: SdkHttpClient
-
 
     private val serverPort: Int = ServerSocket(0).use { it.localPort }
     private val server = embeddedServer(Netty, port = serverPort) {
@@ -70,7 +69,7 @@ open class HttpEngineBenchmarks {
                 call.response.header("x-foobar", "foobar")
                 call.respondBytes(largeData)
             }
-            post("/upload" ) {
+            post("/upload") {
                 val packet = call.request.receiveChannel().readRemaining()
                 call.respondText("read ${packet.remaining} bytes")
                 packet.close()
@@ -134,7 +133,6 @@ open class HttpEngineBenchmarks {
         println("destroy exiting")
     }
 
-
     /**
      * Sequential requests raw throughput
      */
@@ -144,9 +142,9 @@ open class HttpEngineBenchmarks {
         try {
             val body = call.response.body.readAll()
             blackhole.consume(body)
-        }catch (ex: Exception) {
+        } catch (ex: Exception) {
             println(ex)
-        }finally {
+        } finally {
             call.complete()
         }
     }
@@ -164,9 +162,9 @@ open class HttpEngineBenchmarks {
                 try {
                     val body = call.response.body.readAll()
                     blackhole.consume(body)
-                }catch (ex: Exception) {
+                } catch (ex: Exception) {
                     println("failed to consume body: ${ex.message}")
-                }finally {
+                } finally {
                     call.complete()
                 }
             }
@@ -183,9 +181,9 @@ open class HttpEngineBenchmarks {
         try {
             val body = call.response.body.readAll()
             blackhole.consume(body)
-        }catch (ex: Exception) {
+        } catch (ex: Exception) {
             println("failed to consume body: ${ex.message}")
-        }finally {
+        } finally {
             call.complete()
         }
     }
@@ -200,9 +198,9 @@ open class HttpEngineBenchmarks {
         try {
             val body = call.response.body.readAll()
             blackhole.consume(body)
-        }catch (ex: Exception) {
+        } catch (ex: Exception) {
             println("failed to consume body: ${ex.message}")
-        }finally {
+        } finally {
             call.complete()
         }
     }

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -81,7 +81,7 @@ open class HttpEngineBenchmarks {
      * Sequential requests raw throughput
      */
     @Benchmark
-    fun roundTripSequential(blackhole: Blackhole) = runBlocking {
+    fun roundTripSequentialNoTls(blackhole: Blackhole) = runBlocking {
         val call = httpClient.call(request)
         try {
             val body = call.response.body.readAll()
@@ -98,7 +98,7 @@ open class HttpEngineBenchmarks {
      */
     @Benchmark
     @OperationsPerInvocation(CONCURRENT_CALLS)
-    fun roundTripConcurrent(blackhole: Blackhole) = runBlocking {
+    fun roundTripConcurrentNoTls(blackhole: Blackhole) = runBlocking {
         repeat(CONCURRENT_CALLS) {
             // scope should wait for all children to complete
             launch {
@@ -115,7 +115,6 @@ open class HttpEngineBenchmarks {
             }
         }
     }
-
 }
 
 // TODO - sequential/concurrent requests internal buffering overhead (aka large response)

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -5,22 +5,25 @@
 
 package aws.smithy.kotlin.benchmarks.http
 
-import aws.smithy.kotlin.runtime.http.Protocol
-import aws.smithy.kotlin.runtime.http.SdkHttpClient
+import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
-import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.headers
 import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.http.response.complete
-import aws.smithy.kotlin.runtime.http.sdkHttpClient
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.benchmark.Blackhole
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.annotations.Level
+import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
 
 private const val CONCURRENT_CALLS = 50
@@ -40,21 +43,45 @@ private val engines = mapOf<String, BenchmarkEngineFactory>(
     KTOR_OKHTTP to BenchmarkEngineFactory { KtorOkHttpEngine() }
 )
 
+// 12MB
+private val largeResponse = ByteArray(12*1024*1024)
+
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.SECONDS)
 open class HttpEngineBenchmarks {
-
-    lateinit var httpClient: SdkHttpClient
-
     @Param(OKHTTP_ENGINE, CRT_ENGINE, KTOR_OKHTTP)
     var httpClientName: String = ""
 
-    val request = HttpRequest {
+    lateinit var httpClient: SdkHttpClient
+
+
+    private val serverPort: Int = ServerSocket(0).use { it.localPort }
+    private val server = embeddedServer(Netty, port = serverPort) {
+        routing {
+            get("/hello") {
+                call.respondText("hello")
+            }
+            get("/download") {
+                call.response.header("x-foo", "foo")
+                call.response.header("x-bar", "bar")
+                call.response.header("x-baz", "baz")
+                call.response.header("x-foobar", "foobar")
+                call.respondBytes(largeResponse)
+            }
+            post("/upload" ) {
+                val packet = call.request.receiveChannel().readRemaining()
+                call.respondText("read ${packet.remaining} bytes")
+                packet.close()
+            }
+        }
+    }
+
+    private val helloRequest = HttpRequest {
         url {
             scheme = Protocol.HTTP
             host = "localhost"
-            port = 8090
+            port = serverPort
             path = "/hello"
         }
 
@@ -63,14 +90,41 @@ open class HttpEngineBenchmarks {
         }
     }
 
+    private val downloadRequest = HttpRequest {
+        url {
+            scheme = Protocol.HTTP
+            host = "localhost"
+            port = serverPort
+            path = "/download"
+        }
+
+        headers {
+            append("Host", url.host)
+        }
+    }
+
+    private val uploadRequest = HttpRequest {
+        url {
+            scheme = Protocol.HTTP
+            host = "localhost"
+            port = serverPort
+            path = "/upload"
+        }
+        body = HttpBody.fromBytes(largeResponse)
+    }
+
     @Setup(Level.Trial)
     fun create() {
+        println("benchmark test server listening on: localhost:$serverPort")
+        server.start(false)
         val engine = engines[httpClientName]!!.create()
         httpClient = sdkHttpClient(engine, manageEngine = true)
     }
 
     @TearDown(Level.Trial)
     fun destroy() {
+        println("stopping server")
+        server.stop(0, 0, TimeUnit.SECONDS)
         println("closing client")
         httpClient.close()
         // give time to background threads to complete asynchronous shutdown
@@ -84,7 +138,7 @@ open class HttpEngineBenchmarks {
      */
     @Benchmark
     fun roundTripSequentialNoTls(blackhole: Blackhole) = runBlocking {
-        val call = httpClient.call(request)
+        val call = httpClient.call(helloRequest)
         try {
             val body = call.response.body.readAll()
             blackhole.consume(body)
@@ -104,19 +158,48 @@ open class HttpEngineBenchmarks {
         repeat(CONCURRENT_CALLS) {
             // scope should wait for all children to complete
             launch {
-                val call = httpClient.call(request)
+                val call = httpClient.call(helloRequest)
                 try {
                     val body = call.response.body.readAll()
                     blackhole.consume(body)
                 }catch (ex: Exception) {
-                    // println("failed to consume body: ${ex.message}")
-                    // println("stacktrace: ${ex.stackTraceToString()}")
+                    println("failed to consume body: ${ex.message}")
                 }finally {
                     call.complete()
                 }
             }
         }
     }
-}
 
-// TODO - sequential/concurrent requests internal buffering overhead (aka large response)
+    /**
+     * Raw download throughput (output MB/s will be roughly op/sec * MB/op)
+     */
+    @Benchmark
+    fun downloadThroughputNoTls(blackhole: Blackhole) = runBlocking {
+        val call = httpClient.call(downloadRequest)
+        try {
+            val body = call.response.body.readAll()
+            blackhole.consume(body)
+        }catch (ex: Exception) {
+            println("failed to consume body: ${ex.message}")
+        }finally {
+            call.complete()
+        }
+    }
+
+    /**
+     * Raw upload throughput (output MB/s will be roughly op/sec * MB/op)
+     */
+    @Benchmark
+    fun uploadThroughputNoTls(blackhole: Blackhole) = runBlocking {
+        val call = httpClient.call(uploadRequest)
+        try {
+            val body = call.response.body.readAll()
+            blackhole.consume(body)
+        }catch (ex: Exception) {
+            println("failed to consume body: ${ex.message}")
+        }finally {
+            call.complete()
+        }
+    }
+}

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -28,6 +28,7 @@ private const val CONCURRENT_CALLS = 50
 // TODO - add TLS overhead
 private const val OKHTTP_ENGINE = "OkHttp"
 private const val CRT_ENGINE = "CRT"
+private const val KTOR_OKHTTP = "Ktor_OkHttp"
 
 fun interface BenchmarkEngineFactory {
     fun create(): HttpClientEngine
@@ -35,7 +36,8 @@ fun interface BenchmarkEngineFactory {
 
 private val engines = mapOf<String, BenchmarkEngineFactory>(
     OKHTTP_ENGINE to BenchmarkEngineFactory { OkHttpEngine() },
-    CRT_ENGINE to BenchmarkEngineFactory { CrtHttpEngine() }
+    CRT_ENGINE to BenchmarkEngineFactory { CrtHttpEngine() },
+    KTOR_OKHTTP to BenchmarkEngineFactory { KtorOkHttpEngine() }
 )
 
 @BenchmarkMode(Mode.Throughput)
@@ -45,7 +47,7 @@ open class HttpEngineBenchmarks {
 
     lateinit var httpClient: SdkHttpClient
 
-    @Param(OKHTTP_ENGINE, CRT_ENGINE)
+    @Param(OKHTTP_ENGINE, CRT_ENGINE, KTOR_OKHTTP)
     var httpClientName: String = ""
 
     val request = HttpRequest {
@@ -107,8 +109,8 @@ open class HttpEngineBenchmarks {
                     val body = call.response.body.readAll()
                     blackhole.consume(body)
                 }catch (ex: Exception) {
-                    println("failed to consume body: ${ex.message}")
-                    println("stacktrace: ${ex.stackTraceToString()}")
+                    // println("failed to consume body: ${ex.message}")
+                    // println("stacktrace: ${ex.stackTraceToString()}")
                 }finally {
                     call.complete()
                 }

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -106,6 +106,7 @@ open class HttpEngineBenchmarks {
     private val uploadRequest = HttpRequest {
         url {
             scheme = Protocol.HTTP
+            method = HttpMethod.POST
             host = "localhost"
             port = serverPort
             path = "/upload"
@@ -129,7 +130,7 @@ open class HttpEngineBenchmarks {
         httpClient.close()
         // give time to background threads to complete asynchronous shutdown
         Thread.sleep(4000)
-        println("destroy existing")
+        println("destroy exiting")
     }
 
 

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.benchmarks.http
+
+import aws.smithy.kotlin.runtime.http.Protocol
+import aws.smithy.kotlin.runtime.http.SdkHttpClient
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
+import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
+import aws.smithy.kotlin.runtime.http.readAll
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.headers
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.http.response.complete
+import aws.smithy.kotlin.runtime.http.sdkHttpClient
+import kotlinx.benchmark.Blackhole
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.annotations.Level
+import java.util.concurrent.TimeUnit
+
+private const val CONCURRENT_CALLS = 50
+
+// TODO - add TLS overhead
+private const val OKHTTP_ENGINE = "OkHttp"
+private const val CRT_ENGINE = "CRT"
+
+fun interface BenchmarkEngineFactory {
+    fun create(): HttpClientEngine
+}
+
+private val engines = mapOf<String, BenchmarkEngineFactory>(
+    OKHTTP_ENGINE to BenchmarkEngineFactory { OkHttpEngine() },
+    CRT_ENGINE to BenchmarkEngineFactory { CrtHttpEngine() }
+)
+
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+open class HttpEngineBenchmarks {
+
+    lateinit var httpClient: SdkHttpClient
+
+    @Param(OKHTTP_ENGINE, CRT_ENGINE)
+    var httpClientName: String = ""
+
+    val request = HttpRequest {
+        url {
+            scheme = Protocol.HTTP
+            host = "localhost"
+            port = 8090
+            path = "/hello"
+        }
+
+        headers {
+            append("Host", url.host)
+        }
+    }
+
+    @Setup(Level.Trial)
+    fun create() {
+        val engine = engines[httpClientName]!!.create()
+        httpClient = sdkHttpClient(engine, manageEngine = true)
+    }
+
+    @TearDown(Level.Trial)
+    fun destroy() {
+        println("closing client")
+        httpClient.close()
+        // give time to background threads to complete asynchronous shutdown
+        Thread.sleep(4000)
+        println("destroy existing")
+    }
+
+
+    /**
+     * Sequential requests raw throughput
+     */
+    @Benchmark
+    fun roundTripSequential(blackhole: Blackhole) = runBlocking {
+        val call = httpClient.call(request)
+        try {
+            val body = call.response.body.readAll()
+            blackhole.consume(body)
+        }catch (ex: Exception) {
+            println(ex)
+        }finally {
+            call.complete()
+        }
+    }
+
+    /**
+     * Concurrent requests raw throughput
+     */
+    @Benchmark
+    @OperationsPerInvocation(CONCURRENT_CALLS)
+    fun roundTripConcurrent(blackhole: Blackhole) = runBlocking {
+        repeat(CONCURRENT_CALLS) {
+            // scope should wait for all children to complete
+            launch {
+                val call = httpClient.call(request)
+                try {
+                    val body = call.response.body.readAll()
+                    blackhole.consume(body)
+                }catch (ex: Exception) {
+                    println("failed to consume body: ${ex.message}")
+                    println("stacktrace: ${ex.stackTraceToString()}")
+                }finally {
+                    call.complete()
+                }
+            }
+        }
+    }
+
+}
+
+// TODO - sequential/concurrent requests internal buffering overhead (aka large response)

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/KtorOkHttpEngine.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/KtorOkHttpEngine.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.smithy.kotlin.benchmarks.http
+
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.ktor.KtorEngine
+import io.ktor.client.engine.okhttp.*
+import okhttp3.ConnectionPool
+import okhttp3.Protocol
+import java.util.concurrent.TimeUnit
+import kotlin.time.toJavaDuration
+
+internal fun KtorOkHttpEngine(config: HttpClientEngineConfig = HttpClientEngineConfig.Default): HttpClientEngine {
+    val okHttpEngine = OkHttp.create {
+        config {
+            connectTimeout(config.connectTimeout.toJavaDuration())
+            readTimeout(config.socketReadTimeout.toJavaDuration())
+            writeTimeout(config.socketWriteTimeout.toJavaDuration())
+            val pool = ConnectionPool(
+                maxIdleConnections = config.maxConnections.toInt(),
+                keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS
+            )
+            connectionPool(pool)
+
+            if (config.alpn.isNotEmpty()) {
+                val protocols = config.alpn.mapNotNull {
+                    when (it) {
+                        aws.smithy.kotlin.runtime.http.engine.AlpnId.HTTP1_1 -> Protocol.HTTP_1_1
+                        aws.smithy.kotlin.runtime.http.engine.AlpnId.HTTP2 -> Protocol.HTTP_2
+                        else -> null
+                    }
+                }
+                protocols(protocols)
+            }
+        }
+    }
+
+    return KtorEngine(okHttpEngine)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Bootstrap a benchmark suite for HTTP client engines. This is a very rough test suite that we can build from.

I'm currently seeing the following two errors when running the benchmarks:
1. 
```
failed to consume body: failed to read all HttpBody bytes from stream: isClosedForRead: false/true; isClosedForWrite: true/true; availableForRead: 0/0: hello    
```
This only happens on the `KtorEngine` and `OkHttpEngine` which both use the same `SdkByteReadChannel` implementation (backed by ktor) whereas the `CRT` engine uses the custom implementation.

2.
```
stopping server                                                                                                                                                         Jun 15, 2022 11:07:11 AM io.netty.channel.AbstractChannelHandlerContext invokeExceptionCaught                                                                           WARNING: Failed to submit an exceptionCaught() event.                                                                                                                   java.util.concurrent.RejectedExecutionException: event executor terminated                 
        at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:932)                                                                        at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:351)                                                                     at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:344)                                                                       at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:834)                                                                       at io.netty.util.concurrent.SingleThreadEventExecutor.execute0(SingleThreadEventExecutor.java:825)    
        at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:815)                                                                       at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:284)                                                         at io.netty.channel.AbstractChannelHandlerContext.fireExceptionCaught(AbstractChannelHandlerContext.java:273)                                                           at io.netty.channel.ChannelInboundHandlerAdapter.exceptionCaught(ChannelInboundHandlerAdapter.java:143)
        at io.netty.channel.AbstractChannelHandlerContext.invokeExceptionCaught(AbstractChannelHandlerContext.java:302)                                                         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:264)
        at io.netty.channel.AbstractChannelHandlerContext.access$300(AbstractChannelHandlerContext.java:61)                                                             
        at io.netty.channel.AbstractChannelHandlerContext$4.run(AbstractChannelHandlerContext.java:253)                                                               
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)                                                                     
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)                                                                   
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasksFrom(SingleThreadEventExecutor.java:426)                                                       
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:375)          
        at io.netty.util.concurrent.SingleThreadEventExecutor.confirmShutdown(SingleThreadEventExecutor.java:761)                                                       
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:530)                                                                                               
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)                
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)                                                                                    
        at io.ktor.server.netty.EventLoopGroupProxy$Companion.create$lambda-1$lambda-0(NettyApplicationEngine.kt:260)                                                           at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)                                                                                at java.base/java.lang.Thread.run(Thread.java:829)                                                                                                                                                                                                                         
```

The second one (2) is likely just not shutting down the server cleanly/correctly but I haven't found the right knob yet. It doesn't happen everytime or on every run and doesn't seem to be affecting anything else. 

The first one (1) is the one that worries me but I haven't been able to reproduce it outside of the benchmark test suite. It is a pre-existing condition. I've updated the `check` to include additional state in the event it does happen in production. We probably want to revisit this API and not limit it to `Int.MAX_VALUE` bytes but rather `Long.MAX_VALUE`. This would necessitate returning a different type other than `ByteArray` though which is [limited](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-byte-array/-init-.html) to `Int.MAX_VALUE`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
