### PR TITLE
Fix smithy sets

### DIFF
--- a/.changes/9bbbf88e-193f-4efa-955a-10c17c1d7e83.json
+++ b/.changes/9bbbf88e-193f-4efa-955a-10c17c1d7e83.json
@@ -1,0 +1,5 @@
+{
+    "id": "9bbbf88e-193f-4efa-955a-10c17c1d7e83",
+    "type": "bugfix",
+    "description": "**Breaking**: Generate `List<T>` members for all collection types. (Previously, `Set<T>` would be generated for lists decorated with `@uniqueItems`.)"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.hierarchicalStructureSupport=false
 
 # SDK
-sdkVersion=0.11.3-SNAPSHOT
+sdkVersion=0.12.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.7.0

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.BoxTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.StreamingTrait
-import software.amazon.smithy.model.traits.UniqueItemsTrait
 import java.util.logging.Logger
 
 /**
@@ -147,19 +146,11 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     override fun listShape(shape: ListShape): Symbol {
         val reference = toSymbol(shape.member)
         val valueType = if (shape.hasTrait<SparseTrait>()) "${reference.name}?" else reference.name
-        return if (shape.hasTrait<UniqueItemsTrait>()) {
-            createSymbolBuilder(shape, "Set<$valueType>", boxed = true)
-                .addReference(reference)
-                .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableSetOf<$valueType>")
-                .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "setOf<$valueType>")
-                .build()
-        } else {
-            createSymbolBuilder(shape, "List<$valueType>", boxed = true)
-                .addReferences(reference)
-                .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableListOf<$valueType>")
-                .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "listOf<$valueType>")
-                .build()
-        }
+        return createSymbolBuilder(shape, "List<$valueType>", boxed = true)
+            .addReferences(reference)
+            .putProperty(SymbolProperty.MUTABLE_COLLECTION_FUNCTION, "mutableListOf<$valueType>")
+            .putProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION, "listOf<$valueType>")
+            .build()
     }
 
     override fun mapShape(shape: MapShape): Symbol {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -173,7 +173,7 @@ class SymbolProviderTest {
     }
 
     @Test
-    fun `creates sets`() {
+    fun `creates lists even when @uniqueItems is present`() {
         val model = """
             structure Record { }
 
@@ -184,15 +184,15 @@ class SymbolProviderTest {
         """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
 
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
-        val setShape = model.expectShape<ListShape>("foo.bar#Records")
-        val setSymbol = provider.toSymbol(setShape)
+        val listShape = model.expectShape<ListShape>("foo.bar#Records")
+        val listSymbol = provider.toSymbol(listShape)
 
-        assertEquals("Set<Record>", setSymbol.name)
-        assertEquals(true, setSymbol.isBoxed)
-        assertEquals("null", setSymbol.defaultValue())
+        assertEquals("List<Record>", listSymbol.name)
+        assertEquals(true, listSymbol.isBoxed)
+        assertEquals("null", listSymbol.defaultValue())
 
         // collections should contain a reference to the member type
-        assertEquals("Record", setSymbol.references[0].symbol.name)
+        assertEquals("Record", listSymbol.references[0].symbol.name)
     }
 
     @Test

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -546,7 +546,7 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a set of primitive values`() {
+    fun `it deserializes a structure containing a list of unique primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
@@ -566,7 +566,7 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeList(PAYLOAD_DESCRIPTOR) {
-                                val col0 = mutableSetOf<Int>()
+                                val col0 = mutableListOf<Int>()
                                 while (hasNextElement()) {
                                     val el0 = if (nextHasValue()) { deserializeInt() } else { deserializeNull(); continue }
                                     col0.add(el0)
@@ -586,15 +586,15 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a set of a map primitive values`() {
+    fun `it deserializes a structure containing a list of unique maps`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
-                payload: IntegerSet
+                payload: MapSet
             }
             
             @uniqueItems
-            list IntegerSet {
+            list MapSet {
                 member: StringMap
             }
             
@@ -611,7 +611,7 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeList(PAYLOAD_DESCRIPTOR) {
-                                val col0 = mutableSetOf<Map<String, String>>()
+                                val col0 = mutableListOf<Map<String, String>>()
                                 while (hasNextElement()) {
                                     val el0 = deserializer.deserializeMap(PAYLOAD_C0_DESCRIPTOR) {
                                         val map1 = mutableMapOf<String, String>()
@@ -639,15 +639,15 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a set of a list of primitive values`() {
+    fun `it deserializes a structure containing a list of unique lists of primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
-                payload: IntegerSet
+                payload: ListSet
             }
             
             @uniqueItems
-            list IntegerSet {
+            list ListSet {
                 member: StringList
             }
             
@@ -663,7 +663,7 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeList(PAYLOAD_DESCRIPTOR) {
-                                val col0 = mutableSetOf<List<String>>()
+                                val col0 = mutableListOf<List<String>>()
                                 while (hasNextElement()) {
                                     val el0 = deserializer.deserializeList(PAYLOAD_C0_DESCRIPTOR) {
                                         val col1 = mutableListOf<String>()
@@ -690,7 +690,7 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a nested structure of a set of primitive values`() {
+    fun `it deserializes a structure containing a nested structure of a list of unique primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
@@ -726,7 +726,7 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a list of a set of primitive values`() {
+    fun `it deserializes a structure containing a list of a list of unique primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
@@ -750,10 +750,10 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeList(PAYLOAD_DESCRIPTOR) {
-                                val col0 = mutableListOf<Set<Int>>()
+                                val col0 = mutableListOf<List<Int>>()
                                 while (hasNextElement()) {
                                     val el0 = deserializer.deserializeList(PAYLOAD_C0_DESCRIPTOR) {
-                                        val col1 = mutableSetOf<Int>()
+                                        val col1 = mutableListOf<Int>()
                                         while (hasNextElement()) {
                                             val el1 = if (nextHasValue()) { deserializeInt() } else { deserializeNull(); continue }
                                             col1.add(el1)
@@ -777,7 +777,7 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a map of a set of primitive values`() {
+    fun `it deserializes a structure containing a map of a list of unique primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
@@ -802,13 +802,13 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeMap(PAYLOAD_DESCRIPTOR) {
-                                val map0 = mutableMapOf<String, Set<Int>>()
+                                val map0 = mutableMapOf<String, List<Int>>()
                                 while (hasNextEntry()) {
                                     val k0 = key()
                                     val v0 =
                                         if (nextHasValue()) {
                                             deserializer.deserializeList(PAYLOAD_C0_DESCRIPTOR) {
-                                                val col1 = mutableSetOf<Int>()
+                                                val col1 = mutableListOf<Int>()
                                                 while (hasNextElement()) {
                                                     val el1 = if (nextHasValue()) { deserializeInt() } else { deserializeNull(); continue }
                                                     col1.add(el1)
@@ -834,7 +834,7 @@ class DeserializeStructGeneratorTest {
     }
 
     @Test
-    fun `it deserializes a structure containing a sparse map of a set of primitive values`() {
+    fun `it deserializes a structure containing a sparse map of a list of unique primitive values`() {
         val model = (
             modelPrefix + """            
             structure FooResponse { 
@@ -860,13 +860,13 @@ class DeserializeStructGeneratorTest {
                     when (findNextFieldIndex()) {
                         PAYLOAD_DESCRIPTOR.index -> builder.payload =
                             deserializer.deserializeMap(PAYLOAD_DESCRIPTOR) {
-                                val map0 = mutableMapOf<String, Set<Int>?>()
+                                val map0 = mutableMapOf<String, List<Int>?>()
                                 while (hasNextEntry()) {
                                     val k0 = key()
                                     val v0 =
                                         if (nextHasValue()) {
                                             deserializer.deserializeList(PAYLOAD_C0_DESCRIPTOR) {
-                                                val col1 = mutableSetOf<Int>()
+                                                val col1 = mutableListOf<Int>()
                                                 while (hasNextElement()) {
                                                     val el1 = if (nextHasValue()) { deserializeInt() } else { deserializeNull(); continue }
                                                     col1.add(el1)


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Missed during [the recent Smithy 1.22 upgrade](https://github.com/awslabs/smithy-kotlin/pull/672) was that sets should be fully replaced with lists _even in codegen_ (i.e., not just models). Thus, no longer generating `Set<T>` for members and ignoring `@uniqueItems` traits.

This is a **breaking change** which will mandate a minor version bump.

**Companion PR**: (link coming soon)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.