### PR TITLE
fix: expand test coverage of engine implementations to include empty body repr

### DIFF
--- a/.changes/04cb3052-4479-4b00-a08c-f7b5fbe1d59a.json
+++ b/.changes/04cb3052-4479-4b00-a08c-f7b5fbe1d59a.json
@@ -1,0 +1,8 @@
+{
+    "id": "04cb3052-4479-4b00-a08c-f7b5fbe1d59a",
+    "type": "bugfix",
+    "description": "Fix ktor engine representation of empty payload",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#638"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -123,7 +123,7 @@ class KtorEngine(
             }
 
             val contentLength = httpResp.contentLength()
-            val body = if (contentLength == 0L && content.isClosedForRead) {
+            val body = if (contentLength == 0L) {
                 HttpBody.Empty
             } else {
                 KtorHttpBody(httpResp.contentLength(), content)

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.http.engine.ktor
 
 import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.Headers
+import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.engine.*
 import aws.smithy.kotlin.runtime.http.operation.withContext
@@ -121,7 +122,12 @@ class KtorEngine(
                 waiter.signal()
             }
 
-            val body = KtorHttpBody(httpResp.contentLength(), content)
+            val contentLength = httpResp.contentLength()
+            val body = if (contentLength == 0L && content.isClosedForRead) {
+                HttpBody.Empty
+            } else {
+                KtorHttpBody(httpResp.contentLength(), content)
+            }
 
             // copy the headers so that we no longer depend on the underlying ktor HttpResponse object
             // outside of the body content (which will signal once read that it is safe to exit the block)

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
@@ -134,7 +134,6 @@ class DownloadTest : AbstractEngineTest() {
 
                 val body = call.response.body
                 assertIs<HttpBody.Empty>(body, "${client.engine}")
-                println("${client.engine} was empty body")
             } finally {
                 call.complete()
             }

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
@@ -116,4 +116,28 @@ class DownloadTest : AbstractEngineTest() {
             }
         }
     }
+
+    @Test
+    fun testEmptyPayloadRepresentation() = testEngines {
+        // We have behavior built on top of how an empty payload is represented, ensure it is consitent
+        // across engines, see https://github.com/awslabs/aws-sdk-kotlin/issues/638
+        test { env, client ->
+            val req = HttpRequest {
+                testSetup(env)
+                url.path = "/download/empty"
+            }
+
+            val call = client.call(req)
+            try {
+                assertEquals(HttpStatusCode.OK, call.response.status)
+                assertEquals(0, call.response.body.contentLength, "${client.engine}")
+
+                val body = call.response.body
+                assertIs<HttpBody.Empty>(body, "${client.engine}")
+                println("${client.engine} was empty body")
+            } finally {
+                call.complete()
+            }
+        }
+    }
 }

--- a/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Downloads.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/src/aws/smithy/kotlin/runtime/http/test/suite/Downloads.kt
@@ -55,6 +55,12 @@ internal fun Application.downloadTests() {
 
                 call.respond(content)
             }
+
+            get("/empty") {
+                call.response.status(HttpStatusCode.OK)
+                call.response.header("x-foo", "foo")
+                call.response.header("x-bar", "bar")
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/638

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Fix ktor engine representation of empty http body. Expand test suite to cover this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
