### PR TITLE
Feat dsl overloads as ext methods

### DIFF
--- a/.changes/e1fa257d-73b3-4616-8c39-f32956008124.json
+++ b/.changes/e1fa257d-73b3-4616-8c39-f32956008124.json
@@ -1,0 +1,5 @@
+{
+    "id": "e1fa257d-73b3-4616-8c39-f32956008124",
+    "type": "bugfix",
+    "description": "**Breaking**: Move DSL overloads on generated clients to extension methods"
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
@@ -80,16 +80,12 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
                 renderServiceConfig()
             }
             .call {
-                operations.forEach { op ->
-                    renderOperation(operationsIndex, op)
-                }
+                operations.forEach { renderOperation(operationsIndex, it) }
             }
             .closeBlock("}")
             .write("")
 
-        operations.forEach { op ->
-            renderOperationDslOverload(operationsIndex, op)
-        }
+        operations.forEach { renderOperationDslOverload(operationsIndex, it) }
     }
 
     private fun renderServiceConfig() {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGenerator.kt
@@ -86,6 +86,10 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
             }
             .closeBlock("}")
             .write("")
+
+        operations.forEach { op ->
+            renderOperationDslOverload(operationsIndex, op)
+        }
     }
 
     private fun renderServiceConfig() {
@@ -154,7 +158,9 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.renderDocumentation(op)
         writer.renderAnnotations(op)
         writer.write(opIndex.operationSignature(ctx.model, ctx.symbolProvider, op, includeOptionalDefault = true))
+    }
 
+    private fun renderOperationDslOverload(opIndex: OperationIndex, op: OperationShape) {
         // Add DSL overload (if appropriate)
         opIndex.getInput(op).ifPresent { inputShape ->
             val outputShape = opIndex.getOutput(op)
@@ -167,7 +173,7 @@ class ServiceGenerator(private val ctx: RenderingContext<ServiceShape>) {
                 writer.write("")
                 writer.renderDocumentation(op)
                 writer.renderAnnotations(op)
-                val signature = "suspend fun $operationName(block: $input.Builder.() -> Unit)"
+                val signature = "suspend inline fun ${serviceSymbol.name}.$operationName(crossinline block: $input.Builder.() -> Unit)"
                 val impl = "$operationName($input.Builder().apply(block).build())"
                 writer.write("$signature = $impl")
             }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -233,6 +233,7 @@ class StructureGenerator(
                 write("")
 
                 // generate the constructor used internally by serde
+                write("@PublishedApi")
                 write("internal constructor()")
                 // generate the constructor that converts from the underlying immutable class to a builder instance
                 writer.write("@PublishedApi")

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -164,11 +164,11 @@ class ServiceGeneratorTest {
     @Test
     fun `it adds DSL overloads for operations`() {
         val expectedSignatures = listOf(
-            "suspend fun getFoo(block: GetFooRequest.Builder.() -> Unit) = getFoo(GetFooRequest.Builder().apply(block).build())",
-            "suspend fun getFooNoInput(block: GetFooNoInputRequest.Builder.() -> Unit) = getFooNoInput(GetFooNoInputRequest.Builder().apply(block).build())",
-            "suspend fun getFooNoOutput(block: GetFooNoOutputRequest.Builder.() -> Unit) = getFooNoOutput(GetFooNoOutputRequest.Builder().apply(block).build())",
-            "suspend fun getFooStreamingInput(block: GetFooStreamingInputRequest.Builder.() -> Unit) = getFooStreamingInput(GetFooStreamingInputRequest.Builder().apply(block).build())",
-            "suspend fun getFooStreamingInputNoOutput(block: GetFooStreamingInputNoOutputRequest.Builder.() -> Unit) = getFooStreamingInputNoOutput(GetFooStreamingInputNoOutputRequest.Builder().apply(block).build())",
+            "suspend inline fun TestClient.getFoo(crossinline block: GetFooRequest.Builder.() -> Unit) = getFoo(GetFooRequest.Builder().apply(block).build())",
+            "suspend inline fun TestClient.getFooNoInput(crossinline block: GetFooNoInputRequest.Builder.() -> Unit) = getFooNoInput(GetFooNoInputRequest.Builder().apply(block).build())",
+            "suspend inline fun TestClient.getFooNoOutput(crossinline block: GetFooNoOutputRequest.Builder.() -> Unit) = getFooNoOutput(GetFooNoOutputRequest.Builder().apply(block).build())",
+            "suspend inline fun TestClient.getFooStreamingInput(crossinline block: GetFooStreamingInputRequest.Builder.() -> Unit) = getFooStreamingInput(GetFooStreamingInputRequest.Builder().apply(block).build())",
+            "suspend inline fun TestClient.getFooStreamingInputNoOutput(crossinline block: GetFooStreamingInputNoOutputRequest.Builder.() -> Unit) = getFooStreamingInputNoOutput(GetFooStreamingInputNoOutputRequest.Builder().apply(block).build())",
         )
         expectedSignatures.forEach {
             commonTestContents.shouldContainOnlyOnceWithDiff(it)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -174,6 +174,7 @@ class StructureGeneratorTest {
                 var `object`: kotlin.String? = null
                 var quux: com.test.model.Qux? = null
         
+                @PublishedApi
                 internal constructor()
                 @PublishedApi
                 internal constructor(x: com.test.model.MyStruct) : this() {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Move DSL overloads for builder-style invocation of generated operations out of the client interface and into extension methods. This is generally correct since the behavior is a convenience and not a separate function that inheritors need to implement. It has the additional benefit of simplifying unit testing and mocking.

This is a **breaking change** since now these extension methods require a different import than before.

**Companion PR**: [aws-sdk-kotlin#653](https://github.com/awslabs/aws-sdk-kotlin/pull/653)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
