### PR TITLE
chore: enable explicit API mode for codegen

### DIFF
--- a/.changes/4d59fd7e-dde7-4816-8485-cc3140a41512.json
+++ b/.changes/4d59fd7e-dde7-4816-8485-cc3140a41512.json
@@ -1,0 +1,5 @@
+{
+    "id": "4d59fd7e-dde7-4816-8485-cc3140a41512",
+    "type": "misc",
+    "description": "Enable [Explicit API mode](https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md)"
+}

--- a/smithy-kotlin-codegen/build.gradle.kts
+++ b/smithy-kotlin-codegen/build.gradle.kts
@@ -90,6 +90,9 @@ tasks.test {
     testLogging {
         events("passed", "skipped", "failed")
         showStandardStreams = true
+        showStackTraces = true
+        showExceptions = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
 }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
@@ -109,8 +109,8 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
         writer.renderDocumentation(shape)
         writer.renderAnnotations(shape)
         // NOTE: The smithy spec only allows string shapes to apply to a string shape at the moment
-        writer.withBlock("sealed class ${symbol.name} {", "}") {
-            write("\nabstract val value: #Q\n", KotlinTypes.String)
+        writer.withBlock("public sealed class ${symbol.name} {", "}") {
+            write("\npublic abstract val value: #Q\n", KotlinTypes.String)
 
             val sortedDefinitions = enumTrait
                 .values
@@ -124,16 +124,16 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
             if (generatedNames.contains("SdkUnknown")) throw CodegenException("generating SdkUnknown would cause duplicate variant for enum shape: $shape")
 
             // generate the unknown which will always be last
-            writer.withBlock("data class SdkUnknown(override val value: #Q) : #Q() {", "}", KotlinTypes.String, symbol) {
+            writer.withBlock("public data class SdkUnknown(override val value: #Q) : #Q() {", "}", KotlinTypes.String, symbol) {
                 renderToStringOverride()
             }
 
             write("")
 
             // generate the fromValue() static method
-            withBlock("companion object {", "}") {
+            withBlock("public companion object {", "}") {
                 writer.dokka("Convert a raw value to one of the sealed variants or [SdkUnknown]")
-                openBlock("fun fromValue(str: #Q): #Q = when(str) {", KotlinTypes.String, symbol)
+                openBlock("public fun fromValue(str: #Q): #Q = when(str) {", KotlinTypes.String, symbol)
                     .call {
                         sortedDefinitions.forEach { definition ->
                             val variantName = getVariantName(definition)
@@ -145,7 +145,7 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
                     .write("")
 
                 writer.dokka("Get a list of all possible variants")
-                openBlock("fun values(): #Q<#Q> = listOf(", KotlinTypes.Collections.List, symbol)
+                openBlock("public fun values(): #Q<#Q> = listOf(", KotlinTypes.Collections.List, symbol)
                     .call {
                         sortedDefinitions.forEachIndexed { idx, definition ->
                             val variantName = getVariantName(definition)
@@ -170,7 +170,7 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
             throw CodegenException("prefixing invalid enum value to form a valid Kotlin identifier causes generated sealed class names to not be unique: $variantName; shape=$shape")
         }
 
-        writer.openBlock("object $variantName : #Q() {", symbol)
+        writer.openBlock("public object $variantName : #Q() {", symbol)
             .write("override val value: #Q = #S", KotlinTypes.String, definition.value)
             .call { renderToStringOverride() }
             .closeBlock("}")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -34,14 +34,14 @@ object ExceptionBaseClassGenerator {
         val name = clientName(ctx.settings.sdkId)
         writer.dokka("Base class for all service related exceptions thrown by the $name client")
         writer.withBlock(
-            "open class #T : #T {", "}",
+            "public open class #T : #T {", "}",
             serviceException,
             baseException
         ) {
-            write("constructor() : super()")
-            write("constructor(message: String?) : super(message)")
-            write("constructor(message: String?, cause: Throwable?) : super(message, cause)")
-            write("constructor(cause: Throwable?) : super(cause)")
+            write("public constructor() : super()")
+            write("public constructor(message: String?) : super(message)")
+            write("public constructor(message: String?, cause: Throwable?) : super(message, cause)")
+            write("public constructor(cause: Throwable?) : super(cause)")
 
             writer.declareSection(ExceptionBaseClassSection)
         }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGenerator.kt
@@ -98,6 +98,7 @@ fun renderKmpGradleBuild(
         
         kotlin {
             #W
+            #W
             sourceSets {
                 val commonMain by getting {
                     dependencies {
@@ -119,6 +120,7 @@ fun renderKmpGradleBuild(
         }
         """.trimIndent(),
         pluginsRenderer,
+        { w: GradleWriter -> if (isRootModule) w.write("explicitApi()") },
         { w: GradleWriter -> if (isRootModule) repositoryRenderer(w) },
         { w: GradleWriter -> if (isRootModule) renderRootJvmPluginConfig(w) else w.write("jvm()") },
         { w: GradleWriter -> renderDependencies(w, scope = Scope.SOURCE, isKmp = true, dependencies = dependencies) },
@@ -168,8 +170,11 @@ fun renderJvmGradleBuild(
         val optInAnnotations = listOf(
             #W
         )
-        kotlin.sourceSets.all {
-            optInAnnotations.forEach { languageSettings.optIn(it) }
+        kotlin {
+            #W
+            sourceSets.all {
+                optInAnnotations.forEach { languageSettings.optIn(it) }
+            }
         }
 
         tasks.test {
@@ -183,7 +188,8 @@ fun renderJvmGradleBuild(
         pluginsRenderer,
         { w: GradleWriter -> if (isRootModule) repositoryRenderer(w) },
         { w: GradleWriter -> renderDependencies(w, scope = Scope.SOURCE, isKmp = false, dependencies = dependencies) },
-        annotationRenderer
+        annotationRenderer,
+        { w: GradleWriter -> if (isRootModule) w.write("explicitApi()") },
     )
 }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt
@@ -131,7 +131,7 @@ class PaginatorGenerator : KotlinIntegration {
             )
             .addImportReferences(cursorSymbol, SymbolReference.ContextOption.DECLARE)
             .withBlock(
-                "fun #T.#LPaginated(initialRequest: #T): #T<#T> =",
+                "public fun #T.#LPaginated(initialRequest: #T): #T<#T> =",
                 "",
                 serviceSymbol,
                 operationShape.defaultName(),
@@ -168,7 +168,7 @@ class PaginatorGenerator : KotlinIntegration {
                 """.trimMargin()
             )
             .withBlock(
-                "fun #T.#LPaginated(block: #T.Builder.() -> #T): #T<#T> =",
+                "public fun #T.#LPaginated(block: #T.Builder.() -> #T): #T<#T> =",
                 "",
                 serviceSymbol,
                 operationShape.defaultName(),
@@ -211,7 +211,7 @@ class PaginatorGenerator : KotlinIntegration {
                 itemDesc.targetMember.defaultName(serviceShape)
             )
             .withBlock(
-                "fun #T<#T>.#L(): #T<#L> =", "",
+                "public fun #T<#T>.#L(): #T<#L> =", "",
                 ExternalTypes.KotlinxCoroutines.Flow,
                 outputSymbol,
                 itemDesc.itemLiteral,

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -51,7 +51,7 @@ class StructureGenerator(
      * Renders a normal (non-error) Smithy structure to a Kotlin class
      */
     private fun renderStructure() {
-        writer.openBlock("class #T private constructor(builder: Builder) {", symbol)
+        writer.openBlock("public class #T private constructor(builder: Builder) {", symbol)
             .call { renderImmutableProperties() }
             .write("")
             .call { renderCompanionObject() }
@@ -87,18 +87,18 @@ class StructureGenerator(
 
             memberShape.hasTrait<HttpLabelTrait>() ->
                 writer.write(
-                    """val #1L: #2F = requireNotNull(builder.#1L) { "A non-null value must be provided for #1L" }""",
+                    """public val #1L: #2F = requireNotNull(builder.#1L) { "A non-null value must be provided for #1L" }""",
                     memberName,
                     memberSymbol,
                 )
 
-            else -> writer.write("val #1L: #2F = builder.#1L", memberName, memberSymbol)
+            else -> writer.write("public val #1L: #2F = builder.#1L", memberName, memberSymbol)
         }
     }
 
     private fun renderCompanionObject() {
-        writer.withBlock("companion object {", "}") {
-            write("operator fun invoke(block: Builder.() -> #Q): #Q = Builder().apply(block).build()", KotlinTypes.Unit, symbol)
+        writer.withBlock("public companion object {", "}") {
+            write("public operator fun invoke(block: Builder.() -> #Q): #Q = Builder().apply(block).build()", KotlinTypes.Unit, symbol)
         }
     }
 
@@ -216,19 +216,19 @@ class StructureGenerator(
         // situation we have with constructors and positional arguments not playing well
         // with models evolving over time (e.g. new fields in different positions)
         writer.write("")
-            .write("inline fun copy(block: Builder.() -> #Q = {}): #Q = Builder(this).apply(block).build()", KotlinTypes.Unit, symbol)
+            .write("public inline fun copy(block: Builder.() -> #Q = {}): #Q = Builder(this).apply(block).build()", KotlinTypes.Unit, symbol)
             .write("")
     }
 
     private fun renderBuilder() {
         writer.write("")
-            .withBlock("class Builder {", "}") {
+            .withBlock("public class Builder {", "}") {
                 for (member in sortedMembers) {
                     val (memberName, memberSymbol) = memberNameSymbolIndex[member]!!
                     // we want the type names sans nullability (?) for arguments
                     writer.renderMemberDocumentation(model, member)
                     writer.renderAnnotations(member)
-                    write("var #L: #E", memberName, memberSymbol)
+                    write("public var #L: #E", memberName, memberSymbol)
                 }
                 write("")
 
@@ -258,7 +258,7 @@ class StructureGenerator(
                     val (memberName, memberSymbol) = memberNameSymbolIndex[member]!!
                     writer.dokka("construct an [${memberSymbol.fullName}] inside the given [block]")
                     writer.renderAnnotations(member)
-                    openBlock("fun #L(block: #Q.Builder.() -> #Q) {", memberName, memberSymbol, KotlinTypes.Unit)
+                    openBlock("public fun #L(block: #Q.Builder.() -> #Q) {", memberName, memberSymbol, KotlinTypes.Unit)
                         .write("this.#L = #Q.invoke(block)", memberName, memberSymbol)
                         .closeBlock("}")
                 }
@@ -280,7 +280,7 @@ class StructureGenerator(
         val exceptionBaseClass = ExceptionBaseClassGenerator.baseExceptionSymbol(ctx.settings)
         writer.addImport(exceptionBaseClass)
 
-        writer.openBlock("class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {", symbol)
+        writer.openBlock("public class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {", symbol)
             .write("")
             .call { renderImmutableProperties() }
             .write("")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGenerator.kt
@@ -59,7 +59,7 @@ internal fun KotlinWriter.renderWaiter(wi: WaiterInfo) {
     write("")
     wi.waiter.documentation.ifPresent(::dokka)
     withBlock(
-        "suspend fun #T.#L(request: #T): Outcome<#T> {",
+        "public suspend fun #T.#L(request: #T): Outcome<#T> {",
         "}",
         wi.serviceSymbol,
         wi.methodName,
@@ -77,7 +77,7 @@ internal fun KotlinWriter.renderWaiter(wi: WaiterInfo) {
     write("")
     wi.waiter.documentation.ifPresent(this::dokka)
     write(
-        "suspend fun #T.#L(block: #T.Builder.() -> Unit): Outcome<#T> =",
+        "public suspend fun #T.#L(block: #T.Builder.() -> Unit): Outcome<#T> =",
         wi.serviceSymbol,
         wi.methodName,
         wi.inputSymbol,

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -35,37 +35,37 @@ class ClientConfigGeneratorTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedCtor = """
-class Config private constructor(builder: Builder): HttpClientConfig, IdempotencyTokenConfig, SdkClientConfig {
+public class Config private constructor(builder: Builder): HttpClientConfig, IdempotencyTokenConfig, SdkClientConfig {
 """
         contents.shouldContainWithDiff(expectedCtor)
 
         val expectedProps = """
-    val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
+    public val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
-    val retryStrategy: RetryStrategy = StandardRetryStrategy()
+    public val retryStrategy: RetryStrategy = StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilder = """
-    class Builder {
+    public class Builder {
         /**
          * Set the [aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver] used to resolve service endpoints. Operation requests will be
          * made against the endpoint returned by the resolver.
          */
-        var endpointResolver: EndpointResolver? = null
+        public var endpointResolver: EndpointResolver? = null
         /**
          * Override the default HTTP client engine used to make SDK requests (e.g. configure proxy behavior, timeouts, concurrency, etc).
          * NOTE: The caller is responsible for managing the lifetime of the engine when set. The SDK
          * client will not close it when the client is closed.
          */
-        var httpClientEngine: HttpClientEngine? = null
+        public var httpClientEngine: HttpClientEngine? = null
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
          * that represent idempotent tokens when not explicitly set by the caller using this generator.
          */
-        var idempotencyTokenProvider: IdempotencyTokenProvider? = null
+        public var idempotencyTokenProvider: IdempotencyTokenProvider? = null
         /**
          * Configure events that will be logged. By default clients will not output
          * raw requests or responses. Use this setting to opt-in to additional debug logging.
@@ -76,7 +76,7 @@ class Config private constructor(builder: Builder): HttpClientConfig, Idempotenc
          * performance considerations when dumping the request/response body. This is primarily a tool for
          * debug purposes.
          */
-        var sdkLogMode: SdkLogMode = SdkLogMode.Default
+        public var sdkLogMode: SdkLogMode = SdkLogMode.Default
 
         @PublishedApi
         internal fun build(): Config = Config(this)
@@ -120,29 +120,29 @@ class Config private constructor(builder: Builder): HttpClientConfig, Idempotenc
 
         // we should have no base classes when not using the default and no inheritFrom specified
         val expectedCtor = """
-class Config private constructor(builder: Builder) {
+public class Config private constructor(builder: Builder) {
 """
         contents.shouldContain(expectedCtor)
 
         val expectedProps = """
-        var boolProp: Boolean? = null
+        public var boolProp: Boolean? = null
         /**
          * non-null-int
          */
-        var intProp: Int = 1
-        var nullIntProp: Int? = null
-        var stringProp: String? = null
+        public var intProp: Int = 1
+        public var nullIntProp: Int? = null
+        public var stringProp: String? = null
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilderProps = """
-        var boolProp: Boolean? = null
+        public var boolProp: Boolean? = null
         /**
          * non-null-int
          */
-        var intProp: Int = 1
-        var nullIntProp: Int? = null
-        var stringProp: String? = null
+        public var intProp: Int = 1
+        public var nullIntProp: Int? = null
+        public var stringProp: String? = null
 """
         contents.shouldContainWithDiff(expectedBuilderProps)
     }
@@ -167,7 +167,7 @@ class Config private constructor(builder: Builder) {
         val contents = writer.toString()
 
         val expectedProps = """
-    val customProp: Int? = builder.customProp
+    public val customProp: Int? = builder.customProp
 """
         contents.shouldContain(expectedProps)
     }
@@ -251,8 +251,8 @@ class Config private constructor(builder: Builder) {
         contents.assertBalancedBracesAndParens()
 
         val expectedCompanion = """
-    companion object {
-        inline operator fun invoke(block: Builder.() -> kotlin.Unit): Config = Builder().apply(block).build()
+    public companion object {
+        public inline operator fun invoke(block: Builder.() -> kotlin.Unit): Config = Builder().apply(block).build()
     }
 """
         contents.shouldContainWithDiff(expectedCompanion)
@@ -303,21 +303,21 @@ class Config private constructor(builder: Builder) {
         val contents = writer.toString()
 
         val expectedProps = """
-    val constFoo: Foo = ConstantFoo
-    val defaultFoo: Foo = builder.defaultFoo
-    val nullFoo: Foo? = builder.nullFoo
-    val requiredDefaultedFoo: Foo = builder.requiredDefaultedFoo ?: DefaultedFoo()
-    val requiredFoo: Foo = requireNotNull(builder.requiredFoo) { "requiredFoo is a required configuration property" }
-    val requiredFoo2: Foo = requireNotNull(builder.requiredFoo2) { "override message" }
+    public val constFoo: Foo = ConstantFoo
+    public val defaultFoo: Foo = builder.defaultFoo
+    public val nullFoo: Foo? = builder.nullFoo
+    public val requiredDefaultedFoo: Foo = builder.requiredDefaultedFoo ?: DefaultedFoo()
+    public val requiredFoo: Foo = requireNotNull(builder.requiredFoo) { "requiredFoo is a required configuration property" }
+    public val requiredFoo2: Foo = requireNotNull(builder.requiredFoo2) { "override message" }
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedImplProps = """
-        var defaultFoo: Foo = DefaultFoo
-        var nullFoo: Foo? = null
-        var requiredDefaultedFoo: Foo? = null
-        var requiredFoo: Foo? = null
-        var requiredFoo2: Foo? = null
+        public var defaultFoo: Foo = DefaultFoo
+        public var nullFoo: Foo? = null
+        public var requiredDefaultedFoo: Foo? = null
+        public var requiredFoo: Foo? = null
+        public var requiredFoo2: Foo? = null
 """
         contents.shouldContainWithDiff(expectedImplProps)
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
@@ -45,32 +45,32 @@ class EnumGeneratorTest {
 /**
  * Documentation for this enum
  */
-sealed class Baz {
+public sealed class Baz {
 
-    abstract val value: kotlin.String
+    public abstract val value: kotlin.String
 
     /**
      * Documentation for bar
      */
-    object Bar : test.model.Baz() {
+    public object Bar : test.model.Baz() {
         override val value: kotlin.String = "BAR"
         override fun toString(): kotlin.String = value
     }
 
-    object Foo : test.model.Baz() {
+    public object Foo : test.model.Baz() {
         override val value: kotlin.String = "FOO"
         override fun toString(): kotlin.String = value
     }
 
-    data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
+    public data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
         override fun toString(): kotlin.String = value
     }
 
-    companion object {
+    public companion object {
         /**
          * Convert a raw value to one of the sealed variants or [SdkUnknown]
          */
-        fun fromValue(str: kotlin.String): test.model.Baz = when(str) {
+        public fun fromValue(str: kotlin.String): test.model.Baz = when(str) {
             "BAR" -> Bar
             "FOO" -> Foo
             else -> SdkUnknown(str)
@@ -79,7 +79,7 @@ sealed class Baz {
         /**
          * Get a list of all possible variants
          */
-        fun values(): kotlin.collections.List<test.model.Baz> = listOf(
+        public fun values(): kotlin.collections.List<test.model.Baz> = listOf(
             Bar,
             Foo
         )
@@ -125,9 +125,9 @@ sealed class Baz {
 /**
  * Documentation for this enum
  */
-sealed class Baz {
+public sealed class Baz {
 
-    abstract val value: kotlin.String
+    public abstract val value: kotlin.String
 
     /**
      * T2 instances are Burstable Performance
@@ -135,25 +135,25 @@ sealed class Baz {
      * performance with the ability to burst above the
      * baseline.
      */
-    object T2Micro : test.model.Baz() {
+    public object T2Micro : test.model.Baz() {
         override val value: kotlin.String = "t2.micro"
         override fun toString(): kotlin.String = value
     }
 
-    object T2Nano : test.model.Baz() {
+    public object T2Nano : test.model.Baz() {
         override val value: kotlin.String = "t2.nano"
         override fun toString(): kotlin.String = value
     }
 
-    data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
+    public data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
         override fun toString(): kotlin.String = value
     }
 
-    companion object {
+    public companion object {
         /**
          * Convert a raw value to one of the sealed variants or [SdkUnknown]
          */
-        fun fromValue(str: kotlin.String): test.model.Baz = when(str) {
+        public fun fromValue(str: kotlin.String): test.model.Baz = when(str) {
             "t2.micro" -> T2Micro
             "t2.nano" -> T2Nano
             else -> SdkUnknown(str)
@@ -162,7 +162,7 @@ sealed class Baz {
         /**
          * Get a list of all possible variants
          */
-        fun values(): kotlin.collections.List<test.model.Baz> = listOf(
+        public fun values(): kotlin.collections.List<test.model.Baz> = listOf(
             T2Micro,
             T2Nano
         )
@@ -226,7 +226,7 @@ sealed class Baz {
         contents.shouldContainOnlyOnce(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                sealed class Fruit {
+                public sealed class Fruit {
             """.trimIndent()
         )
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
@@ -188,11 +188,11 @@ class ExceptionGeneratorTest {
             val contents = writer.toString()
 
             val expected = """
-                open class TestException : ServiceException {
-                    constructor() : super()
-                    constructor(message: String?) : super(message)
-                    constructor(message: String?, cause: Throwable?) : super(message, cause)
-                    constructor(cause: Throwable?) : super(cause)
+                public open class TestException : ServiceException {
+                    public constructor() : super()
+                    public constructor(message: String?) : super(message)
+                    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+                    public constructor(cause: Throwable?) : super(cause)
                 }
             """.trimIndent()
 
@@ -233,11 +233,11 @@ class ExceptionGeneratorTest {
             val contents = writer.toString()
 
             val expected = """
-                open class TestException : QuxException {
-                    constructor() : super()
-                    constructor(message: String?) : super(message)
-                    constructor(message: String?, cause: Throwable?) : super(message, cause)
-                    constructor(cause: Throwable?) : super(cause)
+                public open class TestException : QuxException {
+                    public constructor() : super()
+                    public constructor(message: String?) : super(message)
+                    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+                    public constructor(cause: Throwable?) : super(cause)
                 }
             """.trimIndent()
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/GradleGeneratorTest.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.model.node.Node
 import kotlin.test.Test
 
 class GradleGeneratorTest {
-
     @Test
     fun `it writes dependencies`() {
         val model = loadModelFromResource("simple-service.smithy")
@@ -80,9 +79,13 @@ class GradleGeneratorTest {
         val expectedVersion = """
             kotlin("jvm") version
         """.trimIndent()
+        val expectedExplicitApi = """
+            explicitApi()
+        """.trimIndent()
 
         contents.shouldContain(expectedRepositories)
         contents.shouldContain(expectedVersion)
+        contents.shouldContain(expectedExplicitApi)
     }
 
     @Test
@@ -114,7 +117,11 @@ class GradleGeneratorTest {
         val expectedVersion = """
             kotlin("multiplatform") version
         """.trimIndent()
+        val expectedExplicitApi = """
+            explicitApi()
+        """.trimIndent()
 
         contents.shouldContain(expectedVersion)
+        contents.shouldContain(expectedExplicitApi)
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGeneratorTest.kt
@@ -151,7 +151,7 @@ class PaginatorGeneratorTest {
              * @param initialRequest A [ListFunctionsRequest] to start pagination
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
-            fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
+            public fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
                 flow {
                     var cursor: kotlin.String? = null
                     var isFirstPage: Boolean = true
@@ -178,7 +178,7 @@ class PaginatorGeneratorTest {
              * @param block A builder block used for DSL-style invocation of the operation
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
-            fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
+            public fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
                 listFunctionsPaginated(ListFunctionsRequest.Builder().apply(block).build())
         """.trimIndent()
 
@@ -206,7 +206,7 @@ class PaginatorGeneratorTest {
              * @param initialRequest A [ListFunctionsRequest] to start pagination
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
-            fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
+            public fun TestClient.listFunctionsPaginated(initialRequest: ListFunctionsRequest): Flow<ListFunctionsResponse> =
                 flow {
                     var cursor: kotlin.String? = null
                     var isFirstPage: Boolean = true
@@ -233,7 +233,7 @@ class PaginatorGeneratorTest {
              * @param block A builder block used for DSL-style invocation of the operation
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [ListFunctionsResponse]
              */
-            fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
+            public fun TestClient.listFunctionsPaginated(block: ListFunctionsRequest.Builder.() -> Unit): Flow<ListFunctionsResponse> =
                 listFunctionsPaginated(ListFunctionsRequest.Builder().apply(block).build())
             
             /**
@@ -242,7 +242,7 @@ class PaginatorGeneratorTest {
              * @return A [kotlinx.coroutines.flow.Flow] that can collect [FunctionConfiguration]
              */
             @JvmName("listFunctionsResponseFunctionConfiguration")
-            fun Flow<ListFunctionsResponse>.functions(): Flow<FunctionConfiguration> =
+            public fun Flow<ListFunctionsResponse>.functions(): Flow<FunctionConfiguration> =
                 transform() { response ->
                     response.functions?.forEach {
                         emit(it)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceGeneratorTest.kt
@@ -34,7 +34,7 @@ class ServiceGeneratorTest {
 
     @Test
     fun `it renders interface`() {
-        commonTestContents.shouldContainOnlyOnce("interface TestClient : SdkClient {")
+        commonTestContents.shouldContainOnlyOnce("public interface TestClient : SdkClient {")
     }
 
     @Test
@@ -49,15 +49,15 @@ class ServiceGeneratorTest {
     @Test
     fun `it renders signatures correctly`() {
         val expectedSignatures = listOf(
-            "suspend fun getFoo(input: GetFooRequest): GetFooResponse",
-            "suspend fun getFooNoRequired(input: GetFooNoRequiredRequest = GetFooNoRequiredRequest {}): GetFooNoRequiredResponse",
-            "suspend fun getFooSomeRequired(input: GetFooSomeRequiredRequest): GetFooSomeRequiredResponse",
-            "suspend fun getFooNoInput(input: GetFooNoInputRequest = GetFooNoInputRequest {}): GetFooNoInputResponse",
-            "suspend fun getFooNoOutput(input: GetFooNoOutputRequest): GetFooNoOutputResponse",
-            "suspend fun getFooStreamingInput(input: GetFooStreamingInputRequest): GetFooStreamingInputResponse",
-            "suspend fun <T> getFooStreamingOutput(input: GetFooStreamingOutputRequest, block: suspend (GetFooStreamingOutputResponse) -> T): T",
-            "suspend fun <T> getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputRequest = GetFooStreamingOutputNoInputRequest {}, block: suspend (GetFooStreamingOutputNoInputResponse) -> T): T",
-            "suspend fun getFooStreamingInputNoOutput(input: GetFooStreamingInputNoOutputRequest): GetFooStreamingInputNoOutputResponse"
+            "public suspend fun getFoo(input: GetFooRequest): GetFooResponse",
+            "public suspend fun getFooNoRequired(input: GetFooNoRequiredRequest = GetFooNoRequiredRequest {}): GetFooNoRequiredResponse",
+            "public suspend fun getFooSomeRequired(input: GetFooSomeRequiredRequest): GetFooSomeRequiredResponse",
+            "public suspend fun getFooNoInput(input: GetFooNoInputRequest = GetFooNoInputRequest {}): GetFooNoInputResponse",
+            "public suspend fun getFooNoOutput(input: GetFooNoOutputRequest): GetFooNoOutputResponse",
+            "public suspend fun getFooStreamingInput(input: GetFooStreamingInputRequest): GetFooStreamingInputResponse",
+            "public suspend fun <T> getFooStreamingOutput(input: GetFooStreamingOutputRequest, block: suspend (GetFooStreamingOutputResponse) -> T): T",
+            "public suspend fun <T> getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputRequest = GetFooStreamingOutputNoInputRequest {}, block: suspend (GetFooStreamingOutputNoInputResponse) -> T): T",
+            "public suspend fun getFooStreamingInputNoOutput(input: GetFooStreamingInputNoOutputRequest): GetFooStreamingInputNoOutputResponse"
         )
         expectedSignatures.forEach {
             commonTestContents.shouldContainOnlyOnceWithDiff(it)
@@ -67,13 +67,13 @@ class ServiceGeneratorTest {
     @Test
     fun `it renders a companion object with default client factory if protocol generator`() {
         val expected = """
-            companion object {
-                operator fun invoke(block: Config.Builder.() -> Unit = {}): TestClient {
+            public companion object {
+                public operator fun invoke(block: Config.Builder.() -> Unit = {}): TestClient {
                     val config = Config.Builder().apply(block).build()
                     return DefaultTestClient(config)
                 }
 
-                operator fun invoke(config: Config): TestClient = DefaultTestClient(config)
+                public operator fun invoke(config: Config): TestClient = DefaultTestClient(config)
             }
         """.formatForTest()
         val testContents = generateService("service-generator-test-operations.smithy", true)
@@ -83,7 +83,7 @@ class ServiceGeneratorTest {
     @Test
     fun `it renders a companion object without default client factory if no protocol generator`() {
         val expected = """
-            companion object {
+            public companion object {
             }
         """.formatForTest()
         commonTestContents.shouldContainOnlyOnceWithDiff(expected)
@@ -91,7 +91,7 @@ class ServiceGeneratorTest {
 
     @Test
     fun `it generates config`() {
-        val expected = "class Config"
+        val expected = "public class Config"
         commonTestContents.shouldContainOnlyOnce(expected)
     }
 
@@ -109,14 +109,14 @@ class ServiceGeneratorTest {
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
         val service = model.expectShape<ServiceShape>(TestModelDefault.SERVICE_SHAPE_ID)
         writer.registerSectionWriter(ServiceGenerator.SectionServiceCompanionObject) { codeWriter, _ ->
-            codeWriter.openBlock("companion object {")
-                .write("fun foo(): Int = 1")
+            codeWriter.openBlock("public companion object {")
+                .write("public fun foo(): Int = 1")
                 .closeBlock("}")
         }
 
         writer.registerSectionWriter(ServiceGenerator.SectionServiceConfig) { codeWriter, _ ->
-            codeWriter.openBlock("class Config {")
-                .write("var bar: Int = 2")
+            codeWriter.openBlock("public class Config {")
+                .write("public var bar: Int = 2")
                 .closeBlock("}")
         }
 
@@ -127,15 +127,15 @@ class ServiceGeneratorTest {
         val contents = writer.toString()
 
         val expectedCompanionOverride = """
-            companion object {
-                fun foo(): Int = 1
+            public companion object {
+                public fun foo(): Int = 1
             }
         """.formatForTest()
         contents.shouldContainOnlyOnce(expectedCompanionOverride)
 
         val expectedConfigOverride = """
-            class Config {
-                var bar: Int = 2
+            public class Config {
+                public var bar: Int = 2
             }
         """.formatForTest()
         contents.shouldContainOnlyOnce(expectedConfigOverride)
@@ -146,7 +146,7 @@ class ServiceGeneratorTest {
         deprecatedTestContents.shouldContainOnlyOnce(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                interface TestClient : SdkClient {
+                public interface TestClient : SdkClient {
             """.trimIndent()
         )
     }
@@ -156,22 +156,27 @@ class ServiceGeneratorTest {
         deprecatedTestContents.trimEveryLine().shouldContainOnlyOnce(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                suspend fun yeOldeOperation(input: YeOldeOperationRequest): YeOldeOperationResponse
+                public suspend fun yeOldeOperation(input: YeOldeOperationRequest): YeOldeOperationResponse
             """.trimIndent()
         )
     }
 
     @Test
     fun `it adds DSL overloads for operations`() {
-        val expectedSignatures = listOf(
-            "suspend inline fun TestClient.getFoo(crossinline block: GetFooRequest.Builder.() -> Unit) = getFoo(GetFooRequest.Builder().apply(block).build())",
-            "suspend inline fun TestClient.getFooNoInput(crossinline block: GetFooNoInputRequest.Builder.() -> Unit) = getFooNoInput(GetFooNoInputRequest.Builder().apply(block).build())",
-            "suspend inline fun TestClient.getFooNoOutput(crossinline block: GetFooNoOutputRequest.Builder.() -> Unit) = getFooNoOutput(GetFooNoOutputRequest.Builder().apply(block).build())",
-            "suspend inline fun TestClient.getFooStreamingInput(crossinline block: GetFooStreamingInputRequest.Builder.() -> Unit) = getFooStreamingInput(GetFooStreamingInputRequest.Builder().apply(block).build())",
-            "suspend inline fun TestClient.getFooStreamingInputNoOutput(crossinline block: GetFooStreamingInputNoOutputRequest.Builder.() -> Unit) = getFooStreamingInputNoOutput(GetFooStreamingInputNoOutputRequest.Builder().apply(block).build())",
-        )
-        expectedSignatures.forEach {
-            commonTestContents.shouldContainOnlyOnceWithDiff(it)
+        listOf(
+            "GetFoo",
+            "GetFooNoInput",
+            "GetFooNoOutput",
+            "GetFooStreamingInput",
+            "GetFooStreamingInputNoOutput",
+        ).forEach { op ->
+            val modifiers = "public suspend inline fun"
+            val method = op.replaceFirstChar(Char::lowercaseChar)
+            val params = "(crossinline block: ${op}Request.Builder.() -> Unit)"
+            val impl = "$method(${op}Request.Builder().apply(block).build())"
+
+            val expected = "$modifiers TestClient.$method$params: ${op}Response = $impl"
+            commonTestContents.shouldContainOnlyOnceWithDiff(expected)
         }
     }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -60,8 +60,6 @@ mapOf<String, Int>(
             }
         """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
 
-        println(model.toSmithyIDL())
-
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
         val mapShape = model.expectShape(ShapeId.from("foo.bar#MyList"))
         val writer = KotlinWriter("test")
@@ -179,8 +177,6 @@ MyStruct {
             ])
             string MyEnum
         """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
-
-        println(model.toSmithyIDL())
 
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -72,16 +72,16 @@ class StructureGeneratorTest {
     @Test
     fun `it renders constructors`() {
         val expectedClassDecl = """
-            class MyStruct private constructor(builder: Builder) {
+            public class MyStruct private constructor(builder: Builder) {
                 /**
                  * This *is* documentation about the member.
                  */
-                val bar: kotlin.Int = builder.bar
-                val baz: kotlin.Int? = builder.baz
-                val byteValue: kotlin.Byte? = builder.byteValue
-                val foo: kotlin.String? = builder.foo
-                val `object`: kotlin.String? = builder.`object`
-                val quux: com.test.model.Qux? = builder.quux
+                public val bar: kotlin.Int = builder.bar
+                public val baz: kotlin.Int? = builder.baz
+                public val byteValue: kotlin.Byte? = builder.byteValue
+                public val foo: kotlin.String? = builder.foo
+                public val `object`: kotlin.String? = builder.`object`
+                public val quux: com.test.model.Qux? = builder.quux
         """.formatForTest(indent = "")
 
         commonTestContents.shouldContainOnlyOnceWithDiff(expectedClassDecl)
@@ -90,8 +90,8 @@ class StructureGeneratorTest {
     @Test
     fun `it renders a companion object`() {
         val expected = """
-            companion object {
-                operator fun invoke(block: Builder.() -> kotlin.Unit): com.test.model.MyStruct = Builder().apply(block).build()
+            public companion object {
+                public operator fun invoke(block: Builder.() -> kotlin.Unit): com.test.model.MyStruct = Builder().apply(block).build()
             }
         """.formatForTest()
         commonTestContents.shouldContainOnlyOnceWithDiff(expected)
@@ -155,7 +155,7 @@ class StructureGeneratorTest {
     @Test
     fun `it renders a copy implementation`() {
         val expected = """
-            inline fun copy(block: Builder.() -> kotlin.Unit = {}): com.test.model.MyStruct = Builder(this).apply(block).build()
+            public inline fun copy(block: Builder.() -> kotlin.Unit = {}): com.test.model.MyStruct = Builder(this).apply(block).build()
         """.formatForTest()
         commonTestContents.shouldContainOnlyOnceWithDiff(expected)
     }
@@ -163,16 +163,16 @@ class StructureGeneratorTest {
     @Test
     fun `it renders a builder impl`() {
         val expected = """
-            class Builder {
+            public class Builder {
                 /**
                  * This *is* documentation about the member.
                  */
-                var bar: kotlin.Int = 0
-                var baz: kotlin.Int? = null
-                var byteValue: kotlin.Byte? = null
-                var foo: kotlin.String? = null
-                var `object`: kotlin.String? = null
-                var quux: com.test.model.Qux? = null
+                public var bar: kotlin.Int = 0
+                public var baz: kotlin.Int? = null
+                public var byteValue: kotlin.Byte? = null
+                public var foo: kotlin.String? = null
+                public var `object`: kotlin.String? = null
+                public var quux: com.test.model.Qux? = null
         
                 @PublishedApi
                 internal constructor()
@@ -192,7 +192,7 @@ class StructureGeneratorTest {
                 /**
                  * construct an [com.test.model.Qux] inside the given [block]
                  */
-                fun quux(block: com.test.model.Qux.Builder.() -> kotlin.Unit) {
+                public fun quux(block: com.test.model.Qux.Builder.() -> kotlin.Unit) {
                     this.quux = com.test.model.Qux.invoke(block)
                 }
             }
@@ -234,8 +234,6 @@ class StructureGeneratorTest {
             the effective documentation of Foo$baz resolves to "Member documentation", Foo$bar resolves to "Shape documentation",
             Foo$qux is not documented, Baz resolves to "Shape documentation", and Foo is not documented.
         */
-
-        println(model.toSmithyIDL())
 
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
@@ -311,10 +309,10 @@ class StructureGeneratorTest {
 
         val generated = writer.toString()
         val expected = """
-            class FooRequest private constructor(builder: Builder) {
-                val bar: kotlin.String? = requireNotNull(builder.bar) { "A non-null value must be provided for bar" }
-                val baz: kotlin.Int? = requireNotNull(builder.baz) { "A non-null value must be provided for baz" }
-                val qux: kotlin.String? = builder.qux
+            public class FooRequest private constructor(builder: Builder) {
+                public val bar: kotlin.String? = requireNotNull(builder.bar) { "A non-null value must be provided for bar" }
+                public val baz: kotlin.Int? = requireNotNull(builder.baz) { "A non-null value must be provided for baz" }
+                public val qux: kotlin.String? = builder.qux
         """.formatForTest(indent = "")
         generated.shouldContainOnlyOnceWithDiff(expected)
     }
@@ -407,8 +405,8 @@ class StructureGeneratorTest {
         val contents = writer.toString()
 
         listOf(
-            "val enumMap: Map<String, MyEnum>? = builder.enumMap",
-            "var enumMap: Map<String, MyEnum>? = null"
+            "public val enumMap: Map<String, MyEnum>? = builder.enumMap",
+            "public var enumMap: Map<String, MyEnum>? = null"
         ).forEach { line ->
             contents.shouldContainOnlyOnceWithDiff(line)
         }
@@ -454,8 +452,8 @@ class StructureGeneratorTest {
         val contents = writer.toString()
 
         listOf(
-            "val enumMap: Map<String, MyEnum?>? = builder.enumMap",
-            "var enumMap: Map<String, MyEnum?>? = null"
+            "public val enumMap: Map<String, MyEnum?>? = builder.enumMap",
+            "public var enumMap: Map<String, MyEnum?>? = null"
         ).forEach { line ->
             contents.shouldContainOnlyOnceWithDiff(line)
         }
@@ -466,18 +464,17 @@ class StructureGeneratorTest {
         deprecatedTestContents.shouldContainOnlyOnceWithDiff(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                class MyStruct private constructor(builder: Builder) {
+                public class MyStruct private constructor(builder: Builder) {
             """.trimIndent()
         )
     }
 
     @Test
     fun `it annotates deprecated members`() {
-        println(deprecatedTestContents)
         deprecatedTestContents.trimEveryLine().shouldContainOnlyOnceWithDiff(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                val baz: com.test.model.Qux? = builder.baz
+                public val baz: com.test.model.Qux? = builder.baz
             """.trimIndent()
         )
     }
@@ -487,7 +484,7 @@ class StructureGeneratorTest {
         deprecatedTestContents.trimEveryLine().shouldContainOnlyOnceWithDiff(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                val baz: com.test.model.Qux? = builder.baz
+                public val baz: com.test.model.Qux? = builder.baz
             """.trimIndent()
         )
     }
@@ -621,7 +618,7 @@ class StructureGeneratorTest {
         val contents = writer.toString()
 
         val expectedProperty = """
-            val events: Flow<com.test.model.Events>? = builder.events
+            public val events: Flow<com.test.model.Events>? = builder.events
         """.formatForTest()
         contents.shouldContainOnlyOnceWithDiff(expectedProperty)
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/UnionGeneratorTest.kt
@@ -46,10 +46,10 @@ class UnionGeneratorTest {
             /**
              * Documentation for MyUnion
              */
-            sealed class MyUnion {
-                data class Bar(val value: kotlin.Int) : test.model.MyUnion()
-                data class Baz(val value: kotlin.Int) : test.model.MyUnion()
-                data class Blz(val value: kotlin.ByteArray) : test.model.MyUnion() {
+            public sealed class MyUnion {
+                public data class Bar(val value: kotlin.Int) : test.model.MyUnion()
+                public data class Baz(val value: kotlin.Int) : test.model.MyUnion()
+                public data class Blz(val value: kotlin.ByteArray) : test.model.MyUnion() {
             
                     override fun hashCode(): kotlin.Int {
                         return value.contentHashCode()
@@ -69,64 +69,64 @@ class UnionGeneratorTest {
                 /**
                  * Documentation for foo
                  */
-                data class Foo(val value: kotlin.String) : test.model.MyUnion()
-                data class MyStruct(val value: test.model.MyStruct) : test.model.MyUnion()
-                object SdkUnknown : test.model.MyUnion()
+                public data class Foo(val value: kotlin.String) : test.model.MyUnion()
+                public data class MyStruct(val value: test.model.MyStruct) : test.model.MyUnion()
+                public object SdkUnknown : test.model.MyUnion()
             
                 /**
                  * Casts this [MyUnion] as a [Bar] and retrieves its [kotlin.Int] value. Throws an exception if the [MyUnion] is not a
                  * [Bar].
                  */
-                fun asBar(): kotlin.Int = (this as MyUnion.Bar).value
+                public fun asBar(): kotlin.Int = (this as MyUnion.Bar).value
             
                 /**
                  * Casts this [MyUnion] as a [Bar] and retrieves its [kotlin.Int] value. Returns null if the [MyUnion] is not a [Bar].
                  */
-                fun asBarOrNull(): kotlin.Int? = (this as? MyUnion.Bar)?.value
+                public fun asBarOrNull(): kotlin.Int? = (this as? MyUnion.Bar)?.value
             
                 /**
                  * Casts this [MyUnion] as a [Baz] and retrieves its [kotlin.Int] value. Throws an exception if the [MyUnion] is not a
                  * [Baz].
                  */
-                fun asBaz(): kotlin.Int = (this as MyUnion.Baz).value
+                public fun asBaz(): kotlin.Int = (this as MyUnion.Baz).value
             
                 /**
                  * Casts this [MyUnion] as a [Baz] and retrieves its [kotlin.Int] value. Returns null if the [MyUnion] is not a [Baz].
                  */
-                fun asBazOrNull(): kotlin.Int? = (this as? MyUnion.Baz)?.value
+                public fun asBazOrNull(): kotlin.Int? = (this as? MyUnion.Baz)?.value
             
                 /**
                  * Casts this [MyUnion] as a [Blz] and retrieves its [kotlin.ByteArray] value. Throws an exception if the [MyUnion] is not a
                  * [Blz].
                  */
-                fun asBlz(): kotlin.ByteArray = (this as MyUnion.Blz).value
+                public fun asBlz(): kotlin.ByteArray = (this as MyUnion.Blz).value
             
                 /**
                  * Casts this [MyUnion] as a [Blz] and retrieves its [kotlin.ByteArray] value. Returns null if the [MyUnion] is not a [Blz].
                  */
-                fun asBlzOrNull(): kotlin.ByteArray? = (this as? MyUnion.Blz)?.value
+                public fun asBlzOrNull(): kotlin.ByteArray? = (this as? MyUnion.Blz)?.value
             
                 /**
                  * Casts this [MyUnion] as a [Foo] and retrieves its [kotlin.String] value. Throws an exception if the [MyUnion] is not a
                  * [Foo].
                  */
-                fun asFoo(): kotlin.String = (this as MyUnion.Foo).value
+                public fun asFoo(): kotlin.String = (this as MyUnion.Foo).value
             
                 /**
                  * Casts this [MyUnion] as a [Foo] and retrieves its [kotlin.String] value. Returns null if the [MyUnion] is not a [Foo].
                  */
-                fun asFooOrNull(): kotlin.String? = (this as? MyUnion.Foo)?.value
+                public fun asFooOrNull(): kotlin.String? = (this as? MyUnion.Foo)?.value
             
                 /**
                  * Casts this [MyUnion] as a [MyStruct] and retrieves its [test.model.MyStruct] value. Throws an exception if the [MyUnion] is not a
                  * [MyStruct].
                  */
-                fun asMyStruct(): test.model.MyStruct = (this as MyUnion.MyStruct).value
+                public fun asMyStruct(): test.model.MyStruct = (this as MyUnion.MyStruct).value
             
                 /**
                  * Casts this [MyUnion] as a [MyStruct] and retrieves its [test.model.MyStruct] value. Returns null if the [MyUnion] is not a [MyStruct].
                  */
-                fun asMyStructOrNull(): test.model.MyStruct? = (this as? MyUnion.MyStruct)?.value
+                public fun asMyStructOrNull(): test.model.MyStruct? = (this as? MyUnion.MyStruct)?.value
             }
         """.trimIndent()
 
@@ -170,7 +170,7 @@ class UnionGeneratorTest {
         contents.shouldContainOnlyOnce(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                sealed class MyUnion {
+                public sealed class MyUnion {
             """.trimIndent()
         )
     }
@@ -191,7 +191,7 @@ class UnionGeneratorTest {
         contents.trimEveryLine().shouldContainOnlyOnce(
             """
                 @Deprecated("No longer recommended for use. See AWS API documentation for more details.")
-                data class Bar(val value: kotlin.Int) : test.model.MyUnion()
+                public data class Bar(val value: kotlin.Int) : test.model.MyUnion()
             """.trimIndent()
         )
     }
@@ -218,20 +218,20 @@ class UnionGeneratorTest {
         )
 
         val expectedClassDecl = """
-            sealed class MyUnion {
-                data class Foo(val value: test.model.MyStruct) : test.model.MyUnion()
-                object SdkUnknown : test.model.MyUnion()
+            public sealed class MyUnion {
+                public data class Foo(val value: test.model.MyStruct) : test.model.MyUnion()
+                public object SdkUnknown : test.model.MyUnion()
             
                 /**
                  * Casts this [MyUnion] as a [Foo] and retrieves its [test.model.MyStruct] value. Throws an exception if the [MyUnion] is not a
                  * [Foo].
                  */
-                fun asFoo(): test.model.MyStruct = (this as MyUnion.Foo).value
+                public fun asFoo(): test.model.MyStruct = (this as MyUnion.Foo).value
             
                 /**
                  * Casts this [MyUnion] as a [Foo] and retrieves its [test.model.MyStruct] value. Returns null if the [MyUnion] is not a [Foo].
                  */
-                fun asFooOrNull(): test.model.MyStruct? = (this as? MyUnion.Foo)?.value
+                public fun asFooOrNull(): test.model.MyStruct? = (this as? MyUnion.Foo)?.value
             }
         """.trimIndent()
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -42,7 +42,7 @@ class ServiceWaitersGeneratorTest {
             /**
              * Wait until a foo exists
              */
-            suspend fun TestClient.waitUntilFooExists(request: DescribeFooRequest): Outcome<DescribeFooResponse> {
+            public suspend fun TestClient.waitUntilFooExists(request: DescribeFooRequest): Outcome<DescribeFooResponse> {
         """.trimIndent()
         val methodFooter = """
                 val policy = AcceptorRetryPolicy(request, acceptors)
@@ -58,7 +58,7 @@ class ServiceWaitersGeneratorTest {
             /**
              * Wait until a foo exists
              */
-            suspend fun TestClient.waitUntilFooExists(block: DescribeFooRequest.Builder.() -> Unit): Outcome<DescribeFooResponse> =
+            public suspend fun TestClient.waitUntilFooExists(block: DescribeFooRequest.Builder.() -> Unit): Outcome<DescribeFooResponse> =
                 waitUntilFooExists(DescribeFooRequest.Builder().apply(block).build())
         """.trimIndent()
         generated.shouldContainOnlyOnce(expected)

--- a/tests/compile/build.gradle.kts
+++ b/tests/compile/build.gradle.kts
@@ -37,5 +37,8 @@ tasks.test {
     testLogging {
         events("passed", "skipped", "failed")
         showStandardStreams = true
+        showStackTraces = true
+        showExceptions = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
 }

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/ApiEvolutionTest.kt
@@ -65,7 +65,7 @@ class ApiEvolutionTest {
             import test.model.PostFooRequest
             import kotlinx.coroutines.runBlocking
             
-            fun main() {
+            public fun main() {
                 val testClient = ExampleClient { }
                 runBlocking {
                     val resp = testClient.postFoo(PostFooRequest{})
@@ -130,7 +130,7 @@ class ApiEvolutionTest {
             import test.model.PostFooRequest
             import kotlinx.coroutines.runBlocking
             
-            fun main() {
+            public fun main() {
                 val testClient = ExampleClient { }
                 runBlocking {
                     val resp = testClient.postFoo(PostFooRequest {})
@@ -189,7 +189,7 @@ class ApiEvolutionTest {
             import test.model.PostFooRequest
             import kotlinx.coroutines.runBlocking
             
-            fun main() {
+            public fun main() {
                 val testClient = ExampleClient { }
                 runBlocking {
                     val resp = testClient.postFoo(PostFooRequest{})
@@ -254,7 +254,7 @@ class ApiEvolutionTest {
             import test.model.PostFooRequest
             import kotlinx.coroutines.runBlocking
             
-            fun main() {
+            public fun main() {
                 val testClient = ExampleClient { }
                 runBlocking {
                     val resp = testClient.postFoo(PostFooRequest{})

--- a/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/TestUtils.kt
+++ b/tests/compile/src/test/kotlin/software/amazon/smithy/kotlin/codegen/util/TestUtils.kt
@@ -104,11 +104,15 @@ fun compileSdkAndTest(
 
     // Run test against
     return KotlinCompilation().apply {
-        kotlincArguments = listOf("-Xopt-in=aws.smithy.kotlin.runtime.util.InternalApi")
+        kotlincArguments = listOf(
+            "-Xopt-in=aws.smithy.kotlin.runtime.util.InternalApi",
+            "-Xexplicit-api=strict",
+        )
         sources = sdkSources
         inheritClassPath = true
         messageOutputStream = outputSink
         jvmTarget = "1.8"
+
     }.compile()
 }
 


### PR DESCRIPTION
## Issue \#

#216 

## Description of changes

This change enables [Explicit API mode](https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md) for **smithy-kotlin** codegen. PRing this separately from runtime changes since **a)** there are fewer changes here and **b)** the risk of getting it wrong is slightly higher in codegen so it deserves higher scrutiny.

Companion PR: [aws-sdk-kotlin#657](https://github.com/awslabs/aws-sdk-kotlin/pull/657)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
