### PR TITLE
chore: upgrade crt-kotlin to 0.6.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,4 @@ kotlinLoggingVersion=2.1.21
 slf4jVersion=1.7.36
 
 # crt
-crtKotlinVersion=0.6.0
+crtKotlinVersion=0.6.2

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGenerator.kt
@@ -83,8 +83,11 @@ private fun KotlinWriter.renderPathAcceptor(directive: String, includeInput: Boo
             PathComparator.STRING_EQUALS -> "$actual?.toString() == ${expected.dq()}"
             PathComparator.BOOLEAN_EQUALS -> "$actual == ${expected.toBoolean()}"
             PathComparator.ANY_STRING_EQUALS -> "$actual?.any { it?.toString() == ${expected.dq()} } ?: false"
+
+            // NOTE: the size > 0 check is necessary because the waiter spec says that `allStringEquals` requires
+            // at least one value unlike Kotlin's `all` which returns true if the collection is empty
             PathComparator.ALL_STRING_EQUALS ->
-                "($actual?.size ?: 0) > 1 && $actual?.all { it?.toString() == ${expected.dq()} }"
+                "$actual != null && $actual.size > 0 && $actual.all { it?.toString() == ${expected.dq()} }"
         }
         write(comparison)
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
@@ -77,7 +77,7 @@ class AcceptorGeneratorTest {
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
                     val output = it?.output
                     val tags = output?.tags
-                    (tags?.size ?: 0) > 1 && tags?.all { it?.toString() == "foo" }
+                    tags != null && tags.size > 0 && tags.all { it?.toString() == "foo" }
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
                     val output = it?.output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Upgrade to latest `aws-crt-kotlin` compiled against Kotlin 1.7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
