### PR TITLE
fix: validate that members bound to URI paths are non-null at object construction

### DIFF
--- a/.changes/ec8ea669-5999-45d9-ad8e-dbb8d35d3c4e.json
+++ b/.changes/ec8ea669-5999-45d9-ad8e-dbb8d35d3c4e.json
@@ -1,0 +1,8 @@
+{
+    "id": "ec8ea669-5999-45d9-ad8e-dbb8d35d3c4e",
+    "type": "bugfix",
+    "description": "Validate that members bound to URI paths are non-null at object construction",
+    "issues": [
+        "awslabs/smithy-kotlin#139"
+    ]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -91,7 +91,9 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     override fun stringShape(shape: StringShape): Symbol = if (shape.isEnum) {
         createEnumSymbol(shape)
     } else {
-        createSymbolBuilder(shape, "String", boxed = true, namespace = "kotlin").build()
+        createSymbolBuilder(shape, "String", boxed = true, namespace = "kotlin")
+            .defaultValue("\"\"")
+            .build()
     }
 
     fun createEnumSymbol(shape: StringShape): Symbol {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
@@ -58,12 +58,9 @@ val Symbol.isNotBoxed: Boolean
  * Gets the default value for the symbol if present, else null
  * @param defaultBoxed the string to pass back for boxed values
  */
-fun Symbol.defaultValue(defaultBoxed: String? = "null"): String? {
-    // boxed types should always be defaulted to null
-    if (isBoxed) {
-        return defaultBoxed
-    }
+fun Symbol.defaultValue(defaultBoxed: String? = "null"): String? = if (isBoxed) defaultBoxed else defaultUnboxedValue()
 
+fun Symbol.defaultUnboxedValue(): String? {
     val default = getProperty(SymbolProperty.DEFAULT_VALUE_KEY, String::class.java)
     return if (default.isPresent) default.get() else null
 }


### PR DESCRIPTION
## Issue \#

Closes #139 

## Description of changes

This change adds validation that URI-bound members are set to non-null values at object construction time. This prevents malformed requests from being sent to services with `null` serialized into URIs.

Companion PR: (link coming soon)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
