### PR TITLE
feat(rt): add support for HTTP_REQUEST_EVENT signature type

### DIFF
--- a/.changes/cd913c8a-f5a8-4bfe-9ab9-d08301c2338f.json
+++ b/.changes/cd913c8a-f5a8-4bfe-9ab9-d08301c2338f.json
@@ -1,0 +1,5 @@
+{
+    "id": "cd913c8a-f5a8-4bfe-9ab9-d08301c2338f",
+    "type": "feature",
+    "description": "Add support for HTTP_REQUEST_EVENT chunked signing"
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult.kt
@@ -21,7 +21,7 @@ data class AwsSigningResult<T>(
      * * `HTTP_REQUEST_VIA_QUERY_PARAMS` - hex encoding of the binary signature value
      * * `HTTP_REQUEST_CHUNK/SIGV4` - hex encoding of the binary signature value
      * * `HTTP_REQUEST_CHUNK/SIGV4_ASYMMETRIC` - '*'-padded hex encoding of the binary signature value
-     * * `HTTP_REQUEST_EVENT` - binary signature value
+     * * `HTTP_REQUEST_EVENT` - hex encoding of the binary signature value
      */
     val signature: ByteArray,
 ) {

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SignatureCalculator.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/SignatureCalculator.kt
@@ -6,7 +6,9 @@ package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.hashing.*
+import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
+import aws.smithy.kotlin.runtime.time.epochMilliseconds
 import aws.smithy.kotlin.runtime.util.encodeToHex
 
 /**
@@ -64,7 +66,13 @@ internal class DefaultSignatureCalculator(private val sha256Provider: HashSuppli
             appendLine(config.signingDate.format(TimestampFormat.ISO_8601_CONDENSED))
             appendLine(config.credentialScope)
             appendLine(prevSignature.decodeToString()) // Should already be a byte array of ASCII hex chars
-            appendLine(HashSpecification.EmptyBody.hash)
+
+            val nonSignatureHeadersHash = when (config.signatureType) {
+                AwsSignatureType.HTTP_REQUEST_EVENT -> eventStreamNonSignatureHeaders(config.signingDate)
+                else -> HashSpecification.EmptyBody.hash
+            }
+
+            appendLine(nonSignatureHeadersHash)
             append(chunkBody.hash(sha256Provider).encodeToHex())
         }
 
@@ -85,4 +93,40 @@ internal class DefaultSignatureCalculator(private val sha256Provider: HashSuppli
             appendLine(config.credentialScope)
             append(canonicalRequest.encodeToByteArray().hash(sha256Provider).encodeToHex())
         }
+}
+
+private const val HEADER_TIMESTAMP_TYPE: Byte = 8
+
+/**
+ * Return the sha256 hex representation of the encoded event stream date header
+ *
+ * ```
+ * sha256Hex( Header(":date", HeaderValue::Timestamp(date)).encodeToByteArray() )
+ * ```
+ *
+ * NOTE: This duplicates parts of the event stream encoding implementation here to avoid a direct dependency.
+ * Should this become more involved than encoding a single date header we should reconsider this choice.
+ *
+ * see [Event Stream implementation](https://github.com/awslabs/aws-sdk-kotlin/blob/v0.16.4-beta/aws-runtime/protocols/aws-event-stream/common/src/aws/sdk/kotlin/runtime/protocol/eventstream/Header.kt#L51)
+ */
+private fun eventStreamNonSignatureHeaders(date: Instant): String {
+    val bytes = ByteArray(15)
+    // encode header name
+    val name = ":date".encodeToByteArray()
+    var offset = 0
+    bytes[offset++] = name.size.toByte()
+    name.copyInto(bytes, destinationOffset = offset)
+    offset += name.size
+
+    // encode header value
+    bytes[offset++] = HEADER_TIMESTAMP_TYPE
+    writeLongBE(bytes, offset, date.epochMilliseconds)
+    return bytes.sha256().encodeToHex()
+}
+
+private fun writeLongBE(dest: ByteArray, offset: Int, x: Long) {
+    var idx = offset
+    for (i in 7 downTo 0) {
+        dest[idx++] = ((x ushr (i * 8)) and 0xff).toByte()
+    }
 }

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
@@ -5,7 +5,9 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.asStaticProvider
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.testCredentialsProvider
+import aws.smithy.kotlin.runtime.hashing.sha256
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.decodeHexBytes
 import aws.smithy.kotlin.runtime.util.encodeToHex
@@ -79,5 +81,45 @@ class DefaultSignatureCalculatorTest {
         """.trimIndent()
         val actual = SignatureCalculator.Default.stringToSign(canonicalRequest, config)
         assertEquals(expected, actual)
+    }
+
+    private data class ChunkStringToSignTest(val signatureType: AwsSignatureType, val expectedNonSignatureHeaderHash: String)
+    @Test
+    fun testChunkStringToSign() {
+        // Test event stream signing
+        // https://docs.aws.amazon.com/transcribe/latest/dg/streaming-http2.html
+        // Adapted from: https://github.com/awslabs/smithy-rs/blob/v0.38.0/aws/rust-runtime/aws-sigv4/src/event_stream.rs#L166
+        val tests = listOf(
+            ChunkStringToSignTest(AwsSignatureType.HTTP_REQUEST_CHUNK, HashSpecification.EmptyBody.hash),
+            ChunkStringToSignTest(
+                AwsSignatureType.HTTP_REQUEST_EVENT,
+                "0c0e3b3bf66b59b976181bd7d401927bbd624107303c713fd1e5f3d3c8dd1b1e"
+            )
+        )
+
+        val epoch = Instant.fromEpochSeconds(123_456_789L, 1234)
+        val prevSignature = "last message sts".encodeToByteArray().sha256().encodeToHex().encodeToByteArray()
+        val chunkBody = "test payload".encodeToByteArray()
+
+        for (test in tests) {
+            val config = AwsSigningConfig {
+                credentialsProvider = Credentials("fake access key", "fake secret key").asStaticProvider()
+                signingDate = epoch
+                region = "us-east-1"
+                service = "testservice"
+                signatureType = test.signatureType
+            }
+            val expected = """
+            AWS4-HMAC-SHA256-PAYLOAD
+            19731129T213309Z
+            19731129/us-east-1/testservice/aws4_request
+            be1f8c7d79ef8e1abc5254a2c70e4da3bfaf4f07328f527444e1fc6ea67273e2
+            ${test.expectedNonSignatureHeaderHash}
+            813ca5285c28ccee5cab8b10ebda9c908fd6d78ed9dc94cc65ea6cb67a7f13ae
+            """.trimIndent()
+
+            val actual = SignatureCalculator.Default.chunkStringToSign(chunkBody, prevSignature, config)
+            assertEquals(expected, actual)
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-kotlin#543
sibling PR: https://github.com/awslabs/aws-sdk-kotlin/pull/644

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Add support for `HTTP_REQUEST_EVENT` signature type. This works the same as chunk signing and only varies in the how the canonical string is formed. `HTTP_REQUEST_CHUNK` uses the sha-256 of an empty body whereas `HTTP_REQUEST_EVENT` uses the sha-256 of the `:date` event stream header.

NOTE: I have duplicated the logic for the binary representation of this header here to avoid a direct dependency on `aws-event-stream` package from `aws-sdk-kotlin`. It's unclear if there are other scenarios or considerations here ([CRT seems to think so](https://github.com/awslabs/aws-c-auth/blob/f29ffca89dc0b6a1d722ae9bacb230ec9dc765f4/source/signing_config.c#L59-L60)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
