### PR TITLE
chore: upgrade Smithy to 1.22

### DIFF
--- a/.changes/5bdddd68-7b25-4785-9a20-03790e330f27.json
+++ b/.changes/5bdddd68-7b25-4785-9a20-03790e330f27.json
@@ -1,0 +1,5 @@
+{
+    "id": "5bdddd68-7b25-4785-9a20-03790e330f27",
+    "type": "feature",
+    "description": "Add support for NOT, OR, and AND JMESPath expressions in waiters"
+}

--- a/.changes/ba998d36-ef93-4b63-8830-18e0f38c3b9a.json
+++ b/.changes/ba998d36-ef93-4b63-8830-18e0f38c3b9a.json
@@ -1,0 +1,8 @@
+{
+    "id": "ba998d36-ef93-4b63-8830-18e0f38c3b9a",
+    "type": "misc",
+    "description": "Upgrade Smithy version to 1.22",
+    "issues": [
+        "awslabs/smithy-kotlin#599"
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.9
 
 # codegen
-smithyVersion=1.17.0
+smithyVersion=1.22.0
 smithyGradleVersion=0.5.3
 
 # testing/utility

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
@@ -18,3 +18,16 @@ inline fun <reified T> Collection<T>.flattenIfPossible(): Collection<T> = this
 
 @JvmName("flattenNestedCollection")
 inline fun <reified T> Collection<Collection<T>>.flattenIfPossible(): Collection<T> = flatten()
+
+/**
+ * Evaluates the "truthiness" of a value based on
+ * [JMESPath definitions](https://jmespath.org/specification.html#or-expressions).
+ */
+fun truthiness(value: Any?): Boolean = when (value) {
+    is Boolean -> value
+    is Collection<*> -> value.isNotEmpty()
+    is Map<*, *> -> value.isNotEmpty()
+    is String -> value.isNotEmpty()
+    null -> false
+    else -> true
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
@@ -37,7 +37,7 @@ fun <T : AbstractCodeWriter<T>> T.withBlock(
 /**
  * Like [withBlock], except the closing write of [textAfterNewLine] does NOT include a line break.
  */
-fun <T : CodeWriter> T.withInlineBlock(
+fun <T : AbstractCodeWriter<T>> T.withInlineBlock(
     textBeforeNewLine: String,
     textAfterNewLine: String,
     vararg args: Any,
@@ -81,9 +81,9 @@ fun <T : AbstractCodeWriter<T>> T.wrapBlockIf(
 }
 
 /**
- * Like [CodeWriter.closeBlock], except the closing write of [textAfterNewLine] does NOT include a line break.
+ * Like [AbstractCodeWriter.closeBlock], except the closing write of [textAfterNewLine] does NOT include a line break.
  */
-fun <T : CodeWriter> T.closeInlineBlock(textAfterNewLine: String): T {
+fun <T : AbstractCodeWriter<T>> T.closeInlineBlock(textAfterNewLine: String): T {
     writeInline("\n")
     dedent()
     writeInline(textAfterNewLine)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
@@ -5,7 +5,8 @@
 package software.amazon.smithy.kotlin.codegen.core
 
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
-import software.amazon.smithy.utils.CodeWriter
+import software.amazon.smithy.utils.AbstractCodeWriter
+import software.amazon.smithy.utils.SimpleCodeWriter
 import java.util.function.BiFunction
 
 /**
@@ -26,7 +27,7 @@ import java.util.function.BiFunction
  * writer.closeBlock("}")
  * ```
  */
-fun <T : CodeWriter> T.withBlock(
+fun <T : AbstractCodeWriter<T>> T.withBlock(
     textBeforeNewLine: String,
     textAfterNewLine: String,
     vararg args: Any,
@@ -51,7 +52,7 @@ fun <T : CodeWriter> T.withBlock(
  * if (foo == bar) writer.closeBlock("}")
  * ```
  */
-fun <T : CodeWriter> T.wrapBlockIf(
+fun <T : AbstractCodeWriter<T>> T.wrapBlockIf(
     condition: Boolean,
     textBeforeNewLine: String,
     textAfterNewLine: String,
@@ -78,7 +79,7 @@ fun <T : CodeWriter> T.wrapBlockIf(
  *     .closeBlock("}")
  * ```
  */
-fun <T : CodeWriter> T.closeAndOpenBlock(
+fun <T : AbstractCodeWriter<T>> T.closeAndOpenBlock(
     textBeforeNewLine: String,
     vararg args: Any,
 ): T = apply {
@@ -91,7 +92,11 @@ fun <T : CodeWriter> T.closeAndOpenBlock(
  * of the type housing the codegen associated with the section. This keeps [SectionId]s closely
  * associated with their targets.
  */
-fun <T : CodeWriter> T.declareSection(id: SectionId, context: Map<String, Any?> = emptyMap(), block: T.() -> Unit = {}): T {
+fun <T : AbstractCodeWriter<T>> T.declareSection(
+    id: SectionId,
+    context: Map<String, Any?> = emptyMap(),
+    block: T.() -> Unit = { },
+): T {
     putContext(context)
     pushState(id.javaClass.canonicalName)
     block(this)
@@ -100,25 +105,27 @@ fun <T : CodeWriter> T.declareSection(id: SectionId, context: Map<String, Any?> 
     return this
 }
 
-private fun <T : CodeWriter> T.removeContext(context: Map<String, Any?>): Unit =
+private fun <T : AbstractCodeWriter<T>> T.removeContext(context: Map<String, Any?>): Unit =
     context.keys.forEach { key -> removeContext(key) }
 
 /**
  * Convenience function to get a typed value out of the context or throw if the key doesn't exist
  * or the type is wrong
  */
-inline fun <reified T> CodeWriter.getContextValue(key: String): T = checkNotNull(getContext(key) as? T) {
-    "Expected `$key` in CodeWriter context"
-}
+inline fun <W : AbstractCodeWriter<W>, reified V> AbstractCodeWriter<W>.getContextValue(key: String): V =
+    checkNotNull(getContext(key) as? V) {
+        "Expected `$key` in CodeWriter context"
+    }
 
-// Specifies a function that receives a [CodeWriter]
-typealias InlineCodeWriter = CodeWriter.() -> Unit
+typealias InlineCodeWriter = AbstractCodeWriter<*>.() -> Unit
+
 /**
  * Formatter to enable passing a writing function
- * @param codeWriterCreator function that creates a new [CodeWriter] instance used to generate output of inline content
+ * @param codeWriterCreator function that creates a new [AbstractCodeWriter] instance used to generate output of inline
+ * content
  */
 class InlineCodeWriterFormatter(
-    private val codeWriterCreator: () -> CodeWriter = { CodeWriter() }
+    private val codeWriterCreator: () -> AbstractCodeWriter<*> = ::SimpleCodeWriter
 ) : BiFunction<Any, String, String> {
     @Suppress("UNCHECKED_CAST")
     override fun apply(t: Any, u: String): String {
@@ -133,7 +140,7 @@ class InlineCodeWriterFormatter(
  * Optionally call the [Runnable] if [test] is true, otherwise do nothing and return the instance without
  * running the block
  */
-fun CodeWriter.callIf(test: Boolean, runnable: Runnable): CodeWriter {
+fun <T : AbstractCodeWriter<T>> T.callIf(test: Boolean, runnable: Runnable): T {
     if (test) {
         runnable.run()
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -132,6 +132,7 @@ object RuntimeTypes {
         val AttributeKey = runtimeSymbol("AttributeKey", KotlinDependency.UTILS)
         val flattenIfPossible = runtimeSymbol("flattenIfPossible", KotlinDependency.UTILS)
         val length = runtimeSymbol("length", KotlinDependency.UTILS)
+        val truthiness = runtimeSymbol("truthiness", KotlinDependency.UTILS)
         val urlEncodeComponent = runtimeSymbol("urlEncodeComponent", KotlinDependency.UTILS, "text")
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessor.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
 package software.amazon.smithy.kotlin.codegen.model
 
 import software.amazon.smithy.kotlin.codegen.KotlinSettings

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessor.kt
@@ -1,0 +1,37 @@
+package software.amazon.smithy.kotlin.codegen.model
+
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.traits.UniqueItemsTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+
+/**
+ * Replaces deprecated Smithy `set` shapes with `list` shapes annotated with the `@uniqueItems` trait. This transformer
+ * should only be necessary until all models have migrated away from `set` shapes.
+ */
+class SetRefactorPreprocessor : KotlinIntegration {
+    override fun preprocessModel(model: Model, settings: KotlinSettings): Model {
+        val replaced = model
+            .shapeIds
+            .map(model::expectShape)
+            .mapNotNull(::toSetShapeOrNull)
+            .map(::toUniqueValuedList)
+
+        return ModelTransformer.create().replaceShapes(model, replaced)
+    }
+}
+
+// Necessary to suppress deprecation because we're detecting deprecated shapes!
+@Suppress("DEPRECATION")
+private fun toSetShapeOrNull(shape: Shape) = shape as? software.amazon.smithy.model.shapes.SetShape
+
+private fun toUniqueValuedList(shape: CollectionShape): ListShape = ListShape
+    .builder()
+    .id(shape.id)
+    .member(shape.member)
+    .traits(shape.allTraits.values + UniqueItemsTrait())
+    .build()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/SerdeIndex.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/SerdeIndex.kt
@@ -129,7 +129,6 @@ private fun walkNestedShapesRequiringSerde(model: Model, shapes: Set<Shape>): Se
                 RelationshipType.MEMBER_TARGET,
                 RelationshipType.STRUCTURE_MEMBER,
                 RelationshipType.LIST_MEMBER,
-                RelationshipType.SET_MEMBER,
                 RelationshipType.MAP_VALUE,
                 RelationshipType.UNION_MEMBER -> true
                 else -> false

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.kotlin.codegen.model.isBoxed
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.StreamingTrait
-import software.amazon.smithy.utils.CodeWriter
 
 /**
  * Renders Smithy union shapes
@@ -115,7 +114,12 @@ class UnionGenerator(
     }
 
     // generate a `hashCode()` implementation
-    private fun renderHashCode(model: Model, sortedMembers: List<MemberShape>, symbolProvider: SymbolProvider, writer: CodeWriter) {
+    private fun renderHashCode(
+        model: Model,
+        sortedMembers: List<MemberShape>,
+        symbolProvider: SymbolProvider,
+        writer: KotlinWriter,
+    ) {
         writer.write("")
         writer.withBlock("override fun hashCode(): #Q {", "}", KotlinTypes.Int) {
             write("return value#L", selectHashFunctionForShape(model, sortedMembers[0], symbolProvider))
@@ -156,7 +160,7 @@ class UnionGenerator(
     }
 
     // generate a `equals()` implementation
-    private fun renderEquals(model: Model, sortedMembers: List<MemberShape>, typeName: String, writer: CodeWriter) {
+    private fun renderEquals(model: Model, sortedMembers: List<MemberShape>, typeName: String, writer: KotlinWriter) {
         writer.write("")
         writer.withBlock("override fun equals(other: #Q?): #Q {", "}", KotlinTypes.Any, KotlinTypes.Boolean) {
             write("if (this === other) return true")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
@@ -46,8 +46,7 @@ class DeserializeUnionGenerator(
      */
     override fun renderMemberShape(memberShape: MemberShape) {
         when (val targetShape = ctx.model.expectShape(memberShape.target)) {
-            is ListShape,
-            is SetShape -> renderListMemberDeserializer(memberShape, targetShape as CollectionShape)
+            is ListShape -> renderListMemberDeserializer(memberShape, targetShape as CollectionShape)
             is MapShape -> renderMapMemberDeserializer(memberShape, targetShape)
             is StructureShape,
             is UnionShape -> renderShapeDeserializer(memberShape)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -196,7 +196,7 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
         val operandName = expression.expression.accept(this)
         val truthinessName = addTempVar("${operandName}Truthiness", "truthiness($operandName)")
         val notName = "not${operandName.replaceFirstChar(Char::uppercaseChar)}"
-        return addTempVar(notName, "!${truthinessName}")
+        return addTempVar(notName, "!$truthinessName")
     }
 
     override fun visitObjectProjection(expression: ObjectProjectionExpression): String {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -73,12 +73,10 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
     override fun visitAnd(expression: AndExpression): String {
         writer.addImport(RuntimeTypes.Utils.truthiness)
 
-        val left = expression.left
-        val leftName = left.accept(this)
+        val leftName = expression.left.accept(this)
         val leftTruthinessName = addTempVar("${leftName}Truthiness", "truthiness($leftName)")
 
-        val right = expression.right
-        val rightName = right.accept(this)
+        val rightName = expression.right.accept(this)
 
         return addTempVar("and", "if ($leftTruthinessName) $rightName else $leftName")
     }
@@ -208,12 +206,10 @@ class KotlinJmespathExpressionVisitor(val writer: KotlinWriter) : ExpressionVisi
     override fun visitOr(expression: OrExpression): String {
         writer.addImport(RuntimeTypes.Utils.truthiness)
 
-        val left = expression.left
-        val leftName = left.accept(this)
+        val leftName = expression.left.accept(this)
         val leftTruthinessName = addTempVar("${leftName}Truthiness", "truthiness($leftName)")
 
-        val right = expression.right
-        val rightName = right.accept(this)
+        val rightName = expression.right.accept(this)
 
         return addTempVar("or", "if ($leftTruthinessName) $leftName else $rightName")
     }

--- a/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -1,4 +1,5 @@
 software.amazon.smithy.kotlin.codegen.lang.BuiltinPreprocessor
 software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor
+software.amazon.smithy.kotlin.codegen.model.SetRefactorPreprocessor
 software.amazon.smithy.kotlin.codegen.rendering.PaginatorGenerator
 software.amazon.smithy.kotlin.codegen.rendering.waiters.ServiceWaitersGenerator

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterTest.kt
@@ -4,19 +4,19 @@
  */
 package software.amazon.smithy.kotlin.codegen.core
 
-import software.amazon.smithy.utils.CodeWriter
+import software.amazon.smithy.utils.AbstractCodeWriter
+import software.amazon.smithy.utils.SimpleCodeWriter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class CodeWriterTest {
-
+class AbstractCodeWriterTest {
     @Test
     fun itSupportsInlineCodegen() {
-        val unit = CodeWriter()
+        val unit = SimpleCodeWriter()
 
         unit.putFormatter('W', InlineCodeWriterFormatter())
 
-        unit.write("Here is \$W content", { writer: CodeWriter -> writer.write("inline") })
+        unit.write("Here is \$W content", { writer: AbstractCodeWriter<*> -> writer.write("inline") })
 
         val actual = unit.toString()
 
@@ -25,7 +25,7 @@ class CodeWriterTest {
 
     @Test
     fun itSupportsDiscreteInlineWriters() {
-        val unit = CodeWriter()
+        val unit = SimpleCodeWriter()
 
         unit.putFormatter('W', InlineCodeWriterFormatter())
 
@@ -40,7 +40,7 @@ class CodeWriterTest {
 
     @Test
     fun itSupportsMultiLineInlineWriters() {
-        val unit = CodeWriter()
+        val unit = SimpleCodeWriter()
 
         unit.putFormatter('W', InlineCodeWriterFormatter())
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -177,13 +177,14 @@ class SymbolProviderTest {
         val model = """
             structure Record { }
 
-            set Records {
+            @uniqueItems
+            list Records {
                 member: Record,
             }
         """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
 
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
-        val setShape = model.expectShape<SetShape>("foo.bar#Records")
+        val setShape = model.expectShape<ListShape>("foo.bar#Records")
         val setSymbol = provider.toSymbol(setShape)
 
         assertEquals("Set<Record>", setSymbol.name)
@@ -328,7 +329,7 @@ class SymbolProviderTest {
         assertEquals("Document", documentSymbol.name)
         assertEquals("null", documentSymbol.defaultValue())
         assertEquals(true, documentSymbol.isBoxed)
-        assertEquals("${KotlinDependency.CORE.namespace}.smithy", documentSymbol.namespace)
+        assertEquals("${CORE.namespace}.smithy", documentSymbol.namespace)
         assertEquals(1, documentSymbol.dependencies.size)
     }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
 package software.amazon.smithy.kotlin.codegen.model
 
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
@@ -1,0 +1,71 @@
+package software.amazon.smithy.kotlin.codegen.model
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.UniqueItemsTrait
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class SetRefactorPreprocessorTest {
+    @Test
+    fun itRefactorsSetShapes() {
+        val model = """
+            namespace com.test
+            
+            service FooService {
+                version: "1.0.0"
+            }
+            
+            set OldSet {
+                member: String
+            }
+            
+            @uniqueItems
+            list NewSet {
+                member: String
+            }
+            
+            list RegularList {
+                member: String
+            }
+        """.toSmithyModel()
+
+        fun assertStringMember(shape: CollectionShape) {
+            val memberShape = model.expectShape(shape.member.target)
+            assertTrue(memberShape.isStringShape, "Expected member to have String type")
+        }
+
+        val settings = KotlinSettings(
+            ShapeId.from("com.test#FooService"),
+            KotlinSettings.PackageSettings(
+                "test",
+                "1.0",
+                "",
+            ),
+            "Foo"
+        )
+
+        val integration = SetRefactorPreprocessor()
+        val modified = integration.preprocessModel(model, settings)
+
+        val oldSet = modified.expectShape(ShapeId.from("com.test#OldSet"))
+        assertIs<ListShape>(oldSet)
+        assertTrue(oldSet.hasTrait<UniqueItemsTrait>(), "Expected old set to have @uniqueItems trait")
+        assertStringMember(oldSet)
+
+        val newSet = modified.expectShape(ShapeId.from("com.test#NewSet"))
+        assertIs<ListShape>(newSet)
+        assertTrue(newSet.hasTrait<UniqueItemsTrait>(), "Expected new set to have @uniqueItems trait")
+        assertStringMember(newSet)
+
+        val regularList = modified.expectShape(ShapeId.from("com.test#RegularList"))
+        assertIs<ListShape>(regularList)
+        assertFalse(regularList.hasTrait<UniqueItemsTrait>(), "Expected regular list not to have @uniqueItems trait")
+        assertStringMember(regularList)
+    }
+}

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -553,7 +553,8 @@ class DeserializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }            
         """
@@ -592,7 +593,8 @@ class DeserializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: StringMap
             }
             
@@ -644,7 +646,8 @@ class DeserializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: StringList
             }
             
@@ -698,7 +701,8 @@ class DeserializeStructGeneratorTest {
                 payload: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -733,7 +737,8 @@ class DeserializeStructGeneratorTest {
                 member: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -784,7 +789,8 @@ class DeserializeStructGeneratorTest {
                 value: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -841,7 +847,8 @@ class DeserializeStructGeneratorTest {
                 value: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
@@ -557,7 +557,8 @@ class SerializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }            
         """
@@ -588,7 +589,8 @@ class SerializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: StringMap
             }
             
@@ -626,7 +628,8 @@ class SerializeStructGeneratorTest {
                 payload: IntegerSet
             }
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: StringList
             }
             
@@ -669,7 +672,8 @@ class SerializeStructGeneratorTest {
                 payload: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -698,7 +702,8 @@ class SerializeStructGeneratorTest {
                 member: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -738,7 +743,8 @@ class SerializeStructGeneratorTest {
                 value: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """
@@ -779,7 +785,8 @@ class SerializeStructGeneratorTest {
                 value: IntegerSet
             }            
             
-            set IntegerSet {
+            @uniqueItems
+            list IntegerSet {
                 member: Integer
             }
         """

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitorTest.kt
@@ -18,7 +18,18 @@ import kotlin.test.fail
 class KotlinJmespathExpressionVisitorTest {
     @Test
     fun testAndExpression() {
-        assertUnimplemented(path = "foo && bar")
+        assertVisit(
+            path = "foo && bar",
+            expectedActualName = "and",
+            expectedCodegen = """
+                import aws.smithy.kotlin.runtime.util.truthiness
+                
+                val foo = it?.foo
+                val fooTruthiness = truthiness(foo)
+                val bar = it?.bar
+                val and = if (fooTruthiness) bar else foo
+            """.trimIndent(),
+        )
     }
 
     @Test
@@ -205,7 +216,17 @@ class KotlinJmespathExpressionVisitorTest {
 
     @Test
     fun testNotExpression() {
-        assertUnimplemented(path = "!foo")
+        assertVisit(
+            path = "!foo",
+            expectedActualName = "notFoo",
+            expectedCodegen = """
+                import aws.smithy.kotlin.runtime.util.truthiness
+                
+                val foo = it?.foo
+                val fooTruthiness = truthiness(foo)
+                val notFoo = !fooTruthiness
+            """.trimIndent(),
+        )
     }
 
     @Test
@@ -220,6 +241,22 @@ class KotlinJmespathExpressionVisitorTest {
                     val bar = it?.bar
                     listOfNotNull(bar)
                 }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun testOrExpression() {
+        assertVisit(
+            path = "foo || bar",
+            expectedActualName = "or",
+            expectedCodegen = """
+                import aws.smithy.kotlin.runtime.util.truthiness
+                
+                val foo = it?.foo
+                val fooTruthiness = truthiness(foo)
+                val bar = it?.bar
+                val or = if (fooTruthiness) foo else bar
             """.trimIndent(),
         )
     }
@@ -240,11 +277,6 @@ class KotlinJmespathExpressionVisitorTest {
                 }
             """.trimIndent(),
         )
-    }
-
-    @Test
-    fun testOrExpression() {
-        assertUnimplemented(path = "foo || bar")
     }
 
     @Test


### PR DESCRIPTION
## Issue \#

Closes #599 

## Description of changes

This change upgrades from Smithy 1.17 to 1.22:
* The biggest change between the versions is the deprecation of `set` shapes and their replacement with `list` shapes annotated with the `@uniqueItems` trait. Accordingly, this PR updates several uses of set-based classes from Smithy and adds an automatic translator to replace legacy `set` shapes in model files with new lists.
* Additionally, `CodeWriter` is deprecated and replaced with `AbstractCodeWriter` and a default `SimpleCodeWriter` implementation.

**Companion PR**: [aws-sdk-kotlin#647](https://github.com/awslabs/aws-sdk-kotlin/pull/647)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.