### PR TITLE
chore: enable explicit API for runtime components

### DIFF
--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigner.kt
@@ -9,14 +9,14 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 /**
  * A component capable of signing requests and request chunks for AWS APIs.
  */
-interface AwsSigner {
+public interface AwsSigner {
     /**
      * Signs an HTTP request according to the supplied signing configuration
      * @param request The request to sign
      * @param config The signing configuration
      * @return The signed request
      */
-    suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult<HttpRequest>
+    public suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult<HttpRequest>
 
     /**
      * Signs a body chunk according to the supplied signing configuration
@@ -26,7 +26,7 @@ interface AwsSigner {
      * @param config The signing configuration
      * @return The signing result, which provides access to all signing-related result properties
      */
-    suspend fun signChunk(
+    public suspend fun signChunk(
         chunkBody: ByteArray,
         prevSignature: ByteArray,
         config: AwsSigningConfig,

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -12,29 +12,29 @@ import aws.smithy.kotlin.runtime.util.AttributeKey
 /**
  *  [ClientOption] instances related to signing.
  */
-object AwsSigningAttributes {
+public object AwsSigningAttributes {
     /**
      * The signer implementation to use
      */
-    val Signer: ClientOption<AwsSigner> = ClientOption("Signer")
+    public val Signer: ClientOption<AwsSigner> = ClientOption("Signer")
 
     /**
      * AWS region to be used for signing the request
      */
-    val SigningRegion: ClientOption<String> = ClientOption("AwsSigningRegion")
+    public val SigningRegion: ClientOption<String> = ClientOption("AwsSigningRegion")
 
     /**
      * The signature version 4 service signing name to use in the credential scope when signing requests.
      * See: https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html
      */
-    val SigningService: ClientOption<String> = ClientOption("AwsSigningService")
+    public val SigningService: ClientOption<String> = ClientOption("AwsSigningService")
 
     /**
      * Override the date to complete the signing process with. Defaults to current time when not specified.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    val SigningDate: ClientOption<Instant> = ClientOption("SigningDate")
+    public val SigningDate: ClientOption<Instant> = ClientOption("SigningDate")
 
     /**
      * The [CredentialsProvider] to complete the signing process with. Defaults to the provider configured
@@ -42,24 +42,24 @@ object AwsSigningAttributes {
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    val CredentialsProvider: ClientOption<CredentialsProvider> = ClientOption("CredentialsProvider")
+    public val CredentialsProvider: ClientOption<CredentialsProvider> = ClientOption("CredentialsProvider")
 
     /**
      * The specification for determining the hash value for the request.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    val HashSpecification: ClientOption<HashSpecification> = ClientOption("HashSpecification")
+    public val HashSpecification: ClientOption<HashSpecification> = ClientOption("HashSpecification")
 
     /**
      * The signed body header type.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    val SignedBodyHeader: ClientOption<AwsSignedBodyHeader> = ClientOption("SignedBodyHeader")
+    public val SignedBodyHeader: ClientOption<AwsSignedBodyHeader> = ClientOption("SignedBodyHeader")
 
     /**
      * The signature of the HTTP request. This will only exist after the request has been signed.
      */
-    val RequestSignature: AttributeKey<ByteArray> = AttributeKey("AWS_HTTP_SIGNATURE")
+    public val RequestSignature: AttributeKey<ByteArray> = AttributeKey("AWS_HTTP_SIGNATURE")
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig.kt
@@ -8,12 +8,12 @@ import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.time.Duration
 
-typealias ShouldSignHeaderPredicate = (String) -> Boolean
+public typealias ShouldSignHeaderPredicate = (String) -> Boolean
 
 /**
  * Defines the AWS signature version to use
  */
-enum class AwsSigningAlgorithm {
+public enum class AwsSigningAlgorithm {
     /**
      * AWS Signature Version 4
      * see: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
@@ -29,7 +29,7 @@ enum class AwsSigningAlgorithm {
 /**
  * Defines the type of signature to compute
  */
-enum class AwsSignatureType {
+public enum class AwsSignatureType {
     /**
      * A signature for a full http request should be computed and applied via headers
      */
@@ -51,7 +51,7 @@ enum class AwsSignatureType {
     HTTP_REQUEST_EVENT,
 }
 
-enum class AwsSignedBodyHeader {
+public enum class AwsSignedBodyHeader {
     /**
      * Do not add a header.
      */
@@ -66,26 +66,26 @@ enum class AwsSignedBodyHeader {
 /**
  * The configuration for an individual signing operation.
  */
-class AwsSigningConfig(builder: Builder) {
-    companion object {
-        inline operator fun invoke(block: Builder.() -> Unit): AwsSigningConfig = Builder().apply(block).build()
+public class AwsSigningConfig(builder: Builder) {
+    public companion object {
+        public inline operator fun invoke(block: Builder.() -> Unit): AwsSigningConfig = Builder().apply(block).build()
     }
 
     /**
      * The region for which requests will be signed.
      */
-    val region: String = requireNotNull(builder.region) { "Signing config must specify a region" }
+    public val region: String = requireNotNull(builder.region) { "Signing config must specify a region" }
 
     /**
      * The name of service for which requests will be signed.
      */
-    val service: String = requireNotNull(builder.service) { "Signing config must specify a service" }
+    public val service: String = requireNotNull(builder.service) { "Signing config must specify a service" }
 
     /**
      * Indicates the signing date/timestamp to use for the signature. Defaults to the current date at config
      * construction time.
      */
-    val signingDate: Instant = builder.signingDate ?: Instant.now()
+    public val signingDate: Instant = builder.signingDate ?: Instant.now()
 
     /**
      * A predicate to control which headers are a part of the canonical request. Note that skipping auth-required
@@ -97,29 +97,29 @@ class AwsSigningConfig(builder: Builder) {
      *
      * The default predicate is to not reject signing any headers (i.e., `_ -> true`).
      */
-    val shouldSignHeader: ShouldSignHeaderPredicate = builder.shouldSignHeader
+    public val shouldSignHeader: ShouldSignHeaderPredicate = builder.shouldSignHeader
 
     /**
      * The algorithm to use when signing requests.
      */
-    val algorithm: AwsSigningAlgorithm = builder.algorithm
+    public val algorithm: AwsSigningAlgorithm = builder.algorithm
 
     /**
      * Indicates what type of signature to compute.
      */
-    val signatureType: AwsSignatureType = builder.signatureType
+    public val signatureType: AwsSignatureType = builder.signatureType
 
     /**
      * Normally we assume the URI will be encoded once in preparation for transmission. Certain services do not decode
      * before checking signature, requiring the URI to be double-encoded in the canonical request in order to match a
      * signature check.
      */
-    val useDoubleUriEncode: Boolean = builder.useDoubleUriEncode
+    public val useDoubleUriEncode: Boolean = builder.useDoubleUriEncode
 
     /**
      * Controls whether URI paths should be normalized when building the canonical request.
      */
-    val normalizeUriPath: Boolean = builder.normalizeUriPath
+    public val normalizeUriPath: Boolean = builder.normalizeUriPath
 
     /**
      * Determines whether the `X-Amz-Security-Token` query param should be omitted from the canonical signing
@@ -129,24 +129,25 @@ class AwsSigningConfig(builder: Builder) {
      * If this value is false, a non-null security token is _still added to the request_ but it is not used in signature
      * calculation.
      */
-    val omitSessionToken: Boolean = builder.omitSessionToken
+    public val omitSessionToken: Boolean = builder.omitSessionToken
 
     /**
      * Determines the source of the canonical request's body public value. The default is
      * [HashSpecification.CalculateFromPayload], indicating that a public value will be calculated from the payload
      * during signing.
      */
-    val hashSpecification: HashSpecification = builder.hashSpecification ?: HashSpecification.CalculateFromPayload
+    public val hashSpecification: HashSpecification =
+        builder.hashSpecification ?: HashSpecification.CalculateFromPayload
 
     /**
      * Determines which body "hash" header, if any, should be added to the canonical request and the signed request.
      */
-    val signedBodyHeader: AwsSignedBodyHeader = builder.signedBodyHeader
+    public val signedBodyHeader: AwsSignedBodyHeader = builder.signedBodyHeader
 
     /**
      * Indicates the AWS credentials provider from which to fetch credentials.
      */
-    val credentialsProvider: CredentialsProvider = requireNotNull(builder.credentialsProvider) {
+    public val credentialsProvider: CredentialsProvider = requireNotNull(builder.credentialsProvider) {
         "Signing config must specify a credentials provider"
     }
 
@@ -156,9 +157,9 @@ class AwsSigningConfig(builder: Builder) {
      * value is null or if header signing is being used then this parameter has no effect. Note that the resolution of
      * expiration is in seconds.
      */
-    val expiresAfter: Duration? = builder.expiresAfter
+    public val expiresAfter: Duration? = builder.expiresAfter
 
-    fun toBuilder(): Builder = Builder().also {
+    public fun toBuilder(): Builder = Builder().also {
         it.region = region
         it.service = service
         it.signingDate = signingDate
@@ -174,21 +175,21 @@ class AwsSigningConfig(builder: Builder) {
         it.expiresAfter = expiresAfter
     }
 
-    class Builder {
-        var region: String? = null
-        var service: String? = null
-        var signingDate: Instant? = null
-        var shouldSignHeader: ShouldSignHeaderPredicate = { _ -> true } // Don't reject signing any headers by default
-        var algorithm: AwsSigningAlgorithm = AwsSigningAlgorithm.SIGV4
-        var signatureType: AwsSignatureType = AwsSignatureType.HTTP_REQUEST_VIA_HEADERS
-        var useDoubleUriEncode: Boolean = true
-        var normalizeUriPath: Boolean = true
-        var omitSessionToken: Boolean = false
-        var hashSpecification: HashSpecification? = null
-        var signedBodyHeader: AwsSignedBodyHeader = AwsSignedBodyHeader.NONE
-        var credentialsProvider: CredentialsProvider? = null
-        var expiresAfter: Duration? = null
+    public class Builder {
+        public var region: String? = null
+        public var service: String? = null
+        public var signingDate: Instant? = null
+        public var shouldSignHeader: ShouldSignHeaderPredicate = { _ -> true } // Don't reject any headers by default
+        public var algorithm: AwsSigningAlgorithm = AwsSigningAlgorithm.SIGV4
+        public var signatureType: AwsSignatureType = AwsSignatureType.HTTP_REQUEST_VIA_HEADERS
+        public var useDoubleUriEncode: Boolean = true
+        public var normalizeUriPath: Boolean = true
+        public var omitSessionToken: Boolean = false
+        public var hashSpecification: HashSpecification? = null
+        public var signedBodyHeader: AwsSignedBodyHeader = AwsSignedBodyHeader.NONE
+        public var credentialsProvider: CredentialsProvider? = null
+        public var expiresAfter: Duration? = null
 
-        fun build(): AwsSigningConfig = AwsSigningConfig(this)
+        public fun build(): AwsSigningConfig = AwsSigningConfig(this)
     }
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult.kt
@@ -8,11 +8,11 @@ package aws.smithy.kotlin.runtime.auth.awssigning
  * The result of an AWS signing operation
  * @param T The type of the result
  */
-data class AwsSigningResult<T>(
+public data class AwsSigningResult<T>(
     /**
      * The signed output.
      */
-    val output: T,
+    public val output: T,
 
     /**
      * The signature value from the result. Depending on the requested signature type and algorithm, this value will be
@@ -23,7 +23,7 @@ data class AwsSigningResult<T>(
      * * `HTTP_REQUEST_CHUNK/SIGV4_ASYMMETRIC` - '*'-padded hex encoding of the binary signature value
      * * `HTTP_REQUEST_EVENT` - hex encoding of the binary signature value
      */
-    val signature: ByteArray,
+    public val signature: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
@@ -7,39 +7,40 @@ package aws.smithy.kotlin.runtime.auth.awssigning
 /**
  * Specifies a hash for a signable request
  */
-sealed class HashSpecification {
+public sealed class HashSpecification {
     /**
      * Indicates that the hash value should be calculated from the body payload of the request
      */
-    object CalculateFromPayload : HashSpecification()
+    public object CalculateFromPayload : HashSpecification()
 
     /**
      * Specifies a literal value to use as a hash
      */
-    sealed class HashLiteral(open val hash: String) : HashSpecification()
+    public sealed class HashLiteral(public open val hash: String) : HashSpecification()
 
     /**
      * The hash value should indicate an unsigned payload
      */
-    object UnsignedPayload : HashLiteral("UNSIGNED-PAYLOAD")
+    public object UnsignedPayload : HashLiteral("UNSIGNED-PAYLOAD")
 
     /**
-     * The hash value should indicate an empty body
+     * The hash value should indicate an empty body. The resulting hash literal is the SHA256 calculation for the empty
+     * string.
      */
-    object EmptyBody : HashLiteral("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855") // hash of ""
+    public object EmptyBody : HashLiteral("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
     /**
      * The hash value should indicate that signature covers only headers and that there is no payload
      */
-    object StreamingAws4HmacSha256Payload : HashLiteral("STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+    public object StreamingAws4HmacSha256Payload : HashLiteral("STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
 
     /**
      * The hash value should indicate ???
      */
-    object StreamingAws4HmacSha256Events : HashLiteral("STREAMING-AWS4-HMAC-SHA256-EVENTS")
+    public object StreamingAws4HmacSha256Events : HashLiteral("STREAMING-AWS4-HMAC-SHA256-EVENTS")
 
     /**
      * Use an explicit, precalculated value for the hash
      */
-    data class Precalculated(override val hash: String) : HashLiteral(hash)
+    public data class Precalculated(override val hash: String) : HashLiteral(hash)
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -26,7 +26,7 @@ import kotlin.time.Duration
  * @param region The region in which the API call would occur. If none is specified then the region in
  * [PresignedRequestConfig] is used instead.
  */
-data class SigningContext(val service: String?, val region: String?)
+public data class SigningContext(public val service: String?, public val region: String?)
 
 /**
  * Represents a endpoint that will be used for signing which has optionally been contextualized with additional signing
@@ -35,12 +35,12 @@ data class SigningContext(val service: String?, val region: String?)
  * @param context The [SigningContext] overrides for signing. If none are specified, the values in
  * [PresignedRequestConfig] are used instead.
  */
-data class SigningContextualizedEndpoint(val endpoint: Endpoint, val context: SigningContext?)
+public data class SigningContextualizedEndpoint(public val endpoint: Endpoint, public val context: SigningContext?)
 
 /**
  * A lambda function that returns an endpoint and optional signing config overrides based on the given service/region.
  */
-typealias SigningEndpointProvider = suspend (SigningContext) -> SigningContextualizedEndpoint
+public typealias SigningEndpointProvider = suspend (SigningContext) -> SigningContextualizedEndpoint
 
 /**
  * The service configuration details for a presigned request
@@ -53,15 +53,15 @@ typealias SigningEndpointProvider = suspend (SigningContext) -> SigningContextua
  * @property useDoubleUriEncode Determines if presigner should double encode Uri
  * @property normalizeUriPath Determines if presigned URI path will be normalized
  */
-interface ServicePresignConfig {
-    val signer: AwsSigner
-    val region: String
-    val signingName: String
-    val serviceId: String
-    val endpointProvider: SigningEndpointProvider
-    val credentialsProvider: CredentialsProvider
-    val useDoubleUriEncode: Boolean
-    val normalizeUriPath: Boolean
+public interface ServicePresignConfig {
+    public val signer: AwsSigner
+    public val region: String
+    public val signingName: String
+    public val serviceId: String
+    public val endpointProvider: SigningEndpointProvider
+    public val credentialsProvider: CredentialsProvider
+    public val useDoubleUriEncode: Boolean
+    public val normalizeUriPath: Boolean
 }
 
 /**
@@ -69,7 +69,7 @@ interface ServicePresignConfig {
  * @property HEADER
  * @property QUERY_STRING
  */
-enum class PresigningLocation {
+public enum class PresigningLocation {
     /**
      * Signing details are to be placed in a header
      */
@@ -91,14 +91,14 @@ enum class PresigningLocation {
  * @property presigningLocation Specifies where the signing information should be placed in the presigned request
  * @property additionalHeaders Custom headers that should be signed as part of the request
  */
-data class PresignedRequestConfig(
-    val method: HttpMethod,
-    val path: String,
-    val queryString: QueryParameters = QueryParameters.Empty,
-    val expiresAfter: Duration,
-    val signBody: Boolean = false,
-    val presigningLocation: PresigningLocation,
-    val additionalHeaders: Headers = Headers.Empty
+public data class PresignedRequestConfig(
+    public val method: HttpMethod,
+    public val path: String,
+    public val queryString: QueryParameters = QueryParameters.Empty,
+    public val expiresAfter: Duration,
+    public val signBody: Boolean = false,
+    public val presigningLocation: PresigningLocation,
+    public val additionalHeaders: Headers = Headers.Empty
 )
 
 /**
@@ -108,7 +108,7 @@ data class PresignedRequestConfig(
  * @return a [HttpRequest] that can be executed by any HTTP client within the specified duration
  */
 @InternalApi
-suspend fun createPresignedRequest(
+public suspend fun createPresignedRequest(
     serviceConfig: ServicePresignConfig,
     requestConfig: PresignedRequestConfig,
 ): HttpRequest {

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
@@ -18,9 +18,9 @@ import kotlin.time.Duration
  * HTTP request pipeline middleware that signs outgoing requests
  */
 @InternalApi
-class AwsSigningMiddleware(private val config: Config) : ModifyRequestMiddleware {
-    companion object {
-        inline operator fun invoke(block: Config.() -> Unit): AwsSigningMiddleware {
+public class AwsSigningMiddleware(private val config: Config) : ModifyRequestMiddleware {
+    public companion object {
+        public inline operator fun invoke(block: Config.() -> Unit): AwsSigningMiddleware {
             val config = Config().apply(block)
             requireNotNull(config.credentialsProvider) { "A credentials provider must be specified for the middleware" }
             requireNotNull(config.service) { "A service must be specified for the middleware" }
@@ -29,71 +29,71 @@ class AwsSigningMiddleware(private val config: Config) : ModifyRequestMiddleware
         }
     }
 
-    class Config {
+    public class Config {
         /**
          * The signer implementation to use for signing
          */
-        var signer: AwsSigner? = null
+        public var signer: AwsSigner? = null
 
         /**
          * The credentials provider used to sign requests with
          */
-        var credentialsProvider: CredentialsProvider? = null
+        public var credentialsProvider: CredentialsProvider? = null
 
         /**
          * The credential scope service name to sign requests for
          * NOTE: The operation context is favored when [AwsSigningAttributes.SigningService] is set
          */
-        var service: String? = null
+        public var service: String? = null
 
         /**
          * Sets what signature should be computed
          */
-        var signatureType: AwsSignatureType = AwsSignatureType.HTTP_REQUEST_VIA_HEADERS
+        public var signatureType: AwsSignatureType = AwsSignatureType.HTTP_REQUEST_VIA_HEADERS
 
         /**
          * The algorithm to sign with
          */
-        var algorithm: AwsSigningAlgorithm = AwsSigningAlgorithm.SIGV4
+        public var algorithm: AwsSigningAlgorithm = AwsSigningAlgorithm.SIGV4
 
         /**
          * Indicates whether the payload should be unsigned _even_ in cases where it would otherwise be signable (e.g.,
          * a replayable stream or byte buffer). Setting this value to `false` will _not_ allow signing a non-replayable
          * stream.
          */
-        var isUnsignedPayload: Boolean = false
+        public var isUnsignedPayload: Boolean = false
 
         /**
          * The uri is assumed to be encoded once in preparation for transmission.  Certain services
          * do not decode before checking signature, requiring double-encoding the uri in the canonical
          * request in order to pass a signature check.
          */
-        var useDoubleUriEncode: Boolean = true
+        public var useDoubleUriEncode: Boolean = true
 
         /**
          * Controls whether or not the uri paths should be normalized when building the canonical request
          */
-        var normalizeUriPath: Boolean = true
+        public var normalizeUriPath: Boolean = true
 
         /**
          * Flag indicating if the "X-Amz-Security-Token" query param should be omitted.
          * Normally, this parameter is added during signing if the credentials have a session token.
          * The only known case where this should be true is when signing a websocket handshake to IoT Core.
          */
-        var omitSessionToken: Boolean = false
+        public var omitSessionToken: Boolean = false
 
         /**
          * Controls what body "hash" header, if any, should be added to the canonical request and the signed request.
          * Most services do not require this additional header.
          */
-        var signedBodyHeader: AwsSignedBodyHeader = AwsSignedBodyHeader.NONE
+        public var signedBodyHeader: AwsSignedBodyHeader = AwsSignedBodyHeader.NONE
 
         /**
          * If non-zero and the signing transform is query param, then signing will add X-Amz-Expires to the query
          * string, equal to the value specified here.  If this value is zero or if header signing is being used then
          * this parameter has no effect.
          */
-        var expiresAfter: Duration? = null
+        public var expiresAfter: Duration? = null
     }
 
     override fun install(op: SdkHttpOperation<*, *>) {

--- a/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
+++ b/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
@@ -25,7 +25,7 @@ import aws.sdk.kotlin.crt.auth.signing.AwsSigningConfig as CrtSigningConfig
 import aws.sdk.kotlin.crt.http.Headers as CrtHeaders
 import aws.sdk.kotlin.crt.http.HttpRequest as CrtHttpRequest
 
-object CrtAwsSigner : AwsSigner {
+public object CrtAwsSigner : AwsSigner {
     override suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult<HttpRequest> {
         val crtRequest = request.toSignableCrtRequest()
         val crtConfig = config.toCrtSigningConfig()

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/DefaultAwsSigner.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/DefaultAwsSigner.kt
@@ -10,7 +10,7 @@ import aws.smithy.kotlin.runtime.logging.Logger
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 
 /** The default implementation of [AwsSigner] */
-val DefaultAwsSigner: AwsSigner = DefaultAwsSignerImpl()
+public val DefaultAwsSigner: AwsSigner = DefaultAwsSignerImpl()
 
 internal class DefaultAwsSignerImpl(
     private val canonicalizer: Canonicalizer = Canonicalizer.Default,

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
@@ -15,6 +15,7 @@ import aws.smithy.kotlin.runtime.http.request.headers
 import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,9 +44,9 @@ private const val EXPECTED_FINAL_CHUNK_SIGNATURE = "b6c6ea8a5354eaf15b3cb7646744
 
 @Suppress("HttpUrlsUsage")
 @OptIn(ExperimentalCoroutinesApi::class)
-abstract class BasicSigningTestBase : HasSigner {
+public abstract class BasicSigningTestBase : HasSigner {
     @Test
-    fun testSignRequestSigV4() = runTest {
+    public fun testSignRequestSigV4(): TestResult = runTest {
         // sanity test
         val request = HttpRequestBuilder().apply {
             method = HttpMethod.POST
@@ -80,7 +81,7 @@ abstract class BasicSigningTestBase : HasSigner {
     }
 
     @Test
-    open fun testSignRequestSigV4Asymmetric() = runTest {
+    public open fun testSignRequestSigV4Asymmetric(): TestResult = runTest {
         // sanity test
         val request = HttpRequestBuilder().apply {
             method = HttpMethod.POST
@@ -163,7 +164,7 @@ abstract class BasicSigningTestBase : HasSigner {
     }
 
     @Test
-    fun testSignChunks() = runTest {
+    public fun testSignChunks(): TestResult = runTest {
         val request = createChunkedTestRequest()
         val chunkedRequestConfig = createChunkedRequestSigningConfig()
         val requestResult = signer.sign(request, chunkedRequestConfig)

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/HasSigner.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/HasSigner.kt
@@ -6,6 +6,6 @@ package aws.smithy.kotlin.runtime.auth.awssigning.tests
 
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
 
-interface HasSigner {
-    val signer: AwsSigner
+public interface HasSigner {
+    public val signer: AwsSigner
 }

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
@@ -19,13 +19,14 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.get
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @Suppress("HttpUrlsUsage")
 @OptIn(ExperimentalCoroutinesApi::class)
-abstract class MiddlewareSigningTestBase : HasSigner {
+public abstract class MiddlewareSigningTestBase : HasSigner {
     private fun buildOperation(streaming: Boolean = false, replayable: Boolean = true): SdkHttpOperation<Unit, HttpResponse> = SdkHttpOperation.build {
         serializer = object : HttpSerialize<Unit> {
             override suspend fun serialize(context: ExecutionContext, input: Unit): HttpRequestBuilder =
@@ -86,7 +87,7 @@ abstract class MiddlewareSigningTestBase : HasSigner {
     }
 
     @Test
-    fun testSignRequest() = runTest {
+    public fun testSignRequest(): TestResult = runTest {
         val op = buildOperation()
         val expectedDate = "20201016T195600Z"
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
@@ -99,7 +100,7 @@ abstract class MiddlewareSigningTestBase : HasSigner {
     }
 
     @Test
-    fun testUnsignedRequest() = runTest {
+    public fun testUnsignedRequest(): TestResult = runTest {
         val op = buildOperation()
         val expectedDate = "20201016T195600Z"
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
@@ -112,7 +113,7 @@ abstract class MiddlewareSigningTestBase : HasSigner {
     }
 
     @Test
-    fun testSignReplayableStreamingRequest() = runTest {
+    public fun testSignReplayableStreamingRequest(): TestResult = runTest {
         val op = buildOperation(streaming = true)
         val expectedDate = "20201016T195600Z"
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
@@ -125,7 +126,7 @@ abstract class MiddlewareSigningTestBase : HasSigner {
     }
 
     @Test
-    fun testSignOneShotStream() = runTest {
+    public fun testSignOneShotStream(): TestResult = runTest {
         val op = buildOperation(streaming = true, replayable = false)
         val expectedDate = "20201016T195600Z"
         // should have same signature as testUnsignedRequest()

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBase.kt
@@ -4,4 +4,4 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning.tests
 
-expect abstract class SigningSuiteTestBase : HasSigner
+public expect abstract class SigningSuiteTestBase : HasSigner

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningTestUtil.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningTestUtil.kt
@@ -8,8 +8,8 @@ package aws.smithy.kotlin.runtime.auth.awssigning.tests
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 
-val testCredentialsProvider = Credentials("AKID", "SECRET", "SESSION").asStaticProvider()
+public val testCredentialsProvider: CredentialsProvider = Credentials("AKID", "SECRET", "SESSION").asStaticProvider()
 
-fun Credentials.asStaticProvider() = object : CredentialsProvider {
+public fun Credentials.asStaticProvider(): CredentialsProvider = object : CredentialsProvider {
     override suspend fun getCredentials(): Credentials = this@asStaticProvider
 }

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -62,16 +62,16 @@ private val defaultTestSigningConfig = AwsSigningConfig.Builder().apply {
     normalizeUriPath = true
 }
 
-data class Sigv4TestSuiteTest(
-    val path: Path,
-    val request: HttpRequestBuilder,
-    val canonicalRequest: String,
-    val stringToSign: String,
-    val signature: String,
-    val signedRequest: HttpRequestBuilder,
-    val config: AwsSigningConfig = defaultTestSigningConfig.build(),
+public data class Sigv4TestSuiteTest(
+    public val path: Path,
+    public val request: HttpRequestBuilder,
+    public val canonicalRequest: String,
+    public val stringToSign: String,
+    public val signature: String,
+    public val signedRequest: HttpRequestBuilder,
+    public val config: AwsSigningConfig = defaultTestSigningConfig.build(),
 ) {
-    override fun toString() = path.fileName.toString()
+    override fun toString(): String = path.fileName.toString()
 }
 
 private val testSuitePath: Path by lazy {
@@ -88,12 +88,12 @@ private val AwsSignatureType.fileNamePart: String
         else -> error("Unsupported signature type $this for test suite")
     }
 
-typealias SigningStateProvider = suspend (HttpRequest, AwsSigningConfig) -> String
+public typealias SigningStateProvider = suspend (HttpRequest, AwsSigningConfig) -> String
 
 // FIXME - move to common test (will require ability to access test resources in a KMP compatible way)
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // necessary so arg factory methods can handle disabledTests
-actual abstract class SigningSuiteTestBase : HasSigner {
+public actual abstract class SigningSuiteTestBase : HasSigner {
     private val testDirPaths: List<Path> by lazy {
         Files
             .walk(testSuitePath)
@@ -103,7 +103,7 @@ actual abstract class SigningSuiteTestBase : HasSigner {
             .map { it.parent }
     }
 
-    protected open val disabledTests = setOf(
+    protected open val disabledTests: Set<String> = setOf(
         // TODO https://github.com/awslabs/smithy-kotlin/issues/653
         // ktor-http-cio parser doesn't support parsing multiline headers since they are deprecated in RFC7230
         "get-header-value-multiline",
@@ -116,11 +116,11 @@ actual abstract class SigningSuiteTestBase : HasSigner {
         "get-vanilla-query-order-value",
     )
 
-    fun headerTestArgs(): List<Sigv4TestSuiteTest> = getTests(AwsSignatureType.HTTP_REQUEST_VIA_HEADERS)
-    fun queryTestArgs(): List<Sigv4TestSuiteTest> = getTests(AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS)
+    public fun headerTestArgs(): List<Sigv4TestSuiteTest> = getTests(AwsSignatureType.HTTP_REQUEST_VIA_HEADERS)
+    public fun queryTestArgs(): List<Sigv4TestSuiteTest> = getTests(AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS)
 
     @Test
-    fun testParseRequest() {
+    public fun testParseRequest() {
         // sanity test that we are converting requests from file correctly
         val noBodyTest = testSuitePath.resolve("post-vanilla")
         val actual = getSignedRequest(noBodyTest, AwsSignatureType.HTTP_REQUEST_VIA_HEADERS)
@@ -137,13 +137,13 @@ actual abstract class SigningSuiteTestBase : HasSigner {
 
     @ParameterizedTest(name = "header middleware test {0} (#{index})")
     @MethodSource("headerTestArgs")
-    fun testSigv4TestSuiteHeaders(test: Sigv4TestSuiteTest) {
+    public fun testSigv4TestSuiteHeaders(test: Sigv4TestSuiteTest) {
         testSigv4Middleware(test)
     }
 
     @ParameterizedTest(name = "query param middleware test {0} (#{index})")
     @MethodSource("queryTestArgs")
-    fun testSigv4TestSuiteQuery(test: Sigv4TestSuiteTest) {
+    public fun testSigv4TestSuiteQuery(test: Sigv4TestSuiteTest) {
         testSigv4Middleware(test)
     }
 
@@ -182,17 +182,17 @@ actual abstract class SigningSuiteTestBase : HasSigner {
 
     @ParameterizedTest(name = "header canonical request test {0} (#{index})")
     @MethodSource("headerTestArgs")
-    fun testCanonicalRequestHeaders(test: Sigv4TestSuiteTest) {
+    public fun testCanonicalRequestHeaders(test: Sigv4TestSuiteTest) {
         testCanonicalRequest(test)
     }
 
     @ParameterizedTest(name = "query param canonical request test {0} (#{index})")
     @MethodSource("queryTestArgs")
-    fun testCanonicalRequestQuery(test: Sigv4TestSuiteTest) {
+    public fun testCanonicalRequestQuery(test: Sigv4TestSuiteTest) {
         testCanonicalRequest(test)
     }
 
-    open val canonicalRequestProvider: SigningStateProvider? = null
+    public open val canonicalRequestProvider: SigningStateProvider? = null
 
     private fun testCanonicalRequest(test: Sigv4TestSuiteTest) = runBlocking {
         assumeTrue(canonicalRequestProvider != null)
@@ -203,17 +203,17 @@ actual abstract class SigningSuiteTestBase : HasSigner {
 
     @ParameterizedTest(name = "header signature test {0} (#{index})")
     @MethodSource("headerTestArgs")
-    fun testSignatureHeaders(test: Sigv4TestSuiteTest) {
+    public fun testSignatureHeaders(test: Sigv4TestSuiteTest) {
         testSignature(test)
     }
 
     @ParameterizedTest(name = "query param signature test {0} (#{index})")
     @MethodSource("queryTestArgs")
-    fun testSignatureQuery(test: Sigv4TestSuiteTest) {
+    public fun testSignatureQuery(test: Sigv4TestSuiteTest) {
         testSignature(test)
     }
 
-    open val signatureProvider: SigningStateProvider? = null
+    public open val signatureProvider: SigningStateProvider? = null
 
     private fun testSignature(test: Sigv4TestSuiteTest) = runBlocking {
         assumeTrue(signatureProvider != null)
@@ -224,17 +224,17 @@ actual abstract class SigningSuiteTestBase : HasSigner {
 
     @ParameterizedTest(name = "header string to sign test {0} (#{index})")
     @MethodSource("headerTestArgs")
-    fun testStringToSignHeaders(test: Sigv4TestSuiteTest) {
+    public fun testStringToSignHeaders(test: Sigv4TestSuiteTest) {
         testStringToSign(test)
     }
 
     @ParameterizedTest(name = "query param string to sign test {0} (#{index})")
     @MethodSource("queryTestArgs")
-    fun testStringToSignQuery(test: Sigv4TestSuiteTest) {
+    public fun testStringToSignQuery(test: Sigv4TestSuiteTest) {
         testStringToSign(test)
     }
 
-    open val stringToSignProvider: SigningStateProvider? = null
+    public open val stringToSignProvider: SigningStateProvider? = null
 
     private fun testStringToSign(test: Sigv4TestSuiteTest) = runBlocking {
         assumeTrue(stringToSignProvider != null)

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -67,6 +67,8 @@ subprojects {
     }
 
     kotlin {
+        explicitApi()
+
         sourceSets {
             all {
                 val srcDir = if (name.endsWith("Main")) "src" else "test"

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32.kt
@@ -7,11 +7,11 @@ package aws.smithy.kotlin.runtime.hashing
 import aws.smithy.kotlin.runtime.util.InternalApi
 
 @InternalApi
-abstract class Crc32Base : HashFunction {
+public abstract class Crc32Base : HashFunction {
     override val blockSizeBytes: Int = 4
     override val digestSizeBytes: Int = 4
 
-    abstract fun digestValue(): UInt
+    public abstract fun digestValue(): UInt
 }
 
 /**
@@ -19,10 +19,10 @@ abstract class Crc32Base : HashFunction {
  * directly to avoid doing the integer conversion yourself.
  */
 @InternalApi
-expect class Crc32() : Crc32Base
+public expect class Crc32() : Crc32Base
 
 /**
  * Compute the MD5 hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.crc32(): UInt = Crc32().apply { update(this@crc32) }.digestValue()
+public fun ByteArray.crc32(): UInt = Crc32().apply { update(this@crc32) }.digestValue()

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/HashFunction.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/HashFunction.kt
@@ -10,32 +10,32 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * A cryptographic hash function (algorithm)
  */
 @InternalApi
-interface HashFunction {
+public interface HashFunction {
     /**
      * The size of the hashing block in bytes.
      */
-    val blockSizeBytes: Int
+    public val blockSizeBytes: Int
 
     /**
      * The size of the digest output in bytes.
      */
-    val digestSizeBytes: Int
+    public val digestSizeBytes: Int
 
     /**
      * Update the running hash with [input] bytes. This can be called multiple times.
      */
-    fun update(input: ByteArray, offset: Int = 0, length: Int = input.size)
+    public fun update(input: ByteArray, offset: Int = 0, length: Int = input.size)
 
     /**
      * Finalize the hash computation and return the digest bytes. The hash function will be [reset] after the call is
      * made.
      */
-    fun digest(): ByteArray
+    public fun digest(): ByteArray
 
     /**
      * Resets the digest to its initial state discarding any accumulated digest state.
      */
-    fun reset()
+    public fun reset()
 }
 
 internal fun hash(fn: HashFunction, input: ByteArray): ByteArray = fn.apply { update(input) }.digest()
@@ -44,16 +44,16 @@ internal fun hash(fn: HashFunction, input: ByteArray): ByteArray = fn.apply { up
  * Compute a hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.hash(fn: HashFunction): ByteArray = hash(fn, this)
+public fun ByteArray.hash(fn: HashFunction): ByteArray = hash(fn, this)
 
 /**
  * A function that returns a new instance of a [HashFunction].
  */
 @InternalApi
-typealias HashSupplier = () -> HashFunction
+public typealias HashSupplier = () -> HashFunction
 
 /**
  * Compute a hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.hash(hashSupplier: HashSupplier): ByteArray = hash(hashSupplier(), this)
+public fun ByteArray.hash(hashSupplier: HashSupplier): ByteArray = hash(hashSupplier(), this)

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Hmac.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Hmac.kt
@@ -15,7 +15,7 @@ import kotlin.experimental.xor
  * @param hashFunction The hashing algorithm to use.
  */
 @InternalApi
-fun hmac(key: ByteArray, message: ByteArray, hashFunction: HashFunction): ByteArray {
+public fun hmac(key: ByteArray, message: ByteArray, hashFunction: HashFunction): ByteArray {
     val blockSizedKey = key.resizeToBlock(hashFunction)
 
     val innerKey = blockSizedKey xor 0x36
@@ -38,7 +38,7 @@ fun hmac(key: ByteArray, message: ByteArray, hashFunction: HashFunction): ByteAr
  * @param hashSupplier A supplier that yields a hashing algorithm to use.
  */
 @InternalApi
-fun hmac(key: ByteArray, message: ByteArray, hashSupplier: HashSupplier): ByteArray =
+public fun hmac(key: ByteArray, message: ByteArray, hashSupplier: HashSupplier): ByteArray =
     hmac(key, message, hashSupplier())
 
 private fun ByteArray.resizeToBlock(hashFunction: HashFunction): ByteArray {

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Md5.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Md5.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.hashing
 import aws.smithy.kotlin.runtime.util.InternalApi
 
 @InternalApi
-abstract class Md5Base : HashFunction {
+public abstract class Md5Base : HashFunction {
     override val blockSizeBytes: Int = 64
     override val digestSizeBytes: Int = 16
 }
@@ -16,10 +16,10 @@ abstract class Md5Base : HashFunction {
  * Implementation of RFC1321 MD5 digest
  */
 @InternalApi
-expect class Md5() : Md5Base
+public expect class Md5() : Md5Base
 
 /**
  * Compute the MD5 hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.md5(): ByteArray = hash(Md5(), this)
+public fun ByteArray.md5(): ByteArray = hash(Md5(), this)

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Sha1.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Sha1.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.hashing
 import aws.smithy.kotlin.runtime.util.InternalApi
 
 @InternalApi
-abstract class Sha1Base : HashFunction {
+public abstract class Sha1Base : HashFunction {
     override val blockSizeBytes: Int = 64
     override val digestSizeBytes: Int = 20
 }
@@ -16,10 +16,10 @@ abstract class Sha1Base : HashFunction {
  * Implementation of SHA-1 (Secure Hash Algorithm 1) hash function. See: https://csrc.nist.gov/projects/hash-functions
  */
 @InternalApi
-expect class Sha1() : Sha1Base
+public expect class Sha1() : Sha1Base
 
 /**
  * Compute the SHA-1 hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.sha1(): ByteArray = hash(Sha1(), this)
+public fun ByteArray.sha1(): ByteArray = hash(Sha1(), this)

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Sha256.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Sha256.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.hashing
 import aws.smithy.kotlin.runtime.util.InternalApi
 
 @InternalApi
-abstract class Sha256Base : HashFunction {
+public abstract class Sha256Base : HashFunction {
     override val blockSizeBytes: Int = 64
     override val digestSizeBytes: Int = 32
 }
@@ -17,10 +17,10 @@ abstract class Sha256Base : HashFunction {
 
  */
 @InternalApi
-expect class Sha256() : Sha256Base
+public expect class Sha256() : Sha256Base
 
 /**
  * Compute the SHA-256 hash of the current [ByteArray]
  */
 @InternalApi
-fun ByteArray.sha256(): ByteArray = hash(Sha256(), this)
+public fun ByteArray.sha256(): ByteArray = hash(Sha256(), this)

--- a/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Crc32JVM.kt
+++ b/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Crc32JVM.kt
@@ -6,10 +6,10 @@ package aws.smithy.kotlin.runtime.hashing
 
 import java.util.zip.CRC32
 
-actual class Crc32 : Crc32Base() {
+public actual class Crc32 : Crc32Base() {
     private val md = CRC32()
 
-    override fun update(input: ByteArray, offset: Int, length: Int) = md.update(input, offset, length)
+    override fun update(input: ByteArray, offset: Int, length: Int): Unit = md.update(input, offset, length)
 
     override fun digest(): ByteArray {
         val x = digestValue()
@@ -24,5 +24,5 @@ actual class Crc32 : Crc32Base() {
 
     override fun digestValue(): UInt = md.value.toUInt()
 
-    override fun reset() = md.reset()
+    override fun reset(): Unit = md.reset()
 }

--- a/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Md5JVM.kt
+++ b/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Md5JVM.kt
@@ -6,9 +6,9 @@ package aws.smithy.kotlin.runtime.hashing
 
 import java.security.MessageDigest
 
-actual class Md5 : Md5Base() {
+public actual class Md5 : Md5Base() {
     private val md = MessageDigest.getInstance("MD5")
-    override fun update(input: ByteArray, offset: Int, length: Int) = md.update(input, offset, length)
+    override fun update(input: ByteArray, offset: Int, length: Int): Unit = md.update(input, offset, length)
     override fun digest(): ByteArray = md.digest()
-    override fun reset() = md.reset()
+    override fun reset(): Unit = md.reset()
 }

--- a/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Sha1JVM.kt
+++ b/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Sha1JVM.kt
@@ -6,9 +6,9 @@ package aws.smithy.kotlin.runtime.hashing
 
 import java.security.MessageDigest
 
-actual class Sha1 : Sha1Base() {
+public actual class Sha1 : Sha1Base() {
     private val md = MessageDigest.getInstance("SHA-1")
-    override fun update(input: ByteArray, offset: Int, length: Int) = md.update(input, offset, length)
+    override fun update(input: ByteArray, offset: Int, length: Int): Unit = md.update(input, offset, length)
     override fun digest(): ByteArray = md.digest()
-    override fun reset() = md.reset()
+    override fun reset(): Unit = md.reset()
 }

--- a/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Sha256JVM.kt
+++ b/runtime/hashing/jvm/src/aws/smithy/kotlin/runtime/hashing/Sha256JVM.kt
@@ -6,9 +6,9 @@ package aws.smithy.kotlin.runtime.hashing
 
 import java.security.MessageDigest
 
-actual class Sha256 : Sha256Base() {
+public actual class Sha256 : Sha256Base() {
     private val md = MessageDigest.getInstance("SHA-256")
-    override fun update(input: ByteArray, offset: Int, length: Int) = md.update(input, offset, length)
+    override fun update(input: ByteArray, offset: Int, length: Int): Unit = md.update(input, offset, length)
     override fun digest(): ByteArray = md.digest()
-    override fun reset() = md.reset()
+    override fun reset(): Unit = md.reset()
 }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Buffer.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Buffer.kt
@@ -9,12 +9,12 @@ package aws.smithy.kotlin.runtime.io
  * A buffer that supports read operations. The bytes are stored in memory but the underlying storage may or may
  * not be contiguous.
  */
-interface Buffer {
+public interface Buffer {
 
     /**
      * The number of bytes between the current position and the end of the buffer
      */
-    val readRemaining: ULong
+    public val readRemaining: ULong
 
     /**
      * Advance the internal read position discarding up to [count] readable bytes
@@ -25,67 +25,67 @@ interface Buffer {
     /**
      * Read a single byte from the buffer
      */
-    fun readByte(): Byte
+    public fun readByte(): Byte
 
     /**
      * Read a signed 16-bit integer in big-endian byte order
      */
-    fun readShort(): Short
+    public fun readShort(): Short
 
     /**
      * Read an unsigned 16-bit integer in big-endian byte order
      */
-    fun readUShort(): UShort
+    public fun readUShort(): UShort
 
     /**
      * Read a signed 32-bit integer in big-endian byte order
      */
-    fun readInt(): Int
+    public fun readInt(): Int
 
     /**
      * Read an unsigned 32-bit integer in big-endian byte order
      */
-    fun readUInt(): UInt
+    public fun readUInt(): UInt
 
     /**
      * Read a signed 64-bit integer in big-endian byte order
      */
-    fun readLong(): Long
+    public fun readLong(): Long
 
     /**
      * Read an unsigned 64-bit integer in big-endian byte order
      */
-    fun readULong(): ULong
+    public fun readULong(): ULong
 
     /**
      * Read a 32-bit float in big-endian byte order
      */
-    fun readFloat(): Float
+    public fun readFloat(): Float
 
     /**
      * Read a 64-bit double in big-endian byte order
      */
-    fun readDouble(): Double
+    public fun readDouble(): Double
 
     /**
      * Read from this buffer exactly [length] bytes and write to [dest] starting at [offset]
      * @throws IllegalArgumentException if there are not enough bytes available for read or the offset/length combination is invalid
      */
-    fun readFully(dest: ByteArray, offset: Int = 0, length: Int = dest.size - offset)
+    public fun readFully(dest: ByteArray, offset: Int = 0, length: Int = dest.size - offset)
 
     /**
      * Read all available bytes from this buffer into [dest] starting at [offset] up to the destination buffers size.
      * If the total bytes available is less than [length] then as many bytes as are available will be read.
      * The total bytes read is returned or `-1` if no data is available.
      */
-    fun readAvailable(dest: ByteArray, offset: Int = 0, length: Int = dest.size - offset): Int
+    public fun readAvailable(dest: ByteArray, offset: Int = 0, length: Int = dest.size - offset): Int
 }
 
 /**
  * Reads at most [length] bytes from this buffer into the [dst] buffer
  * @return the number of bytes read
  */
-fun Buffer.readFully(dst: SdkByteBuffer, length: ULong = dst.writeRemaining): ULong {
+public fun Buffer.readFully(dst: SdkByteBuffer, length: ULong = dst.writeRemaining): ULong {
     if (this is SdkByteBuffer) return this.readFully(dst, length)
     TODO("Buffer.readFully fallback not implemented for ${this::class}")
 }
@@ -94,7 +94,7 @@ fun Buffer.readFully(dst: SdkByteBuffer, length: ULong = dst.writeRemaining): UL
  * Reads at most [length] bytes from this buffer or `-1` if no bytes are available for read.
  * @return the number of bytes read or null if the buffer is empty
  */
-fun Buffer.readAvailable(dst: SdkByteBuffer, length: ULong = dst.writeRemaining): ULong? {
+public fun Buffer.readAvailable(dst: SdkByteBuffer, length: ULong = dst.writeRemaining): ULong? {
     if (this is SdkByteBuffer) return this.readAvailable(dst, length)
     TODO("Buffer.readAvailable fallback not implemented for ${this::class}")
 }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Exceptions.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Exceptions.kt
@@ -8,25 +8,25 @@ package aws.smithy.kotlin.runtime.io
 /**
  * Exception thrown when a content-mutation method such as `write` is invoked upon a read-only buffer.
  */
-class ReadOnlyBufferException : UnsupportedOperationException {
-    constructor() : super()
+public class ReadOnlyBufferException : UnsupportedOperationException {
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 }
 
 /**
  * Exception thrown when a content-mutation method such as `write` is invoked upon a buffer that cannot grow
  */
-class FixedBufferSizeException : UnsupportedOperationException {
-    constructor() : super()
+public class FixedBufferSizeException : UnsupportedOperationException {
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Handler.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/Handler.kt
@@ -8,18 +8,18 @@ package aws.smithy.kotlin.runtime.io
 /**
  * Handler is an (asynchronous) transform from [Request] -> [Response]
  */
-interface Handler<in Request, out Response> {
-    suspend fun call(request: Request): Response
+public interface Handler<in Request, out Response> {
+    public suspend fun call(request: Request): Response
 }
 
 /**
  * Alias for a lambda based [Handler]
  */
-typealias HandlerFn<Request, Response> = suspend (Request) -> Response
+public typealias HandlerFn<Request, Response> = suspend (Request) -> Response
 
 /**
  * Adapter for [HandlerFn] that implements [Handler]
  */
-data class HandlerLambda<Request, Response>(private val fn: HandlerFn<Request, Response>) : Handler<Request, Response> {
+public data class HandlerLambda<Request, Response>(private val fn: HandlerFn<Request, Response>) : Handler<Request, Response> {
     override suspend fun call(request: Request): Response = fn(request)
 }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/KtorAdapters.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/KtorAdapters.kt
@@ -102,10 +102,10 @@ internal expect class KtorReadChannelAdapter(chan: KtorByteReadChannel) : SdkByt
 internal expect class KtorWriteChannelAdapter(chan: KtorByteWriteChannel) : SdkByteWriteChannel
 
 @InternalApi
-fun KtorByteReadChannel.toSdkChannel(): SdkByteReadChannel = KtorReadChannelAdapter(this)
+public fun KtorByteReadChannel.toSdkChannel(): SdkByteReadChannel = KtorReadChannelAdapter(this)
 
 @InternalApi
-fun KtorByteWriteChannel.toSdkChannel(): SdkByteWriteChannel = KtorWriteChannelAdapter(this)
+public fun KtorByteWriteChannel.toSdkChannel(): SdkByteWriteChannel = KtorWriteChannelAdapter(this)
 
 @InternalApi
-fun KtorByteChannel.toSdkChannel(): SdkByteChannel = KtorByteChannelAdapter(this)
+public fun KtorByteChannel.toSdkChannel(): SdkByteChannel = KtorByteChannelAdapter(this)

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/MutableBuffer.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/MutableBuffer.kt
@@ -8,14 +8,14 @@ package aws.smithy.kotlin.runtime.io
 /**
  * A mutable buffer that can be written to
  */
-interface MutableBuffer {
+public interface MutableBuffer {
     // TODO - could implement Appendable for convenience, need writeUtf8Char() extension
 
     /**
      * Free space left for writing. Implementations may allocate more memory on the fly in which case this
      * value should indicate how much remains between the buffer capacity and the write position.
      */
-    val writeRemaining: ULong
+    public val writeRemaining: ULong
 
     /**
      * Mark [n] bytes written and advance the internal writePosition by the same amount
@@ -23,64 +23,64 @@ interface MutableBuffer {
      * NOTE: This method does not guarantee that the bytes being advanced past have been initialized.
      * @throws IllegalArgumentException the bytes to advance [n] is greater than [writeRemaining]
      */
-    fun advance(n: ULong)
+    public fun advance(n: ULong)
 
     /**
      * Write a single byte to the buffer
      */
-    fun writeByte(value: Byte)
+    public fun writeByte(value: Byte)
 
     /**
      * Write a signed 16-bit integer in big-endian byte order
      */
-    fun writeShort(value: Short)
+    public fun writeShort(value: Short)
 
     /**
      * Write an unsigned 16-bit integer in big-endian byte order
      */
-    fun writeUShort(value: UShort)
+    public fun writeUShort(value: UShort)
 
     /**
      * Write a signed 32-bit integer in big-endian byte order
      */
-    fun writeInt(value: Int)
+    public fun writeInt(value: Int)
 
     /**
      * Write an unsigned 32-bit integer in big-endian byte order
      */
-    fun writeUInt(value: UInt)
+    public fun writeUInt(value: UInt)
 
     /**
      * Write a signed 64-bit integer in big-endian byte order
      */
-    fun writeLong(value: Long)
+    public fun writeLong(value: Long)
 
     /**
      * Write an unsigned 64-bit integer in big-endian byte order
      */
-    fun writeULong(value: ULong)
+    public fun writeULong(value: ULong)
 
     /**
      * Write a 32-bit float in big-endian byte order
      */
-    fun writeFloat(value: Float)
+    public fun writeFloat(value: Float)
 
     /**
      * Write a 32-bit float in big-endian byte order
      */
-    fun writeDouble(value: Double)
+    public fun writeDouble(value: Double)
 
     /**
      * Write [length] bytes of [src] to this buffer starting at [offset]
      * @throws IllegalArgumentException if there is insufficient space or the offset/length combination is invalid
      */
-    fun writeFully(src: ByteArray, offset: Int = 0, length: Int = src.size - offset)
+    public fun writeFully(src: ByteArray, offset: Int = 0, length: Int = src.size - offset)
 }
 
 /**
  * Write exactly [length] bytes from [src] to this buffer
  */
-fun MutableBuffer.writeFully(src: SdkByteBuffer, length: ULong = src.readRemaining) {
+public fun MutableBuffer.writeFully(src: SdkByteBuffer, length: ULong = src.readRemaining) {
     require(length <= src.readRemaining) {
         "not enough bytes in source buffer to read $length bytes (${src.readRemaining} remaining)"
     }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt
@@ -13,23 +13,23 @@ internal const val DEFAULT_BUFFER_SIZE: Int = 4096
  * Supplies an asynchronous stream of bytes. Use this interface to read data from wherever it’s located:
  * from the network, storage, or a buffer in memory. This is a **single-reader channel**.
  */
-expect interface SdkByteReadChannel : Closeable {
+public expect interface SdkByteReadChannel : Closeable {
     /**
      * Returns number of bytes that can be read without suspension. Read operations do no suspend and
      * return immediately when this number is at least the number of bytes requested for read.
      */
-    val availableForRead: Int
+    public val availableForRead: Int
 
     /**
      * Returns `true` if the channel is closed and no remaining bytes are available for read. It implies
      * that availableForRead is zero.
      */
-    val isClosedForRead: Boolean
+    public val isClosedForRead: Boolean
 
     /**
      * Returns `true` if the channel is closed from the writer side. [availableForRead] may be > 0
      */
-    val isClosedForWrite: Boolean
+    public val isClosedForWrite: Boolean
 
     /**
      * Read up to [limit] bytes into a [ByteArray] suspending until [limit] is reached or the channel
@@ -39,29 +39,29 @@ expect interface SdkByteReadChannel : Closeable {
      *
      * Check [availableForRead] and/or [isClosedForRead] to see if there is additional data left
      */
-    suspend fun readRemaining(limit: Int = Int.MAX_VALUE): ByteArray
+    public suspend fun readRemaining(limit: Int = Int.MAX_VALUE): ByteArray
 
     /**
      * Reads all length bytes to [sink] buffer or fails if source has been closed. Suspends if not enough
      * bytes available.
      */
-    suspend fun readFully(sink: ByteArray, offset: Int = 0, length: Int = sink.size - offset)
+    public suspend fun readFully(sink: ByteArray, offset: Int = 0, length: Int = sink.size - offset)
 
     /**
      * Reads all available bytes to [sink] buffer and returns immediately or suspends if no bytes available
      */
-    suspend fun readAvailable(sink: ByteArray, offset: Int = 0, length: Int = sink.size - offset): Int
+    public suspend fun readAvailable(sink: ByteArray, offset: Int = 0, length: Int = sink.size - offset): Int
 
     /**
      * Suspend until *some* data is available or channel is closed
      */
-    suspend fun awaitContent()
+    public suspend fun awaitContent()
 
     /**
      * Close channel with optional cause cancellation.
      * This is an idempotent operation — subsequent invocations of this function have no effect and return false
      */
-    fun cancel(cause: Throwable?): Boolean
+    public fun cancel(cause: Throwable?): Boolean
 }
 
 /**
@@ -164,7 +164,7 @@ internal suspend fun SdkByteReadChannel.readAvailableFallback(dest: SdkByteBuffe
 /**
  * Reads a UTF-8 code point from the channel. Returns `null` if closed
  */
-suspend fun SdkByteReadChannel.readUtf8CodePoint(): Int? {
+public suspend fun SdkByteReadChannel.readUtf8CodePoint(): Int? {
     awaitContent()
     if (availableForRead == 0 && isClosedForRead) return null
 

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannel.kt
@@ -15,48 +15,48 @@ public expect interface SdkByteWriteChannel : Closeable {
      * suspend and return immediately when this number is at least the number of bytes requested for
      * write.
      */
-    val availableForWrite: Int
+    public val availableForWrite: Int
 
     /**
      * Returns true if channel has been closed. Attempting to write to the channel will throw an exception
      */
-    val isClosedForWrite: Boolean
+    public val isClosedForWrite: Boolean
 
     /**
      * Total number of bytes written to the channel.
      *
      * NOTE: not guaranteed to be atomic and may be updated in middle of a write operation
      */
-    val totalBytesWritten: Long
+    public val totalBytesWritten: Long
 
     /**
      * Returns `true` if the channel flushes automatically all pending bytes after every write operation.
      * If `false` then flush only happens when [flush] is explicitly called or when the buffer is full.
      */
-    val autoFlush: Boolean
+    public val autoFlush: Boolean
 
     /**
      * Writes all [src] bytes and suspends until all bytes written.
      */
-    suspend fun writeFully(src: ByteArray, offset: Int = 0, length: Int = src.size - offset): Unit
+    public suspend fun writeFully(src: ByteArray, offset: Int = 0, length: Int = src.size - offset): Unit
 
     /**
      * Writes as much as possible and only suspends if buffer is full
      * Returns the byte count written.
      */
-    suspend fun writeAvailable(src: ByteArray, offset: Int = 0, length: Int = src.size - offset): Int
+    public suspend fun writeAvailable(src: ByteArray, offset: Int = 0, length: Int = src.size - offset): Int
 
     /**
      * Closes this channel with an optional exceptional [cause]. All pending bytes are flushed.
      * This is an idempotent operation — subsequent invocations of this function have no effect and return false
      */
-    fun close(cause: Throwable?): Boolean
+    public fun close(cause: Throwable?): Boolean
 
     /**
      * Flushes all pending write bytes making them available for read.
      * Thread safe and can be invoked at any time. It does nothing when invoked on a closed channel.
      */
-    fun flush(): Unit
+    public fun flush(): Unit
 }
 
 /**

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/MapRequest.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/MapRequest.kt
@@ -10,7 +10,7 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * Implements [Handler] interface that transforms the request from [R1] to [R2]
  */
-class MapRequest<R1, R2, Response, H>(
+public class MapRequest<R1, R2, Response, H>(
     private val inner: H,
     private val fn: suspend (R1) -> R2
 ) : Handler<R1, Response>

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/MapResponse.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/MapResponse.kt
@@ -10,7 +10,7 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * Implements [Handler] interface that transforms the response from [R1] to [R2]
  */
-class MapResponse<Request, R1, R2, H>(
+public class MapResponse<Request, R1, R2, H>(
     private val inner: H,
     private val fn: suspend (R1) -> R2
 ) : Handler<Request, R2>

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Middleware.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Middleware.kt
@@ -10,20 +10,20 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * Decorates a [Handler], transforming either the request or the response
  */
-interface Middleware<Request, Response> {
-    suspend fun <H> handle(request: Request, next: H): Response
+public interface Middleware<Request, Response> {
+    public suspend fun <H> handle(request: Request, next: H): Response
             where H : Handler<Request, Response>
 }
 
 /**
  * Alias for a lambda based [Middleware]
  */
-typealias MiddlewareFn<Request, Response> = suspend (Request, Handler<Request, Response>) -> Response
+public typealias MiddlewareFn<Request, Response> = suspend (Request, Handler<Request, Response>) -> Response
 
 /**
  * Adapter for [MiddlewareFn] that implements [Middleware]
  */
-data class MiddlewareLambda<Request, Response>(
+public data class MiddlewareLambda<Request, Response>(
     private val fn: MiddlewareFn<Request, Response>
 ) : Middleware<Request, Response> {
     override suspend fun <H : Handler<Request, Response>> handle(request: Request, next: H): Response =
@@ -43,7 +43,7 @@ private data class DecoratedHandler<Request, Response>(
 /**
  * decorate [handler] with the given [middleware] returning a new wrapped service
  */
-fun <Request, Response> decorate(
+public fun <Request, Response> decorate(
     handler: Handler<Request, Response>,
     vararg middleware: Middleware<Request, Response>
 ): Handler<Request, Response> {

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/ModifyRequest.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/ModifyRequest.kt
@@ -10,8 +10,8 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * A transform that only modifies the input type
  */
-interface ModifyRequest<Request> {
-    suspend fun modifyRequest(req: Request): Request
+public interface ModifyRequest<Request> {
+    public suspend fun modifyRequest(req: Request): Request
 }
 
 /**

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/ModifyResponse.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/ModifyResponse.kt
@@ -10,8 +10,8 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * A transform that only modifies the output type
  */
-interface ModifyResponse<Response> {
-    suspend fun modifyResponse(resp: Response): Response
+public interface ModifyResponse<Response> {
+    public suspend fun modifyResponse(resp: Response): Response
 }
 
 /**

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Phase.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/middleware/Phase.kt
@@ -15,8 +15,8 @@ import aws.smithy.kotlin.runtime.io.Handler
  * Giving these individual steps names and types allows for targeted application of middleware at
  * the (most) appropriate step.
  */
-class Phase<Request, Response> : Middleware<Request, Response> {
-    enum class Order {
+public class Phase<Request, Response> : Middleware<Request, Response> {
+    public enum class Order {
         Before, After
     }
 
@@ -25,7 +25,7 @@ class Phase<Request, Response> : Middleware<Request, Response> {
     /**
      * Insert [interceptor] in a specific order into the set of interceptors for this phase
      */
-    fun intercept(order: Order = Order.After, interceptor: suspend (req: Request, next: Handler<Request, Response>) -> Response) {
+    public fun intercept(order: Order = Order.After, interceptor: suspend (req: Request, next: Handler<Request, Response>) -> Response) {
         val wrapped = MiddlewareLambda(interceptor)
         register(wrapped, order)
     }
@@ -33,21 +33,21 @@ class Phase<Request, Response> : Middleware<Request, Response> {
     /**
      * Insert a [transform] that only modifies the request of this phase
      */
-    fun register(transform: ModifyRequest<Request>, order: Order = Order.After) {
+    public fun register(transform: ModifyRequest<Request>, order: Order = Order.After) {
         register(ModifyRequestMiddleware(transform), order)
     }
 
     /**
      * Insert a [transform] that only modifies the response of this phase
      */
-    fun register(transform: ModifyResponse<Response>, order: Order = Order.After) {
+    public fun register(transform: ModifyResponse<Response>, order: Order = Order.After) {
         register(ModifyResponseMiddleware(transform), order)
     }
 
     /**
      * Register a middleware in a specific order
      */
-    fun register(middleware: Middleware<Request, Response>, order: Order = Order.After) {
+    public fun register(middleware: Middleware<Request, Response>, order: Order = Order.After) {
         when (order) {
             Order.Before -> middlewares.addFirst(middleware)
             Order.After -> middlewares.addLast(middleware)

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferJVM.kt
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer
 
 internal fun SdkByteBuffer.hasArray() = memory.buffer.hasArray() && !memory.buffer.isReadOnly
 
-actual fun SdkByteBuffer.bytes(): ByteArray = when (hasArray()) {
+public actual fun SdkByteBuffer.bytes(): ByteArray = when (hasArray()) {
     true -> memory.buffer.array().sliceArray(readPosition.toInt() until readRemaining.toInt())
     false -> ByteArray(readRemaining.toInt()).apply { readFully(this) }
 }
@@ -21,12 +21,12 @@ internal actual fun Memory.Companion.ofByteArray(src: ByteArray, offset: Int, le
 /**
  * Create a new SdkBuffer using the given [ByteBuffer] as the contents
  */
-fun SdkByteBuffer.Companion.of(byteBuffer: ByteBuffer): SdkByteBuffer = SdkByteBuffer(Memory.of(byteBuffer))
+public fun SdkByteBuffer.Companion.of(byteBuffer: ByteBuffer): SdkByteBuffer = SdkByteBuffer(Memory.of(byteBuffer))
 
 /**
  * Read the buffer's content to the [dst] buffer moving its position.
  */
-fun SdkByteBuffer.readFully(dst: ByteBuffer) {
+public fun SdkByteBuffer.readFully(dst: ByteBuffer) {
     val length = dst.remaining().toLong()
     read { memory, readStart, _ ->
         memory.copyTo(dst, readStart)
@@ -37,7 +37,7 @@ fun SdkByteBuffer.readFully(dst: ByteBuffer) {
 /**
  * Read as much from this buffer as possible to [dst] buffer moving its position
  */
-fun SdkByteBuffer.readAvailable(dst: ByteBuffer) {
+public fun SdkByteBuffer.readAvailable(dst: ByteBuffer) {
     val wc = minOf(readRemaining.toInt(), dst.remaining())
     if (wc == 0) return
     val dstCopy = dst.duplicate().apply {

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
@@ -13,18 +13,18 @@ import io.ktor.utils.io.ByteReadChannel as KtorByteReadChannel
  *
  * This interface is functionally equivalent to an asynchronous coroutine compatible [java.io.InputStream]
  */
-actual interface SdkByteReadChannel : Closeable {
+public actual interface SdkByteReadChannel : Closeable {
     /**
      * Returns number of bytes that can be read without suspension. Read operations do no suspend and return immediately when this number is at least the number of bytes requested for read.
      */
-    actual val availableForRead: Int
+    public actual val availableForRead: Int
 
     /**
      * Returns true if the channel is closed and no remaining bytes are available for read. It implies that availableForRead is zero.
      */
-    actual val isClosedForRead: Boolean
+    public actual val isClosedForRead: Boolean
 
-    actual val isClosedForWrite: Boolean
+    public actual val isClosedForWrite: Boolean
 
     /**
      * Read up to [limit] bytes into a [ByteArray] suspending until [limit] is reached or the channel
@@ -32,26 +32,26 @@ actual interface SdkByteReadChannel : Closeable {
      *
      * NOTE: Be careful as this will potentially read the entire byte stream into memory (up to limit)
      */
-    actual suspend fun readRemaining(limit: Int): ByteArray
+    public actual suspend fun readRemaining(limit: Int): ByteArray
 
     /**
      * Reads all length bytes to [sink] buffer or fails if source has been closed. Suspends if not enough bytes available.
      */
-    actual suspend fun readFully(sink: ByteArray, offset: Int, length: Int)
+    public actual suspend fun readFully(sink: ByteArray, offset: Int, length: Int)
 
     /**
      * Reads all available bytes to [sink] buffer and returns immediately or suspends if no bytes available
      * @return number of bytes read or `-1` if the channel has been closed
      */
-    actual suspend fun readAvailable(sink: ByteArray, offset: Int, length: Int): Int
-    suspend fun readAvailable(sink: ByteBuffer): Int
+    public actual suspend fun readAvailable(sink: ByteArray, offset: Int, length: Int): Int
+    public suspend fun readAvailable(sink: ByteBuffer): Int
 
-    actual suspend fun awaitContent()
+    public actual suspend fun awaitContent()
 
     /**
      * Close channel with optional cause cancellation
      */
-    actual fun cancel(cause: Throwable?): Boolean
+    public actual fun cancel(cause: Throwable?): Boolean
 
     override fun close() { cancel(null) }
 }
@@ -59,4 +59,4 @@ actual interface SdkByteReadChannel : Closeable {
 /**
  * Creates a channel for reading from the given buffer
  */
-fun SdkByteReadChannel(content: ByteBuffer): SdkByteReadChannel = KtorByteReadChannel(content).toSdkChannel()
+public fun SdkByteReadChannel(content: ByteBuffer): SdkByteReadChannel = KtorByteReadChannel(content).toSdkChannel()

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannelJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteWriteChannelJVM.kt
@@ -11,48 +11,48 @@ public actual interface SdkByteWriteChannel : Closeable {
      * suspend and return immediately when this number is at least the number of bytes requested for
      * write.
      */
-    actual val availableForWrite: Int
+    public actual val availableForWrite: Int
 
     /**
      * Returns true if channel has been closed. Attempting to write to the channel will throw an exception
      */
-    actual val isClosedForWrite: Boolean
+    public actual val isClosedForWrite: Boolean
 
     /**
      * Total number of bytes written to the channel.
      *
      * NOTE: not guaranteed to be atomic and may be updated in middle of a write operation
      */
-    actual val totalBytesWritten: Long
+    public actual val totalBytesWritten: Long
 
     /**
      * Returns `true` if the channel flushes automatically all pending bytes after every write operation.
      * If `false` then flush only happens when [flush] is explicitly called or when the buffer is full.
      */
-    actual val autoFlush: Boolean
+    public actual val autoFlush: Boolean
 
     /**
      * Writes all [src] bytes and suspends until all bytes written.
      */
-    actual suspend fun writeFully(src: ByteArray, offset: Int, length: Int)
+    public actual suspend fun writeFully(src: ByteArray, offset: Int, length: Int)
 
     /**
      * Writes as much as possible and only suspends if buffer is full
      * Returns the byte count written.
      */
-    actual suspend fun writeAvailable(src: ByteArray, offset: Int, length: Int): Int
+    public actual suspend fun writeAvailable(src: ByteArray, offset: Int, length: Int): Int
 
     /**
      * Closes this channel with an optional exceptional [cause]. All pending bytes are flushed.
      * This is an idempotent operation — subsequent invocations of this function have no effect and return false
      */
-    actual fun close(cause: Throwable?): Boolean
+    public actual fun close(cause: Throwable?): Boolean
 
     /**
      * Flushes all pending write bytes making them available for read.
      * Thread safe and can be invoked at any time. It does nothing when invoked on a closed channel.
      */
-    actual fun flush()
+    public actual fun flush()
 
     override fun close() { close(null) }
 }

--- a/runtime/logging/common/src/aws/smithy/kotlin/runtime/logging/Logger.kt
+++ b/runtime/logging/common/src/aws/smithy/kotlin/runtime/logging/Logger.kt
@@ -12,17 +12,17 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  */
 @InternalApi
 public interface Logger {
-    companion object {
+    public companion object {
         /**
          * Get the logger for the class [T]
          */
-        inline fun <reified T> getLogger(): Logger =
+        public inline fun <reified T> getLogger(): Logger =
             getLogger(requireNotNull(T::class.qualifiedName) { "getLogger<T> cannot be used on an anonymous object" })
 
         /**
          * Get the logger for the given [name]
          */
-        fun getLogger(name: String): Logger = KotlinLoggingAdapter(name)
+        public fun getLogger(name: String): Logger = KotlinLoggingAdapter(name)
     }
 
     /**
@@ -89,24 +89,24 @@ public interface Logger {
 /**
  * Add a log message if trace logging is enabled
  */
-public fun Logger.trace(msg: String) = trace { msg }
+public fun Logger.trace(msg: String): Unit = trace { msg }
 
 /**
  * Add a log message if debug logging is enabled
  */
-public fun Logger.debug(msg: String) = debug { msg }
+public fun Logger.debug(msg: String): Unit = debug { msg }
 
 /**
  * Add a log message if info logging is enabled
  */
-public fun Logger.info(msg: String) = info { msg }
+public fun Logger.info(msg: String): Unit = info { msg }
 
 /**
  * Add a log message if warn logging is enabled
  */
-public fun Logger.warn(msg: String) = warn { msg }
+public fun Logger.warn(msg: String): Unit = warn { msg }
 
 /**
  * Add a log message if error logging is enabled
  */
-public fun Logger.error(msg: String) = error { msg }
+public fun Logger.error(msg: String): Unit = error { msg }

--- a/runtime/logging/common/src/aws/smithy/kotlin/runtime/logging/LoggerExt.kt
+++ b/runtime/logging/common/src/aws/smithy/kotlin/runtime/logging/LoggerExt.kt
@@ -37,9 +37,9 @@ private class ContextualLogger(
 /**
  * Return a new logger with the given key-value pairs as contextual data added to all requests logged
  */
-fun Logger.withContext(vararg pairs: Pair<String, Any>): Logger = ContextualLogger(this, pairs.toMap())
+public fun Logger.withContext(vararg pairs: Pair<String, Any>): Logger = ContextualLogger(this, pairs.toMap())
 
 /**
  * Return a new logger with the given map as contextual data added to all requests logged
  */
-fun Logger.withContext(context: Map<String, Any>): Logger = ContextualLogger(this, context)
+public fun Logger.withContext(context: Map<String, Any>): Logger = ContextualLogger(this, context)

--- a/runtime/protocol/http-client-engines/http-client-engine-default/common/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/common/src/aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngine.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.http.engine
 /**
  * Factory function to create a new HTTP client engine using the default for the current KMP target
  */
-fun DefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)? = null): HttpClientEngine = newDefaultHttpEngine(block)
+public fun DefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)? = null): HttpClientEngine =
+    newDefaultHttpEngine(block)
 
 internal expect fun newDefaultHttpEngine(block: (HttpClientEngineConfig.Builder.() -> Unit)?): HttpClientEngine

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorEngine.kt
@@ -39,7 +39,7 @@ import io.ktor.client.engine.HttpClientEngine as KtorHttpClientEngine
  * may support HTTP features required by any given SDK).
  */
 @InternalApi // FIXME - decide on whether to support in GA or not. Most use cases would be better off by wrapping the underlying ktor engine directly
-class KtorEngine(
+public class KtorEngine(
     private val engine: KtorHttpClientEngine
 ) : HttpClientEngineBase("ktor") {
 
@@ -51,9 +51,9 @@ class KtorEngine(
             "use KtorEngine to wrap it. This constructor will be removed in a future release before GA.",
         level = DeprecationLevel.ERROR
     )
-    constructor(config: HttpClientEngineConfig = HttpClientEngineConfig.Default) : this(DeprecationEngine)
+    public constructor(config: HttpClientEngineConfig = HttpClientEngineConfig.Default) : this(DeprecationEngine)
 
-    val client: HttpClient = HttpClient(engine) {
+    public val client: HttpClient = HttpClient(engine) {
         // do not throw exceptions if status code < 300, error handling is expected by generated clients
         expectSuccess = false
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -21,7 +21,7 @@ import kotlin.time.toJavaDuration
 /**
  * [aws.smithy.kotlin.runtime.http.engine.HttpClientEngine] based on OkHttp.
  */
-class OkHttpEngine(
+public class OkHttpEngine(
     private val config: OkHttpEngineConfig
 ) : HttpClientEngineBase("OkHttp") {
     public constructor() : this(OkHttpEngineConfig.Default)

--- a/runtime/protocol/http-client-engines/test-suite/common/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/src/aws/smithy/kotlin/runtime/http/test/util/AbstractEngineTest.kt
@@ -25,7 +25,7 @@ private val TEST_SERVER = Url.parse("http://127.0.0.1:8082")
 /**
  * Abstract base class that all engine test suite test classes should inherit from.
  */
-abstract class AbstractEngineTest {
+public abstract class AbstractEngineTest {
 
     /**
      * Build a test that will run against each engine in the test suite.
@@ -33,7 +33,7 @@ abstract class AbstractEngineTest {
      * Concrete implementations for each KMP target are responsible for loading the engines
      * supported by that platform and executing the test
      */
-    fun testEngines(skipEngines: Set<String> = emptySet(), block: EngineTestBuilder.() -> Unit) {
+    public fun testEngines(skipEngines: Set<String> = emptySet(), block: EngineTestBuilder.() -> Unit) {
         val builder = EngineTestBuilder().apply(block)
         engineFactories()
             .filter { it.name !in skipEngines }
@@ -59,40 +59,41 @@ internal expect fun engineFactories(): List<TestEngineFactory>
  * @param coroutineId unique ID for current coroutine/job (concurrency > 1)
  * @param attempt the current attempt number when repeat > 1
  */
-data class TestEnvironment(val testServer: Url, val coroutineId: Int, val attempt: Int)
+public data class TestEnvironment(public val testServer: Url, public val coroutineId: Int, public val attempt: Int)
 
 /**
  * Configure the test
  */
-class EngineTestBuilder {
+public class EngineTestBuilder {
     /**
      * Lambda function invoked to configure the [HttpClientEngineConfig] to use for the test. If not specified
      * [HttpClientEngineConfig.Default] is used
      */
-    var engineConfig: HttpClientEngineConfig.Builder.() -> Unit = {}
+    public var engineConfig: HttpClientEngineConfig.Builder.() -> Unit = {}
 
     /**
      * Lambda function that is invoked with the current test environment and an [SdkHttpClient]
      * configured with an engine loaded by [AbstractEngineTest]. Invoke calls against test routes and make
      * assertions here. This will potentially be invoked multiple times (once for each engine supported by a platform).
      */
-    var test: (suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) = { _, _ -> error("engine test not configured") }
+    public var test: (suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) =
+        { _, _ -> error("engine test not configured") }
 
     /**
      * Number of times to repeat [test]
      */
-    var repeat: Int = 1
+    public var repeat: Int = 1
 
     /**
      * The number of coroutines to launch. Each coroutine will invoke [test]
      */
-    var concurrency: Int = 1
+    public var concurrency: Int = 1
 }
 
 /**
  * Shared entry point usable by implementations of [AbstractEngineTest.testEngines]
  */
-fun testWithClient(
+public fun testWithClient(
     client: SdkHttpClient,
     timeout: Duration = 60.seconds,
     builder: EngineTestBuilder
@@ -123,16 +124,16 @@ private suspend fun runConcurrently(level: Int, block: suspend (Int) -> Unit) {
     }
 }
 
-fun EngineTestBuilder.test(block: suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) {
+public fun EngineTestBuilder.test(block: suspend (env: TestEnvironment, client: SdkHttpClient) -> Unit) {
     test = block
 }
 
-fun HttpRequestBuilder.testSetup(env: TestEnvironment) {
+public fun HttpRequestBuilder.testSetup(env: TestEnvironment) {
     url(env.testServer)
     headers.append("Host", "${env.testServer.host}:${env.testServer.port}")
 }
 
-fun EngineTestBuilder.engineConfig(block: HttpClientEngineConfig.Builder.() -> Unit) {
+public fun EngineTestBuilder.engineConfig(block: HttpClientEngineConfig.Builder.() -> Unit) {
     engineConfig = block
 }
 

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.json.*
  * @param wrapped The "real" engine to wrap and record requests and responses from
  */
 @InternalApi
-class RecordingEngine(private val wrapped: HttpClientEngine) : HttpClientEngine by wrapped {
+public class RecordingEngine(private val wrapped: HttpClientEngine) : HttpClientEngine by wrapped {
     private val captured = mutableListOf<HttpCall>()
 
     private suspend fun copyHttpBody(name: String, body: HttpBody): HttpBody = when (body) {
@@ -103,7 +103,7 @@ class RecordingEngine(private val wrapped: HttpClientEngine) : HttpClientEngine 
         put("response", response.toJson())
     }
 
-    fun toJson(): String {
+    public fun toJson(): String {
         val arr = buildJsonArray {
             captured.forEach {
                 add(it.toJson())

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
@@ -25,12 +25,12 @@ import kotlin.test.assertTrue
  * @param expected the expected request. If null no assertions are made on the request
  * @param respondWith the response to return for this request. If null it defaults to an empty 200-OK response
  */
-data class MockRoundTrip(val expected: HttpRequest?, val respondWith: HttpResponse? = null)
+public data class MockRoundTrip(public val expected: HttpRequest?, public val respondWith: HttpResponse? = null)
 
 /**
  * Actual and expected [HttpRequest] pair
  */
-data class CallAssertion(val expected: HttpRequest?, val actual: HttpRequest) {
+public data class CallAssertion(public val expected: HttpRequest?, public val actual: HttpRequest) {
     /**
      * Assert that all of the components set on [expected] are also the same on [actual]. The actual request
      * may have additional headers, only the ones set in [expected] are compared.
@@ -61,12 +61,14 @@ data class CallAssertion(val expected: HttpRequest?, val actual: HttpRequest) {
  * NOTE: This engine is only capable of modeling request/response pairs. More complicated interactions such as duplex
  * streaming are not implemented.
  */
-class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) : HttpClientEngineBase("TestConnection") {
+public class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) :
+    HttpClientEngineBase("TestConnection") {
+
     // expected is mutated in-flight, store original size
     private val iter = expected.iterator()
     private var calls = mutableListOf<CallAssertion>()
 
-    companion object {
+    public companion object {
         /**
          * Construct a [TestConnection] from a JSON payload. The payload should be an array of request-response object
          * pairs.
@@ -110,7 +112,7 @@ class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) : 
          *
          * ```
          */
-        fun fromJson(payload: String): TestConnection = parseHttpTraffic(payload)
+        public fun fromJson(payload: String): TestConnection = parseHttpTraffic(payload)
     }
 
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
@@ -126,12 +128,12 @@ class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) : 
     /**
      * Get the list of captured HTTP requests so far
      */
-    fun requests(): List<CallAssertion> = calls
+    public fun requests(): List<CallAssertion> = calls
 
     /**
      * Assert that each captured request matches the expected
      */
-    suspend fun assertRequests() {
+    public suspend fun assertRequests() {
         assertEquals(expected.size, calls.size)
         calls.forEachIndexed { idx, captured ->
             captured.assertRequest(idx)
@@ -142,25 +144,25 @@ class TestConnection(private val expected: List<MockRoundTrip> = emptyList()) : 
 /**
  * DSL builder for [TestConnection]
  */
-class HttpTestConnectionBuilder {
-    val requests = mutableListOf<MockRoundTrip>()
+public class HttpTestConnectionBuilder {
+    public val requests: MutableList<MockRoundTrip> = mutableListOf<MockRoundTrip>()
 
-    class HttpRequestResponsePairBuilder {
+    public class HttpRequestResponsePairBuilder {
         internal val requestBuilder = HttpRequestBuilder()
-        var response: HttpResponse? = null
-        fun request(block: HttpRequestBuilder.() -> Unit) = requestBuilder.apply(block)
+        public var response: HttpResponse? = null
+        public fun request(block: HttpRequestBuilder.() -> Unit): HttpRequestBuilder = requestBuilder.apply(block)
     }
 
-    fun expect(block: HttpRequestResponsePairBuilder.() -> Unit) {
+    public fun expect(block: HttpRequestResponsePairBuilder.() -> Unit) {
         val builder = HttpRequestResponsePairBuilder().apply(block)
         requests.add(MockRoundTrip(builder.requestBuilder.build(), builder.response))
     }
 
-    fun expect(request: HttpRequest, response: HttpResponse? = null) {
+    public fun expect(request: HttpRequest, response: HttpResponse? = null) {
         requests.add(MockRoundTrip(request, response))
     }
 
-    fun expect(response: HttpResponse? = null) {
+    public fun expect(response: HttpResponse? = null) {
         requests.add(MockRoundTrip(null, response))
     }
 }
@@ -181,7 +183,7 @@ class HttpTestConnectionBuilder {
  * }
  * ```
  */
-fun buildTestConnection(block: HttpTestConnectionBuilder.() -> Unit): TestConnection {
+public fun buildTestConnection(block: HttpTestConnectionBuilder.() -> Unit): TestConnection {
     val builder = HttpTestConnectionBuilder().apply(block)
     return TestConnection(builder.requests)
 }

--- a/runtime/protocol/http-test/jvm/src/aws/smithy/kotlin/runtime/httptest/TestWithLocalServer.kt
+++ b/runtime/protocol/http-test/jvm/src/aws/smithy/kotlin/runtime/httptest/TestWithLocalServer.kt
@@ -28,7 +28,7 @@ public abstract class TestWithLocalServer {
     private val logger = Logger.getLogger<TestWithLocalServer>()
 
     @BeforeTest
-    public fun startServer() = runBlocking {
+    public fun startServer(): Unit = runBlocking {
         withTimeout(5.seconds) {
             var attempt = 0
 

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Headers.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Headers.kt
@@ -10,15 +10,15 @@ import aws.smithy.kotlin.runtime.http.util.StringValuesMapImpl
 /**
  * Immutable mapping of case insensitive HTTP header names to list of [String] values.
  */
-interface Headers : StringValuesMap {
-    companion object {
-        operator fun invoke(block: HeadersBuilder.() -> Unit): Headers = HeadersBuilder()
+public interface Headers : StringValuesMap {
+    public companion object {
+        public operator fun invoke(block: HeadersBuilder.() -> Unit): Headers = HeadersBuilder()
             .apply(block).build()
 
         /**
          * Empty [Headers] instance
          */
-        val Empty: Headers = EmptyHeaders
+        public val Empty: Headers = EmptyHeaders
     }
 }
 
@@ -34,7 +34,7 @@ private object EmptyHeaders : Headers {
 /**
  * Build an immutable HTTP header map
  */
-class HeadersBuilder : StringValuesMapBuilder(true, 8), CanDeepCopy<HeadersBuilder> {
+public class HeadersBuilder : StringValuesMapBuilder(true, 8), CanDeepCopy<HeadersBuilder> {
     override fun toString(): String = "HeadersBuilder ${entries()} "
     override fun build(): Headers = HeadersImpl(values)
 

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpMethod.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpMethod.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.http
 /**
  * Represents an HTTP verb
  */
-enum class HttpMethod {
+public enum class HttpMethod {
     GET,
     POST,
     PUT,
@@ -16,13 +16,13 @@ enum class HttpMethod {
     HEAD,
     OPTIONS;
 
-    companion object {
+    public companion object {
         /**
          * Parse from a raw string representation of an HTTP method (e.g. "get")
          * @return [HttpMethod] for the given string
          * @throws IllegalArgumentException if the method is unknown
          */
-        fun parse(method: String): HttpMethod = when (method.uppercase()) {
+        public fun parse(method: String): HttpMethod = when (method.uppercase()) {
             GET.name -> GET
             POST.name -> POST
             PUT.name -> PUT

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpStatusCode.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpStatusCode.kt
@@ -7,18 +7,18 @@ package aws.smithy.kotlin.runtime.http
 /**
  * Container for an HTTP status code
  */
-data class HttpStatusCode(val value: Int, val description: String) {
+public data class HttpStatusCode(public val value: Int, public val description: String) {
     // NOTE: data class over enum here to be forward compatible with potentially unknown status codes
 
-    enum class Category(private val range: IntRange) : Comparable<Category>, ClosedRange<Int> by range {
+    public enum class Category(private val range: IntRange) : Comparable<Category>, ClosedRange<Int> by range {
         INFORMATION(IntRange(100, 199)),
         SUCCESS(IntRange(200, 299)),
         REDIRECT(IntRange(300, 399)),
         CLIENT_ERROR(IntRange(400, 499)),
         SERVER_ERROR(IntRange(500, 599));
 
-        companion object {
-            fun fromCode(value: Int): Category =
+        public companion object {
+            public fun fromCode(value: Int): Category =
                 values().find { value in it.range } ?: error("Invalid HTTP code $value")
         }
     }
@@ -27,96 +27,97 @@ data class HttpStatusCode(val value: Int, val description: String) {
     override fun equals(other: Any?): Boolean = other is HttpStatusCode && other.value == value
     override fun hashCode(): Int = value.hashCode()
 
-    companion object {
+    public companion object {
         // If you add additional codes update the mapping
 
         // 1xx Informational
-        val Continue = HttpStatusCode(100, "Continue")
-        val SwitchingProtocols = HttpStatusCode(101, "Switching Protocols")
-        val Processing = HttpStatusCode(102, "Processing")
+        public val Continue: HttpStatusCode = HttpStatusCode(100, "Continue")
+        public val SwitchingProtocols: HttpStatusCode = HttpStatusCode(101, "Switching Protocols")
+        public val Processing: HttpStatusCode = HttpStatusCode(102, "Processing")
 
         // 2xx Success
-        val OK = HttpStatusCode(200, "OK")
-        val Created = HttpStatusCode(201, "Created")
-        val Accepted = HttpStatusCode(202, "Accepted")
-        val NonAuthoritativeInformation = HttpStatusCode(203, "Non-Authoritative Information")
-        val NoContent = HttpStatusCode(204, "No Content")
-        val ResetContent = HttpStatusCode(205, "Reset Content")
-        val PartialContent = HttpStatusCode(206, "Partial Content")
-        val MultiStatus = HttpStatusCode(207, "Multi-Status")
+        public val OK: HttpStatusCode = HttpStatusCode(200, "OK")
+        public val Created: HttpStatusCode = HttpStatusCode(201, "Created")
+        public val Accepted: HttpStatusCode = HttpStatusCode(202, "Accepted")
+        public val NonAuthoritativeInformation: HttpStatusCode = HttpStatusCode(203, "Non-Authoritative Information")
+        public val NoContent: HttpStatusCode = HttpStatusCode(204, "No Content")
+        public val ResetContent: HttpStatusCode = HttpStatusCode(205, "Reset Content")
+        public val PartialContent: HttpStatusCode = HttpStatusCode(206, "Partial Content")
+        public val MultiStatus: HttpStatusCode = HttpStatusCode(207, "Multi-Status")
 
         // 3xx Redirection
-        val MultipleChoices = HttpStatusCode(300, "Multiple Choices")
-        val MovedPermanently = HttpStatusCode(301, "Moved Permanently")
-        val Found = HttpStatusCode(302, "Found")
-        val SeeOther = HttpStatusCode(303, "See Other")
-        val NotModified = HttpStatusCode(304, "Not Modified")
-        val UseProxy = HttpStatusCode(305, "Use Proxy")
-        val TemporaryRedirect = HttpStatusCode(307, "Temporary Redirect")
-        val PermanentRedirect = HttpStatusCode(308, "Permanent Redirect")
+        public val MultipleChoices: HttpStatusCode = HttpStatusCode(300, "Multiple Choices")
+        public val MovedPermanently: HttpStatusCode = HttpStatusCode(301, "Moved Permanently")
+        public val Found: HttpStatusCode = HttpStatusCode(302, "Found")
+        public val SeeOther: HttpStatusCode = HttpStatusCode(303, "See Other")
+        public val NotModified: HttpStatusCode = HttpStatusCode(304, "Not Modified")
+        public val UseProxy: HttpStatusCode = HttpStatusCode(305, "Use Proxy")
+        public val TemporaryRedirect: HttpStatusCode = HttpStatusCode(307, "Temporary Redirect")
+        public val PermanentRedirect: HttpStatusCode = HttpStatusCode(308, "Permanent Redirect")
 
         // 4xx Client Error
-        val BadRequest = HttpStatusCode(400, "Bad Request")
-        val Unauthorized = HttpStatusCode(401, "Unauthorized")
-        val PaymentRequired = HttpStatusCode(402, "Payment Required")
-        val Forbidden = HttpStatusCode(403, "Forbidden")
-        val NotFound = HttpStatusCode(404, "Not Found")
-        val MethodNotAllowed = HttpStatusCode(405, "Method Not Allowed")
-        val NotAcceptable = HttpStatusCode(406, "Not Acceptable")
-        val ProxyAuthenticationRequired = HttpStatusCode(407, "Proxy Authentication Required")
-        val RequestTimeout = HttpStatusCode(408, "Request Timeout")
-        val Conflict = HttpStatusCode(409, "Conflict")
-        val Gone = HttpStatusCode(410, "Gone")
-        val LengthRequired = HttpStatusCode(411, "Length Required")
-        val PreconditionFailed = HttpStatusCode(412, "Precondition Failed")
-        val PayloadTooLarge = HttpStatusCode(413, "Payload Too Large")
-        val RequestURITooLong = HttpStatusCode(414, "Request-URI Too Long")
-        val UnsupportedMediaType = HttpStatusCode(415, "Unsupported Media Type")
-        val RequestedRangeNotSatisfiable = HttpStatusCode(416, "Requested Range Not Satisfiable")
-        val ExpectationFailed = HttpStatusCode(417, "Expectation Failed")
-        val UnprocessableEntity = HttpStatusCode(422, "Unprocessable Entity")
-        val Locked = HttpStatusCode(423, "Locked")
-        val FailedDependency = HttpStatusCode(424, "Failed Dependency")
-        val TooEarly = HttpStatusCode(425, "Too Early")
-        val UpgradeRequired = HttpStatusCode(426, "Upgrade Required")
-        val PreconditionRequired = HttpStatusCode(428, "Precondition Required")
-        val TooManyRequests = HttpStatusCode(429, "Too Many Requests")
-        val RequestHeaderFieldTooLarge = HttpStatusCode(431, "Request Header Fields Too Large")
-        val UnavailableForLegalReason = HttpStatusCode(451, "Unavailable For Legal Reason")
+        public val BadRequest: HttpStatusCode = HttpStatusCode(400, "Bad Request")
+        public val Unauthorized: HttpStatusCode = HttpStatusCode(401, "Unauthorized")
+        public val PaymentRequired: HttpStatusCode = HttpStatusCode(402, "Payment Required")
+        public val Forbidden: HttpStatusCode = HttpStatusCode(403, "Forbidden")
+        public val NotFound: HttpStatusCode = HttpStatusCode(404, "Not Found")
+        public val MethodNotAllowed: HttpStatusCode = HttpStatusCode(405, "Method Not Allowed")
+        public val NotAcceptable: HttpStatusCode = HttpStatusCode(406, "Not Acceptable")
+        public val ProxyAuthenticationRequired: HttpStatusCode = HttpStatusCode(407, "Proxy Authentication Required")
+        public val RequestTimeout: HttpStatusCode = HttpStatusCode(408, "Request Timeout")
+        public val Conflict: HttpStatusCode = HttpStatusCode(409, "Conflict")
+        public val Gone: HttpStatusCode = HttpStatusCode(410, "Gone")
+        public val LengthRequired: HttpStatusCode = HttpStatusCode(411, "Length Required")
+        public val PreconditionFailed: HttpStatusCode = HttpStatusCode(412, "Precondition Failed")
+        public val PayloadTooLarge: HttpStatusCode = HttpStatusCode(413, "Payload Too Large")
+        public val RequestURITooLong: HttpStatusCode = HttpStatusCode(414, "Request-URI Too Long")
+        public val UnsupportedMediaType: HttpStatusCode = HttpStatusCode(415, "Unsupported Media Type")
+        public val RequestedRangeNotSatisfiable: HttpStatusCode = HttpStatusCode(416, "Requested Range Not Satisfiable")
+        public val ExpectationFailed: HttpStatusCode = HttpStatusCode(417, "Expectation Failed")
+        public val UnprocessableEntity: HttpStatusCode = HttpStatusCode(422, "Unprocessable Entity")
+        public val Locked: HttpStatusCode = HttpStatusCode(423, "Locked")
+        public val FailedDependency: HttpStatusCode = HttpStatusCode(424, "Failed Dependency")
+        public val TooEarly: HttpStatusCode = HttpStatusCode(425, "Too Early")
+        public val UpgradeRequired: HttpStatusCode = HttpStatusCode(426, "Upgrade Required")
+        public val PreconditionRequired: HttpStatusCode = HttpStatusCode(428, "Precondition Required")
+        public val TooManyRequests: HttpStatusCode = HttpStatusCode(429, "Too Many Requests")
+        public val RequestHeaderFieldTooLarge: HttpStatusCode = HttpStatusCode(431, "Request Header Fields Too Large")
+        public val UnavailableForLegalReason: HttpStatusCode = HttpStatusCode(451, "Unavailable For Legal Reason")
 
         // 5xx Server Error
-        val InternalServerError = HttpStatusCode(500, "Internal Server Error")
-        val NotImplemented = HttpStatusCode(501, "Not Implemented")
-        val BadGateway = HttpStatusCode(502, "Bad Gateway")
-        val ServiceUnavailable = HttpStatusCode(503, "Service Unavailable")
-        val GatewayTimeout = HttpStatusCode(504, "Gateway Timeout")
-        val VersionNotSupported = HttpStatusCode(505, "HTTP Version Not Supported")
-        val VariantAlsoNegotiates = HttpStatusCode(506, "Variant Also Negotiates")
-        val InsufficientStorage = HttpStatusCode(507, "Insufficient Storage")
-        val LoopDetected = HttpStatusCode(508, "Loop Detected")
-        val NotExtended = HttpStatusCode(510, "Not Extended")
-        val NetworkAuthenticationRequired = HttpStatusCode(511, "Network Authentication Required")
+        public val InternalServerError: HttpStatusCode = HttpStatusCode(500, "Internal Server Error")
+        public val NotImplemented: HttpStatusCode = HttpStatusCode(501, "Not Implemented")
+        public val BadGateway: HttpStatusCode = HttpStatusCode(502, "Bad Gateway")
+        public val ServiceUnavailable: HttpStatusCode = HttpStatusCode(503, "Service Unavailable")
+        public val GatewayTimeout: HttpStatusCode = HttpStatusCode(504, "Gateway Timeout")
+        public val VersionNotSupported: HttpStatusCode = HttpStatusCode(505, "HTTP Version Not Supported")
+        public val VariantAlsoNegotiates: HttpStatusCode = HttpStatusCode(506, "Variant Also Negotiates")
+        public val InsufficientStorage: HttpStatusCode = HttpStatusCode(507, "Insufficient Storage")
+        public val LoopDetected: HttpStatusCode = HttpStatusCode(508, "Loop Detected")
+        public val NotExtended: HttpStatusCode = HttpStatusCode(510, "Not Extended")
+        public val NetworkAuthenticationRequired: HttpStatusCode = HttpStatusCode(511, "Network Authentication Required")
 
         private val byValue: Map<Int, HttpStatusCode> = statusCodeMap()
 
         /**
          * Convert a raw status code integer to an [HttpStatusCode] instance
          */
-        fun fromValue(status: Int): HttpStatusCode = byValue[status] ?: HttpStatusCode(status, "Unknown HttpStatusCode")
+        public fun fromValue(status: Int): HttpStatusCode =
+            byValue[status] ?: HttpStatusCode(status, "Unknown HttpStatusCode")
     }
 }
 
 /**
  * Check if the given status code is a success code (HTTP codes 200 to 299 are considered successful)
  */
-fun HttpStatusCode.isSuccess(): Boolean = value in HttpStatusCode.Category.SUCCESS
+public fun HttpStatusCode.isSuccess(): Boolean = value in HttpStatusCode.Category.SUCCESS
 
 /**
  * Check if the given status code is an informational code (HTTP codes 100 to 199 are considered informational)
  */
-fun HttpStatusCode.isInformational(): Boolean = value in HttpStatusCode.Category.INFORMATION
+public fun HttpStatusCode.isInformational(): Boolean = value in HttpStatusCode.Category.INFORMATION
 
-fun HttpStatusCode.category(): HttpStatusCode.Category = HttpStatusCode.Category.fromCode(this.value)
+public fun HttpStatusCode.category(): HttpStatusCode.Category = HttpStatusCode.Category.fromCode(this.value)
 
 private fun statusCodeMap(): Map<Int, HttpStatusCode> = mapOf(
     // 1xx Informational

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Protocol.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Protocol.kt
@@ -16,22 +16,22 @@ public data class Protocol(val protocolName: String, val defaultPort: Int) {
         /**
          * HTTPS over port 443
          */
-        public val HTTPS = Protocol("https", 443)
+        public val HTTPS: Protocol = Protocol("https", 443)
 
         /**
          * HTTP over port 80
          */
-        public val HTTP = Protocol("http", 80)
+        public val HTTP: Protocol = Protocol("http", 80)
 
         /**
          * WebSocket over port 80
          */
-        public val WS = Protocol("ws", 80)
+        public val WS: Protocol = Protocol("ws", 80)
 
         /**
          * Secure WebSocket over port 443
          */
-        public val WSS = Protocol("wss", 443)
+        public val WSS: Protocol = Protocol("wss", 443)
 
         /**
          * Protocols by names map

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/QueryParameters.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/QueryParameters.kt
@@ -10,15 +10,15 @@ import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent
 /**
  * Container for HTTP query parameters
  */
-interface QueryParameters : StringValuesMap {
-    companion object {
-        operator fun invoke(block: QueryParametersBuilder.() -> Unit): QueryParameters = QueryParametersBuilder()
+public interface QueryParameters : StringValuesMap {
+    public companion object {
+        public operator fun invoke(block: QueryParametersBuilder.() -> Unit): QueryParameters = QueryParametersBuilder()
             .apply(block).build()
 
         /**
          * Empty [QueryParameters] instance
          */
-        val Empty: QueryParameters = EmptyQueryParameters
+        public val Empty: QueryParameters = EmptyQueryParameters
     }
 }
 
@@ -31,7 +31,7 @@ private object EmptyQueryParameters : QueryParameters {
     override fun isEmpty(): Boolean = true
 }
 
-class QueryParametersBuilder : StringValuesMapBuilder(true, 8), CanDeepCopy<QueryParametersBuilder> {
+public class QueryParametersBuilder : StringValuesMapBuilder(true, 8), CanDeepCopy<QueryParametersBuilder> {
     override fun toString(): String = "QueryParametersBuilder ${entries()} "
     override fun build(): QueryParameters = QueryParametersImpl(values)
 
@@ -41,7 +41,7 @@ class QueryParametersBuilder : StringValuesMapBuilder(true, 8), CanDeepCopy<Quer
     }
 }
 
-fun Map<String, String>.toQueryParameters(): QueryParameters {
+public fun Map<String, String>.toQueryParameters(): QueryParameters {
     val builder = QueryParametersBuilder()
     entries.forEach { entry -> builder.append(entry.key, entry.value) }
     return builder.build()
@@ -54,14 +54,14 @@ private class QueryParametersImpl(values: Map<String, List<String>> = emptyMap()
 /**
  * Return the encoded query parameter string (without leading '?')
  */
-fun QueryParameters.urlEncode(): String = buildString {
+public fun QueryParameters.urlEncode(): String = buildString {
     urlEncodeTo(this)
 }
 
 /**
  * URL encode the query parameters components to the appendable output (without the leading '?')
  */
-fun QueryParameters.urlEncodeTo(out: Appendable) = urlEncodeQueryParametersTo(entries(), out)
+public fun QueryParameters.urlEncodeTo(out: Appendable): Unit = urlEncodeQueryParametersTo(entries(), out)
 
 internal fun urlEncodeQueryParametersTo(entries: Set<Map.Entry<String, List<String>>>, out: Appendable, encodeFn: (String) -> String = { it.urlEncodeComponent() }) {
     entries.sortedBy { it.key }.forEachIndexed { i, entry ->

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/SdkHttpClient.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/SdkHttpClient.kt
@@ -19,13 +19,13 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlin.coroutines.coroutineContext
 
-typealias HttpHandler = Handler<SdkHttpRequest, HttpCall>
+public typealias HttpHandler = Handler<SdkHttpRequest, HttpCall>
 
 /**
  * Create an [SdkHttpClient] with the given engine, and optionally configure it
  * This will **not** manage the engine lifetime, the caller is expected to close it.
  */
-fun sdkHttpClient(
+public fun sdkHttpClient(
     engine: HttpClientEngine,
     manageEngine: Boolean = false,
 ): SdkHttpClient = SdkHttpClient(engine, manageEngine)
@@ -35,14 +35,14 @@ fun sdkHttpClient(
  *
  * **NOTE**: This is not a general purpose HTTP client. It is meant for generated SDK use.
  */
-class SdkHttpClient(
-    val engine: HttpClientEngine,
+public class SdkHttpClient(
+    public val engine: HttpClientEngine,
     private val manageEngine: Boolean = false
 ) : HttpHandler, Closeable {
     private val closed = atomic(false)
 
-    suspend fun call(request: HttpRequest): HttpCall = executeWithCallContext(ExecutionContext(), request)
-    suspend fun call(request: HttpRequestBuilder): HttpCall = call(request.build())
+    public suspend fun call(request: HttpRequest): HttpCall = executeWithCallContext(ExecutionContext(), request)
+    public suspend fun call(request: HttpRequestBuilder): HttpCall = call(request.build())
     override suspend fun call(request: SdkHttpRequest): HttpCall = executeWithCallContext(request.context, request.subject.build())
 
     // FIXME - can we relocate to engine?

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Url.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/Url.kt
@@ -21,16 +21,16 @@ import aws.smithy.kotlin.runtime.util.text.encodeUrlPath
  * @property forceQuery keep trailing question mark regardless of whether there are any query parameters
  * @property encodeParameters configures if parameter values are encoded (default) or left as-is.
  */
-data class Url(
-    val scheme: Protocol,
-    val host: String,
-    val port: Int = scheme.defaultPort,
-    val path: String = "",
-    val parameters: QueryParameters = QueryParameters.Empty,
-    val fragment: String? = null,
-    val userInfo: UserInfo? = null,
-    val forceQuery: Boolean = false,
-    val encodeParameters: Boolean = true
+public data class Url(
+    public val scheme: Protocol,
+    public val host: String,
+    public val port: Int = scheme.defaultPort,
+    public val path: String = "",
+    public val parameters: QueryParameters = QueryParameters.Empty,
+    public val fragment: String? = null,
+    public val userInfo: UserInfo? = null,
+    public val forceQuery: Boolean = false,
+    public val encodeParameters: Boolean = true
 ) {
     init {
         require(port in 1..65536) { "port must be in between 1 and 65536" }
@@ -101,26 +101,26 @@ private fun encodePath(
 /**
  * URL username and password
  */
-data class UserInfo(val username: String, val password: String)
+public data class UserInfo(public val username: String, public val password: String)
 
 /**
  * Construct a URL by it's individual components
  */
-class UrlBuilder : CanDeepCopy<UrlBuilder> {
-    var scheme = Protocol.HTTPS
-    var host: String = ""
-    var port: Int? = null
-    var path: String = ""
-    var parameters: QueryParametersBuilder = QueryParametersBuilder()
-    var fragment: String? = null
-    var userInfo: UserInfo? = null
-    var forceQuery: Boolean = false
+public class UrlBuilder : CanDeepCopy<UrlBuilder> {
+    public var scheme: Protocol = Protocol.HTTPS
+    public var host: String = ""
+    public var port: Int? = null
+    public var path: String = ""
+    public var parameters: QueryParametersBuilder = QueryParametersBuilder()
+    public var fragment: String? = null
+    public var userInfo: UserInfo? = null
+    public var forceQuery: Boolean = false
 
-    companion object {
-        operator fun invoke(block: UrlBuilder.() -> Unit): Url = UrlBuilder().apply(block).build()
+    public companion object {
+        public operator fun invoke(block: UrlBuilder.() -> Unit): Url = UrlBuilder().apply(block).build()
     }
 
-    fun build(): Url = Url(
+    public fun build(): Url = Url(
         scheme,
         host,
         port ?: scheme.defaultPort,
@@ -149,12 +149,14 @@ class UrlBuilder : CanDeepCopy<UrlBuilder> {
         "UrlBuilder(scheme=$scheme, host='$host', port=$port, path='$path', parameters=$parameters, fragment=$fragment, userInfo=$userInfo, forceQuery=$forceQuery)"
 }
 
-fun UrlBuilder.parameters(block: QueryParametersBuilder.() -> Unit) = parameters.apply(block)
+public fun UrlBuilder.parameters(block: QueryParametersBuilder.() -> Unit) {
+    parameters.apply(block)
+}
 
 // TODO - when we get to other platforms we will likely just roll our own - for now we are going to punt and use JVM
 // capabilities to bootstrap this
 internal expect fun platformUrlParse(url: String): Url
 
 @InternalApi
-val UrlBuilder.encodedPath: String
+public val UrlBuilder.encodedPath: String
     get() = encodePath(path, parameters.entries(), fragment, forceQuery)

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/config/HttpClientConfig.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/config/HttpClientConfig.kt
@@ -10,9 +10,9 @@ import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 /**
  * The user-accessible configuration properties for the SDKs internal HTTP client facility.
  */
-interface HttpClientConfig {
+public interface HttpClientConfig {
     /**
      * Allows for overriding the default HTTP client engine.
      */
-    val httpClientEngine: HttpClientEngine?
+    public val httpClientEngine: HttpClientEngine?
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/content/ByteArrayContent.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/content/ByteArrayContent.kt
@@ -9,7 +9,7 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 /**
  * Implementation of [HttpBody.Bytes] backed by a byte array
  */
-class ByteArrayContent(private val bytes: ByteArray) : HttpBody.Bytes() {
+public class ByteArrayContent(private val bytes: ByteArray) : HttpBody.Bytes() {
     override val contentLength: Long = bytes.size.toLong()
     override fun bytes(): ByteArray = bytes
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/Endpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/Endpoint.kt
@@ -27,9 +27,9 @@ import aws.smithy.kotlin.runtime.http.Url
  * is expected to be mutable and the client cannot modify the endpoint correctly, the operation
  * will likely fail.
  */
-data class Endpoint(
-    val uri: Url,
-    val isHostnameImmutable: Boolean = false,
+public data class Endpoint(
+    public val uri: Url,
+    public val isHostnameImmutable: Boolean = false,
 ) {
-    constructor(uri: String) : this(Url.parse(uri))
+    public constructor(uri: String) : this(Url.parse(uri))
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointResolver.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointResolver.kt
@@ -8,7 +8,7 @@ package aws.smithy.kotlin.runtime.http.endpoints
 /**
  * Resolves endpoints for a given service client
  */
-fun interface EndpointResolver {
+public fun interface EndpointResolver {
     /**
      * Resolve the endpoint to make requests to
      * @return an [Endpoint] that can be used to connect to the service

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
@@ -68,7 +68,7 @@ private fun attachToOuterJob(outerContext: CoroutineContext, requestJob: Job) {
  * ```
  */
 @InternalApi
-suspend fun callContext(): CoroutineContext = coroutineContext[SdkRequestContextElement]!!.callContext
+public suspend fun callContext(): CoroutineContext = coroutineContext[SdkRequestContextElement]!!.callContext
 
 /**
  * Stores the request context

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngine.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngine.kt
@@ -18,12 +18,12 @@ import kotlin.coroutines.CoroutineContext
  * Functionality a real HTTP client must provide.
  * NOTE: Implementations SHOULD inherit from [HttpClientEngineBase] rather than implementing this interface directly.
  */
-interface HttpClientEngine : Closeable, CoroutineScope {
+public interface HttpClientEngine : Closeable, CoroutineScope {
     /**
      * Execute a single HTTP request and return the response.
      * Consumers *MUST* call `HttpCall.complete()` when finished processing the response
      */
-    suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall
+    public suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall
 
     /**
      * Shutdown and cleanup any resources
@@ -62,4 +62,4 @@ public abstract class HttpClientEngineBase(engineName: String) : HttpClientEngin
 /**
  * Indicates an [HttpClientEngine] is closed already and no further requests should be initiated.
  */
-class HttpClientEngineClosedException(override val cause: Throwable? = null) : ClientException("HttpClientEngine already closed")
+public class HttpClientEngineClosedException(override val cause: Throwable? = null) : ClientException("HttpClientEngine already closed")

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
@@ -16,95 +16,96 @@ import kotlin.time.Duration.Companion.seconds
  * NOTE: Not all engines will support every option! Engines *SHOULD* log a warning when given a configuration
  * option they don't understand/support
  */
-open class HttpClientEngineConfig constructor(builder: Builder) {
-    constructor() : this(Builder())
+public open class HttpClientEngineConfig constructor(builder: Builder) {
+    public constructor() : this(Builder())
 
-    companion object {
-        operator fun invoke(block: Builder.() -> Unit): HttpClientEngineConfig = HttpClientEngineConfig(Builder().apply(block))
+    public companion object {
+        public operator fun invoke(block: Builder.() -> Unit): HttpClientEngineConfig =
+            HttpClientEngineConfig(Builder().apply(block))
 
         /**
          * Default client engine config
          */
-        val Default: HttpClientEngineConfig = HttpClientEngineConfig(Builder())
+        public val Default: HttpClientEngineConfig = HttpClientEngineConfig(Builder())
     }
 
     /**
      * Timeout for each read to an underlying socket
      */
-    val socketReadTimeout: Duration = builder.socketReadTimeout
+    public val socketReadTimeout: Duration = builder.socketReadTimeout
 
     /**
      * Timeout for each write to an underlying socket
      */
-    val socketWriteTimeout: Duration = builder.socketWriteTimeout
+    public val socketWriteTimeout: Duration = builder.socketWriteTimeout
 
     /**
      * Maximum number of open connections
      */
-    val maxConnections: UInt = builder.maxConnections
+    public val maxConnections: UInt = builder.maxConnections
 
     /**
      * The amount of time to wait for a connection to be established
      */
-    val connectTimeout: Duration = builder.connectTimeout
+    public val connectTimeout: Duration = builder.connectTimeout
 
     /**
      * The amount of time to wait for an already-established connection from a connection pool
      */
-    val connectionAcquireTimeout: Duration = builder.connectionAcquireTimeout
+    public val connectionAcquireTimeout: Duration = builder.connectionAcquireTimeout
 
     /**
      * The amount of time before an idle connection should be reaped from a connection pool. Zero indicates that
      * idle connections should never be reaped.
      */
-    val connectionIdleTimeout: Duration = builder.connectionIdleTimeout
+    public val connectionIdleTimeout: Duration = builder.connectionIdleTimeout
 
     /**
      * The ALPN protocol list when a TLS connection starts
      */
-    val alpn: List<AlpnId> = builder.alpn
+    public val alpn: List<AlpnId> = builder.alpn
 
     /**
      * The proxy selection policy
      */
-    val proxySelector: ProxySelector = builder.proxySelector
+    public val proxySelector: ProxySelector = builder.proxySelector
 
-    open class Builder {
+    public open class Builder {
         /**
          * Timeout for each read to an underlying socket
          */
-        var socketReadTimeout: Duration = 30.seconds
+        public var socketReadTimeout: Duration = 30.seconds
 
         /**
          * Timeout for each write to an underlying socket
          */
-        var socketWriteTimeout: Duration = 30.seconds
+        public var socketWriteTimeout: Duration = 30.seconds
 
         /**
          * Maximum number of open connections
          */
-        var maxConnections: UInt = 16u
+        public var maxConnections: UInt = 16u
 
         /**
          * The amount of time to wait for a connection to be established
          */
-        var connectTimeout: Duration = 2.seconds
+        public var connectTimeout: Duration = 2.seconds
 
         /**
          * The amount of time to wait for an already-established connection from a connection pool
          */
-        var connectionAcquireTimeout: Duration = 10.seconds
+        public var connectionAcquireTimeout: Duration = 10.seconds
 
         /**
          * The amount of time before an idle connection should be reaped from a connection pool. Zero indicates that
          * idle connections should never be reaped.
          */
-        var connectionIdleTimeout: Duration = 60.seconds
+        public var connectionIdleTimeout: Duration = 60.seconds
 
         /**
          * Set the ALPN protocol list when a TLS connection starts
          */
-        var alpn: List<AlpnId> = emptyList()
+        public var alpn: List<AlpnId> = emptyList()
 
         /**
          * Set the proxy selection policy to be used.
@@ -129,7 +130,7 @@ open class HttpClientEngineConfig constructor(builder: Builder) {
          * proxySelector = ProxySelector.NoProxy
          * ```
          */
-        var proxySelector: ProxySelector = EnvironmentProxySelector()
+        public var proxySelector: ProxySelector = EnvironmentProxySelector()
     }
 }
 
@@ -137,7 +138,7 @@ open class HttpClientEngineConfig constructor(builder: Builder) {
  * Common ALPN identifiers
  * See the [IANA registry](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids)
  */
-enum class AlpnId(val protocolId: String) {
+public enum class AlpnId(public val protocolId: String) {
     /**
      * HTTP 1.1
      */

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/ProxyConfig.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/ProxyConfig.kt
@@ -10,17 +10,17 @@ import aws.smithy.kotlin.runtime.http.Url
 /**
  * A proxy configuration
  */
-sealed class ProxyConfig {
+public sealed class ProxyConfig {
     /**
      * Represents a direct connection or absence of a proxy. Can be used to disable proxy support inferred from
      * environment for example.
      */
-    object Direct : ProxyConfig()
+    public object Direct : ProxyConfig()
 
     /**
      * HTTP based proxy (with or without user/password auth)
      */
-    data class Http(val url: Url) : ProxyConfig() {
-        constructor(url: String) : this(Url.parse(url))
+    public data class Http(public val url: Url) : ProxyConfig() {
+        public constructor(url: String) : this(Url.parse(url))
     }
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/ProxySelector.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/engine/ProxySelector.kt
@@ -11,16 +11,16 @@ import aws.smithy.kotlin.runtime.http.Url
  * Selects the proxy to use for a given [Url]. Implementations **MUST** be stable and return the
  * same [ProxyConfig] for a given [Url].
  */
-fun interface ProxySelector {
+public fun interface ProxySelector {
     /**
      * Return the proxy configuration to use for [Url]
      */
-    fun select(url: Url): ProxyConfig
+    public fun select(url: Url): ProxyConfig
 
-    companion object {
+    public companion object {
         /**
          * Explicitly disable proxy selection
          */
-        val NoProxy = ProxySelector { ProxyConfig.Direct }
+        public val NoProxy: ProxySelector = ProxySelector { ProxyConfig.Direct }
     }
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponse.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponse.kt
@@ -15,35 +15,35 @@ import aws.smithy.kotlin.runtime.io.Handler
 /**
  * Generic HTTP service exception
  */
-class HttpResponseException : SdkBaseException {
+public class HttpResponseException : SdkBaseException {
 
-    constructor() : super()
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 
     /**
      * The HTTP response status code
      */
-    var statusCode: HttpStatusCode? = null
+    public var statusCode: HttpStatusCode? = null
 
     /**
      * The response headers
      */
-    var headers: Headers? = null
+    public var headers: Headers? = null
 
     /**
      * The response payload, if available
      */
-    var body: ByteArray? = null
+    public var body: ByteArray? = null
 
     /**
      * The original request
      */
-    var request: HttpRequest? = null
+    public var request: HttpRequest? = null
 }
 
 /**
@@ -54,7 +54,7 @@ class HttpResponseException : SdkBaseException {
  * so all we can do is throw a generic exception with the code and let the user figure out what modeled error it was
  * using whatever matching mechanism they want.
  */
-class DefaultValidateResponse : ReceiveMiddleware {
+public class DefaultValidateResponse : ReceiveMiddleware {
 
     override suspend fun <H : Handler<SdkHttpRequest, HttpCall>> handle(request: SdkHttpRequest, next: H): HttpCall {
         val call = next.call(request)

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Md5Checksum.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Md5Checksum.kt
@@ -19,7 +19,7 @@ import aws.smithy.kotlin.runtime.util.encodeBase64String
  *   - https://datatracker.ietf.org/doc/html/rfc1864.html
  */
 @InternalApi
-class Md5Checksum : ModifyRequestMiddleware {
+public class Md5Checksum : ModifyRequestMiddleware {
 
     override suspend fun modifyRequest(req: SdkHttpRequest): SdkHttpRequest {
         val checksum = when (val body = req.subject.body) {

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/MutateHeaders.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/MutateHeaders.kt
@@ -13,7 +13,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * HTTP middleware feature that allows mutation of in-flight request headers
  */
 @InternalApi
-class MutateHeaders(
+public class MutateHeaders(
     override: Map<String, String> = emptyMap(),
     append: Map<String, String> = emptyMap(),
     setMissing: Map<String, String> = emptyMap(),
@@ -31,19 +31,19 @@ class MutateHeaders(
     /**
      * Set a header in the request, overriding any existing key of the same name
      */
-    fun set(name: String, value: String): Unit = overrides.set(name, value)
+    public fun set(name: String, value: String): Unit = overrides.set(name, value)
 
     /**
      * Append a value to headers in the request that may already be set, setting the value
      * if the key doesn't already exist
      */
-    fun append(name: String, value: String): Unit = additional.append(name, value)
+    public fun append(name: String, value: String): Unit = additional.append(name, value)
 
     /**
      * Set a header with the given [name] only if the request does not already have a header
      * set for the same name.
      */
-    fun setIfMissing(name: String, value: String) = conditionallySet.append(name, value)
+    public fun setIfMissing(name: String, value: String): Unit = conditionallySet.append(name, value)
 
     override suspend fun modifyRequest(req: SdkHttpRequest): SdkHttpRequest {
         additional.entries().forEach { (key, values) ->

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -14,7 +14,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  *  Http middleware for resolving the service endpoint.
  */
 @InternalApi
-class ResolveEndpoint(
+public class ResolveEndpoint(
     private val resolver: EndpointResolver
 ) : ModifyRequestMiddleware {
 
@@ -31,7 +31,7 @@ class ResolveEndpoint(
  * Populate the request URL parameters from a resolved endpoint
  */
 @InternalApi
-fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
+public fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
     val hostPrefix = req.context.getOrNull(HttpOperationContext.HostPrefix)
     val hostname = if (hostPrefix != null && !endpoint.isHostnameImmutable) {
         "$hostPrefix${endpoint.uri.host}"

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
@@ -23,7 +23,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * @param policy the [RetryPolicy] used to determine when to retry
  */
 @InternalApi
-open class Retry<O>(
+public open class Retry<O>(
     protected val strategy: RetryStrategy,
     protected val policy: RetryPolicy<Any?>
 ) : MutateMiddleware<O> {

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -19,76 +19,77 @@ import aws.smithy.kotlin.runtime.util.get
  * Common configuration for an SDK (HTTP) operation/call
  */
 @InternalApi
-open class HttpOperationContext {
+public open class HttpOperationContext {
 
-    companion object {
+    public companion object {
         /**
          * The expected HTTP status code of a successful response is stored under this key
          */
-        val ExpectedHttpStatus: AttributeKey<Int> = AttributeKey("ExpectedHttpStatus")
+        public val ExpectedHttpStatus: AttributeKey<Int> = AttributeKey("ExpectedHttpStatus")
 
         /**
          * A prefix to prepend the resolved hostname with.
          * See [endpointTrait](https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#endpoint-trait)
          */
-        val HostPrefix: AttributeKey<String> = AttributeKey("HostPrefix")
+        public val HostPrefix: AttributeKey<String> = AttributeKey("HostPrefix")
 
         /**
          * The HTTP calls made for this operation (this may be > 1 if for example retries are involved)
          */
-        val HttpCallList: AttributeKey<List<HttpCall>> = AttributeKey("HttpCallList")
+        public val HttpCallList: AttributeKey<List<HttpCall>> = AttributeKey("HttpCallList")
 
         /**
          * The per/request logging context.
          */
-        val LoggingContext: AttributeKey<Map<String, Any>> = AttributeKey("LoggingContext")
+        public val LoggingContext: AttributeKey<Map<String, Any>> = AttributeKey("LoggingContext")
 
         /**
          * The unique request ID generated for tracking the request in-flight client side.
          *
          * NOTE: This is guaranteed to exist.
          */
-        val SdkRequestId: AttributeKey<String> = AttributeKey("SdkRequestId")
+        public val SdkRequestId: AttributeKey<String> = AttributeKey("SdkRequestId")
 
         /**
          * Build this operation into an HTTP [ExecutionContext]
          */
-        fun build(block: Builder.() -> Unit): ExecutionContext = Builder().apply(block).build()
+        public fun build(block: Builder.() -> Unit): ExecutionContext = Builder().apply(block).build()
     }
 
     /**
      * Convenience builder for constructing HTTP client operations
      */
-    open class Builder : ClientOptionsBuilder() {
+    public open class Builder : ClientOptionsBuilder() {
 
         /**
          * The service name
          */
-        var service: String? by requiredOption(SdkClientOption.ServiceName)
+        public var service: String? by requiredOption(SdkClientOption.ServiceName)
 
         /**
          * The name of the operation
          */
-        var operationName: String? by requiredOption(SdkClientOption.OperationName)
+        public var operationName: String? by requiredOption(SdkClientOption.OperationName)
 
         /**
          * The expected HTTP status code on success
          */
-        var expectedHttpStatus: Int? by option(ExpectedHttpStatus)
+        public var expectedHttpStatus: Int? by option(ExpectedHttpStatus)
 
         /**
          * (Optional) prefix to prepend to a (resolved) hostname
          */
-        var hostPrefix: String? by option(HostPrefix)
+        public var hostPrefix: String? by option(HostPrefix)
     }
 }
 
 @InternalApi
-fun ExecutionContext.getLogger(name: String): Logger {
+public fun ExecutionContext.getLogger(name: String): Logger {
     val instance = Logger.getLogger(name)
     val logCtx = this[HttpOperationContext.LoggingContext]
     return instance.withContext(logCtx)
 }
 
 @InternalApi
-fun Logger.withContext(context: ExecutionContext): Logger = withContext(context.getOrNull(HttpOperationContext.LoggingContext) ?: emptyMap())
+public fun Logger.withContext(context: ExecutionContext): Logger =
+    withContext(context.getOrNull(HttpOperationContext.LoggingContext) ?: emptyMap())

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpSerde.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/HttpSerde.kt
@@ -14,34 +14,34 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 /**
  * Implemented by types that know how to serialize to the HTTP protocol.
  */
-interface HttpSerialize<T> {
-    suspend fun serialize(context: ExecutionContext, input: T): HttpRequestBuilder
+public interface HttpSerialize<T> {
+    public suspend fun serialize(context: ExecutionContext, input: T): HttpRequestBuilder
 }
 
 /**
  * Implemented by types that know how to deserialize from the HTTP protocol.
  */
-interface HttpDeserialize<T> {
-    suspend fun deserialize(context: ExecutionContext, response: HttpResponse): T
+public interface HttpDeserialize<T> {
+    public suspend fun deserialize(context: ExecutionContext, response: HttpResponse): T
 }
 
 /**
  * Convenience deserialize implementation for a type with no output type
  */
-object UnitDeserializer : HttpDeserialize<Unit> {
+public object UnitDeserializer : HttpDeserialize<Unit> {
     override suspend fun deserialize(context: ExecutionContext, response: HttpResponse) {}
 }
 
 /**
  * Convenience serialize implementation for a type with no input type
  */
-object UnitSerializer : HttpSerialize<Unit> {
+public object UnitSerializer : HttpSerialize<Unit> {
     override suspend fun serialize(context: ExecutionContext, input: Unit): HttpRequestBuilder = HttpRequestBuilder()
 }
 
 /**
  * Convenience deserialize implementation that returns the response without modification
  */
-object IdentityDeserializer : HttpDeserialize<HttpResponse> {
+public object IdentityDeserializer : HttpDeserialize<HttpResponse> {
     override suspend fun deserialize(context: ExecutionContext, response: HttpResponse): HttpResponse = response
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMiddleware.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMiddleware.kt
@@ -12,8 +12,8 @@ import aws.smithy.kotlin.runtime.io.middleware.ModifyRequest
 /**
  * Middleware that intercepts the [SdkOperationExecution.initialize] phase
  */
-interface InitializeMiddleware<Request, Response> : Middleware<OperationRequest<Request>, Response> {
-    fun install(op: SdkHttpOperation<Request, Response>) {
+public interface InitializeMiddleware<Request, Response> : Middleware<OperationRequest<Request>, Response> {
+    public fun install(op: SdkHttpOperation<Request, Response>) {
         op.execution.initialize.register(this)
     }
 }
@@ -21,8 +21,8 @@ interface InitializeMiddleware<Request, Response> : Middleware<OperationRequest<
 /**
  * Middleware that intercepts the [SdkOperationExecution.mutate] phase
  */
-interface MutateMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
-    fun install(op: SdkHttpOperation<*, Response>) {
+public interface MutateMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
+    public fun install(op: SdkHttpOperation<*, Response>) {
         op.execution.mutate.register(this)
     }
 }
@@ -32,13 +32,13 @@ interface MutateMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
  *
  * NOTE: This can be applied to any phase that uses [SdkHttpRequest] as it's input type (e.g. mutate, finalize, receive)
  */
-interface ModifyRequestMiddleware : ModifyRequest<SdkHttpRequest> {
+public interface ModifyRequestMiddleware : ModifyRequest<SdkHttpRequest> {
     /**
      * Register this transform with the operation's execution
      *
      * NOTE: the default implementation will register with the [SdkOperationExecution.mutate] phase.
      */
-    fun install(op: SdkHttpOperation<*, *>) {
+    public fun install(op: SdkHttpOperation<*, *>) {
         op.execution.mutate.register(this)
     }
 }
@@ -46,8 +46,8 @@ interface ModifyRequestMiddleware : ModifyRequest<SdkHttpRequest> {
 /**
  * Middleware that intercepts the [SdkOperationExecution.finalize] phase
  */
-interface FinalizeMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
-    fun install(op: SdkHttpOperation<*, Response>) {
+public interface FinalizeMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
+    public fun install(op: SdkHttpOperation<*, Response>) {
         op.execution.finalize.register(this)
     }
 }
@@ -55,8 +55,8 @@ interface FinalizeMiddleware<Response> : Middleware<SdkHttpRequest, Response> {
 /**
  * Middleware that intercepts the [SdkOperationExecution.receive] phase
  */
-interface ReceiveMiddleware : Middleware<SdkHttpRequest, HttpCall> {
-    fun install(op: SdkHttpOperation<*, *>) {
+public interface ReceiveMiddleware : Middleware<SdkHttpRequest, HttpCall> {
+    public fun install(op: SdkHttpOperation<*, *>) {
         op.execution.receive.register(this)
     }
 }
@@ -76,6 +76,6 @@ interface ReceiveMiddleware : Middleware<SdkHttpRequest, HttpCall> {
  *
  * ```
  */
-interface InlineMiddleware<I, O> {
-    fun install(op: SdkHttpOperation<I, O>)
+public interface InlineMiddleware<I, O> {
+    public fun install(op: SdkHttpOperation<I, O>)
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationRequest.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/OperationRequest.kt
@@ -17,8 +17,8 @@ import aws.smithy.kotlin.runtime.http.util.CanDeepCopy
  * @param context The operation context
  * @param subject The input type
  */
-data class OperationRequest<T>(val context: ExecutionContext, val subject: T) {
-    constructor(subject: T) : this(ExecutionContext(), subject)
+public data class OperationRequest<T>(public val context: ExecutionContext, public val subject: T) {
+    public constructor(subject: T) : this(ExecutionContext(), subject)
 }
 
 /**

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -20,9 +20,9 @@ import aws.smithy.kotlin.runtime.util.get
  */
 @OptIn(Uuid.WeakRng::class)
 @InternalApi
-class SdkHttpOperation<I, O>(
-    val execution: SdkOperationExecution<I, O>,
-    val context: ExecutionContext,
+public class SdkHttpOperation<I, O>(
+    public val execution: SdkOperationExecution<I, O>,
+    public val context: ExecutionContext,
     internal val serializer: HttpSerialize<I>,
     internal val deserializer: HttpDeserialize<O>,
 ) {
@@ -40,18 +40,18 @@ class SdkHttpOperation<I, O>(
     /**
      * Install a middleware into this operation's execution stack
      */
-    fun install(middleware: ModifyRequestMiddleware) { middleware.install(this) }
+    public fun install(middleware: ModifyRequestMiddleware) { middleware.install(this) }
 
     // Convenience overloads for various types of middleware that target different phases
     // NOTE: Using install isn't strictly necessary, it's just a pattern for self registration
-    fun install(middleware: InitializeMiddleware<I, O>) { middleware.install(this) }
-    fun install(middleware: MutateMiddleware<O>) { middleware.install(this) }
-    fun install(middleware: FinalizeMiddleware<O>) { middleware.install(this) }
-    fun install(middleware: ReceiveMiddleware) { middleware.install(this) }
-    fun install(middleware: InlineMiddleware<I, O>) { middleware.install(this) }
+    public fun install(middleware: InitializeMiddleware<I, O>) { middleware.install(this) }
+    public fun install(middleware: MutateMiddleware<O>) { middleware.install(this) }
+    public fun install(middleware: FinalizeMiddleware<O>) { middleware.install(this) }
+    public fun install(middleware: ReceiveMiddleware) { middleware.install(this) }
+    public fun install(middleware: InlineMiddleware<I, O>) { middleware.install(this) }
 
-    companion object {
-        inline fun <I, O> build(block: SdkHttpOperationBuilder<I, O>.() -> Unit): SdkHttpOperation<I, O> =
+    public companion object {
+        public inline fun <I, O> build(block: SdkHttpOperationBuilder<I, O>.() -> Unit): SdkHttpOperation<I, O> =
             SdkHttpOperationBuilder<I, O>().apply(block).build()
     }
 }
@@ -60,7 +60,7 @@ class SdkHttpOperation<I, O>(
  * Round trip an operation using the given [HttpHandler]
  */
 @InternalApi
-suspend fun <I, O> SdkHttpOperation<I, O>.roundTrip(
+public suspend fun <I, O> SdkHttpOperation<I, O>.roundTrip(
     httpHandler: HttpHandler,
     input: I,
 ): O = execute(httpHandler, input) { it }
@@ -72,7 +72,7 @@ suspend fun <I, O> SdkHttpOperation<I, O>.roundTrip(
  * output responses where the underlying raw HTTP connection needs to remain open
  */
 @InternalApi
-suspend fun <I, O, R> SdkHttpOperation<I, O>.execute(
+public suspend fun <I, O, R> SdkHttpOperation<I, O>.execute(
     httpHandler: HttpHandler,
     input: I,
     block: suspend (O) -> R
@@ -89,13 +89,13 @@ suspend fun <I, O, R> SdkHttpOperation<I, O>.execute(
 }
 
 @InternalApi
-class SdkHttpOperationBuilder<I, O> {
-    var serializer: HttpSerialize<I>? = null
-    var deserializer: HttpDeserialize<O>? = null
-    val execution: SdkOperationExecution<I, O> = SdkOperationExecution()
-    val context = HttpOperationContext.Builder()
+public class SdkHttpOperationBuilder<I, O> {
+    public var serializer: HttpSerialize<I>? = null
+    public var deserializer: HttpDeserialize<O>? = null
+    public val execution: SdkOperationExecution<I, O> = SdkOperationExecution()
+    public val context: HttpOperationContext.Builder = HttpOperationContext.Builder()
 
-    fun build(): SdkHttpOperation<I, O> {
+    public fun build(): SdkHttpOperation<I, O> {
         val opSerializer = requireNotNull(serializer) { "SdkHttpOperation.serializer must not be null" }
         val opDeserializer = requireNotNull(deserializer) { "SdkHttpOperation.deserializer must not be null" }
         return SdkHttpOperation(execution, context.build(), opSerializer, opDeserializer)
@@ -104,4 +104,6 @@ class SdkHttpOperationBuilder<I, O> {
 /**
  * Configure HTTP operation context elements
  */
-inline fun <I, O> SdkHttpOperationBuilder<I, O>.context(block: HttpOperationContext.Builder.() -> Unit) = context.apply(block)
+public inline fun <I, O> SdkHttpOperationBuilder<I, O>.context(block: HttpOperationContext.Builder.() -> Unit) {
+    context.apply(block)
+}

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -24,7 +24,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 import aws.smithy.kotlin.runtime.io.middleware.decorate as decorateHandler
 
-typealias SdkHttpRequest = OperationRequest<HttpRequestBuilder>
+public typealias SdkHttpRequest = OperationRequest<HttpRequestBuilder>
 
 /**
  * Configure the execution of an operation from [Request] to [Response]
@@ -32,7 +32,7 @@ typealias SdkHttpRequest = OperationRequest<HttpRequestBuilder>
  * An operation has several "phases" of its lifecycle that can be intercepted and customized.
  */
 @InternalApi
-class SdkOperationExecution<Request, Response> {
+public class SdkOperationExecution<Request, Response> {
 
     // technically any phase can act as on the request or the response. The phases
     // are described with their intended use, nothing prevents e.g. registering
@@ -41,25 +41,25 @@ class SdkOperationExecution<Request, Response> {
     /**
      * Prepare the input [Request] (or finalize the [Response]) e.g. set any default parameters if needed
      */
-    val initialize = Phase<OperationRequest<Request>, Response>()
+    public val initialize: Phase<OperationRequest<Request>, Response> = Phase<OperationRequest<Request>, Response>()
 
     /**
      * Modify the outgoing HTTP request
      *
      * At this phase the [Request] (operation input) has been serialized to an HTTP request.
      */
-    val mutate = Phase<SdkHttpRequest, Response>()
+    public val mutate: Phase<SdkHttpRequest, Response> = Phase<SdkHttpRequest, Response>()
 
     /**
      * Last chance to intercept before requests are sent (e.g. signing, retries, etc).
      * First chance to intercept after deserialization.
      */
-    val finalize = Phase<SdkHttpRequest, Response>()
+    public val finalize: Phase<SdkHttpRequest, Response> = Phase<SdkHttpRequest, Response>()
 
     /**
      * First chance to intercept before deserialization into operation output type [Response].
      */
-    val receive = Phase<SdkHttpRequest, HttpCall>()
+    public val receive: Phase<SdkHttpRequest, HttpCall> = Phase<SdkHttpRequest, HttpCall>()
 }
 
 /**

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequest.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequest.kt
@@ -9,21 +9,22 @@ import aws.smithy.kotlin.runtime.http.*
 /**
  * Immutable representation of an HTTP request
  */
-data class HttpRequest(
-    val method: HttpMethod,
-    val url: Url,
-    val headers: Headers,
-    val body: HttpBody
+public data class HttpRequest(
+    public val method: HttpMethod,
+    public val url: Url,
+    public val headers: Headers,
+    public val body: HttpBody
 ) {
-    companion object {
-        operator fun invoke(block: HttpRequestBuilder.() -> Unit): HttpRequest = HttpRequestBuilder().apply(block).build()
+    public companion object {
+        public operator fun invoke(block: HttpRequestBuilder.() -> Unit): HttpRequest =
+            HttpRequestBuilder().apply(block).build()
     }
 }
 
 /**
  * Convert an HttpRequest back to an [HttpRequestBuilder]
  */
-fun HttpRequest.toBuilder(): HttpRequestBuilder {
+public fun HttpRequest.toBuilder(): HttpRequestBuilder {
     val req = this
     return HttpRequestBuilder().apply {
         method = req.method

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
@@ -17,15 +17,16 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * @param headers HTTP headers
  * @param body Outgoing payload. Initially empty
  */
-class HttpRequestBuilder private constructor(
-    var method: HttpMethod,
-    val url: UrlBuilder,
-    val headers: HeadersBuilder,
-    var body: HttpBody,
+public class HttpRequestBuilder private constructor(
+    public var method: HttpMethod,
+    public val url: UrlBuilder,
+    public val headers: HeadersBuilder,
+    public var body: HttpBody,
 ) : CanDeepCopy<HttpRequestBuilder> {
-    constructor() : this(HttpMethod.GET, UrlBuilder(), HeadersBuilder(), HttpBody.Empty)
+    public constructor() : this(HttpMethod.GET, UrlBuilder(), HeadersBuilder(), HttpBody.Empty)
 
-    fun build(): HttpRequest = HttpRequest(method, url.build(), if (headers.isEmpty()) Headers.Empty else headers.build(), body)
+    public fun build(): HttpRequest =
+        HttpRequest(method, url.build(), if (headers.isEmpty()) Headers.Empty else headers.build(), body)
 
     override fun deepCopy(): HttpRequestBuilder =
         HttpRequestBuilder(method, url.deepCopy(), headers.deepCopy(), body)
@@ -40,31 +41,37 @@ class HttpRequestBuilder private constructor(
 /**
  * Modify the URL inside the block
  */
-fun HttpRequestBuilder.url(block: UrlBuilder.() -> Unit) = url.apply(block)
+public fun HttpRequestBuilder.url(block: UrlBuilder.() -> Unit) {
+    url.apply(block)
+}
 
 /**
  * Set values from an existing [Url] instance
  */
-fun HttpRequestBuilder.url(value: Url) = url.apply {
-    scheme = value.scheme
-    host = value.host
-    port = value.port
-    path = value.path
-    parameters.appendAll(value.parameters)
-    fragment = value.fragment
-    userInfo = value.userInfo
-    forceQuery = value.forceQuery
+public fun HttpRequestBuilder.url(value: Url) {
+    url.apply {
+        scheme = value.scheme
+        host = value.host
+        port = value.port
+        path = value.path
+        parameters.appendAll(value.parameters)
+        fragment = value.fragment
+        userInfo = value.userInfo
+        forceQuery = value.forceQuery
+    }
 }
 
 /**
  * Modify the headers inside the given block
  */
-fun HttpRequestBuilder.headers(block: HeadersBuilder.() -> Unit) = headers.apply(block)
+public fun HttpRequestBuilder.headers(block: HeadersBuilder.() -> Unit) {
+    headers.apply(block)
+}
 
 /**
  * Add a single header. This will append to any existing headers with the same name.
  */
-fun HttpRequestBuilder.header(name: String, value: String) = headers.append(name, value)
+public fun HttpRequestBuilder.header(name: String, value: String): Unit = headers.append(name, value)
 
 /**
  * Dump a debug description of the request
@@ -73,7 +80,7 @@ fun HttpRequestBuilder.header(name: String, value: String) = headers.append(name
  * replaced.
  */
 @InternalApi
-suspend fun dumpRequest(request: HttpRequestBuilder, dumpBody: Boolean): String {
+public suspend fun dumpRequest(request: HttpRequestBuilder, dumpBody: Boolean): String {
     val buffer = SdkByteBuffer(256u)
 
     // TODO - we have no way to know the http version at this level to set HTTP/x.x

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
@@ -17,32 +17,32 @@ import kotlin.coroutines.EmptyCoroutineContext
 /**
  * A single request/response pair
  */
-data class HttpCall(
+public data class HttpCall(
     /**
      * The original complete request
      */
-    val request: HttpRequest,
+    public val request: HttpRequest,
 
     /**
      * The [HttpResponse] for the given [request]
      */
-    val response: HttpResponse,
+    public val response: HttpResponse,
 
     /**
      * The time the request was made by the engine
      */
-    val requestTime: Instant,
+    public val requestTime: Instant,
 
     /**
      * The time the response was received. This is a rough estimate of Time-to-first-header (TTFH) as
      * reported by the engine.
      */
-    val responseTime: Instant,
+    public val responseTime: Instant,
 
     /**
      * The context associated with this call
      */
-    val callContext: CoroutineContext = EmptyCoroutineContext
+    public val callContext: CoroutineContext = EmptyCoroutineContext
 )
 
 /**
@@ -52,7 +52,7 @@ data class HttpCall(
  * This must be called when finished with the response!
  */
 @InternalApi
-fun HttpCall.complete() {
+public fun HttpCall.complete() {
     val job = callContext[Job] as? CompletableJob ?: return
 
     // FIXME - make suspend and join() the call context job

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
@@ -20,16 +20,16 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * @property [headers] response headers
  * @property [body] response body content
  */
-data class HttpResponse(
-    val status: HttpStatusCode,
-    val headers: Headers,
-    val body: HttpBody,
+public data class HttpResponse(
+    public val status: HttpStatusCode,
+    public val headers: Headers,
+    public val body: HttpBody,
 ) : ProtocolResponse
 
 /**
  * Get an HTTP header value by name. Returns the first header if multiple headers are set
  */
-fun ProtocolResponse.header(name: String): String? {
+public fun ProtocolResponse.header(name: String): String? {
     val httpResp = this as? HttpResponse
     return httpResp?.headers?.get(name)
 }
@@ -37,7 +37,7 @@ fun ProtocolResponse.header(name: String): String? {
 /**
  * Get all HTTP header values associated with the given name.
  */
-fun ProtocolResponse.getAllHeaders(name: String): List<String>? {
+public fun ProtocolResponse.getAllHeaders(name: String): List<String>? {
     val httpResp = this as? HttpResponse
     return httpResp?.headers?.getAll(name)
 }
@@ -45,7 +45,7 @@ fun ProtocolResponse.getAllHeaders(name: String): List<String>? {
 /**
  * Get the HTTP status code of the response
  */
-fun ProtocolResponse.statusCode(): HttpStatusCode? {
+public fun ProtocolResponse.statusCode(): HttpStatusCode? {
     val httpResp = this as? HttpResponse
     return httpResp?.status
 }
@@ -58,7 +58,7 @@ fun ProtocolResponse.statusCode(): HttpStatusCode? {
  * replaced.
  */
 @InternalApi
-suspend fun dumpResponse(response: HttpResponse, dumpBody: Boolean): Pair<HttpResponse, String> {
+public suspend fun dumpResponse(response: HttpResponse, dumpBody: Boolean): Pair<HttpResponse, String> {
     val buffer = SdkByteBuffer(256u)
     buffer.write("HTTP ${response.status}\r\n")
     response.headers.forEach { key, values ->

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/CanDeepCopy.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/CanDeepCopy.kt
@@ -9,9 +9,9 @@ package aws.smithy.kotlin.runtime.http.util
  * Indicates that an object supports a [deepCopy] operation which will return a copy that can be safely mutated without
  * affecting other instances.
  */
-interface CanDeepCopy<out T> {
+public interface CanDeepCopy<out T> {
     /**
      * Returns a deep copy of this object.
      */
-    fun deepCopy(): T
+    public fun deepCopy(): T
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/HeaderLists.kt
@@ -13,7 +13,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * specification for header values.
  */
 @InternalApi
-fun splitHeaderListValues(value: String): List<String> {
+public fun splitHeaderListValues(value: String): List<String> {
     val results = mutableListOf<String>()
     var currIdx = 0
     while (currIdx < value.length) {
@@ -88,7 +88,7 @@ private fun String.readNextUnquoted(startIdx: Int, delim: Char = ','): Pair<Int,
  * a comma within the timestamp value.
  */
 @InternalApi
-fun splitHttpDateHeaderListValues(value: String): List<String> {
+public fun splitHttpDateHeaderListValues(value: String): List<String> {
     val n = value.count { it == ',' }
     if (n <= 1) {
         return listOf(value)
@@ -125,7 +125,7 @@ private const val QUOTABLE_HEADER_VALUE_CHARS = "\",()"
  * Conditionally quotes and escapes a header value if the header value contains a comma or quote
  */
 @InternalApi
-fun quoteHeaderValue(value: String): String =
+public fun quoteHeaderValue(value: String): String =
     if (value.trim().length != value.length || QUOTABLE_HEADER_VALUE_CHARS.any { value.contains(it) }) {
         val formatted = value.replace("\\", "\\\\").replace("\"", "\\\"")
         "\"$formatted\""

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/StringValuesMap.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/util/StringValuesMap.kt
@@ -9,54 +9,54 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 /**
  * Mapping of String to a List of Strings values
  */
-interface StringValuesMap {
+public interface StringValuesMap {
 
     /**
      * Flag indicating if this map compares keys ignoring case
      */
-    val caseInsensitiveName: Boolean
+    public val caseInsensitiveName: Boolean
 
     /**
      * Gets first value from the list of values associated with a [name], or null if the name is not present
      */
-    operator fun get(name: String): String? = getAll(name)?.firstOrNull()
+    public operator fun get(name: String): String? = getAll(name)?.firstOrNull()
 
     /**
      * Gets all values associated with the [name], or null if the name is not present
      */
-    fun getAll(name: String): List<String>?
+    public fun getAll(name: String): List<String>?
 
     /**
      * Gets all names from the map
      */
-    fun names(): Set<String>
+    public fun names(): Set<String>
 
     /**
      * Gets all entries from the map
      */
-    fun entries(): Set<Map.Entry<String, List<String>>>
+    public fun entries(): Set<Map.Entry<String, List<String>>>
 
     /**
      * Checks if the given [name] exists in the map
      */
-    operator fun contains(name: String): Boolean
+    public operator fun contains(name: String): Boolean
 
     /**
      * Checks if the given [name] and [value] pair exists in the map
      */
-    fun contains(name: String, value: String): Boolean = getAll(name)?.contains(value) ?: false
+    public fun contains(name: String, value: String): Boolean = getAll(name)?.contains(value) ?: false
 
     /**
      * Iterates over all entries in this map and calls [body] for each pair
      *
      * Can be optimized in implementations
      */
-    fun forEach(body: (String, List<String>) -> Unit) = entries().forEach { (k, v) -> body(k, v) }
+    public fun forEach(body: (String, List<String>) -> Unit): Unit = entries().forEach { (k, v) -> body(k, v) }
 
     /**
      * Checks if this map is empty
      */
-    fun isEmpty(): Boolean
+    public fun isEmpty(): Boolean
 }
 
 @InternalApi
@@ -90,51 +90,51 @@ internal open class StringValuesMapImpl(
 internal fun Map<String, List<String>>.deepCopy() = mapValues { (_, v) -> v.toMutableList() }
 
 @InternalApi
-open class StringValuesMapBuilder(val caseInsensitiveName: Boolean = false, size: Int = 8) {
+public open class StringValuesMapBuilder(public val caseInsensitiveName: Boolean = false, size: Int = 8) {
     protected val values: MutableMap<String, MutableList<String>> =
         if (caseInsensitiveName) CaseInsensitiveMap() else LinkedHashMap(size)
 
-    fun getAll(name: String): List<String>? = values[name]
+    public fun getAll(name: String): List<String>? = values[name]
 
-    operator fun contains(name: String): Boolean = name in values
+    public operator fun contains(name: String): Boolean = name in values
 
-    fun contains(name: String, value: String): Boolean = values[name]?.contains(value) ?: false
+    public fun contains(name: String, value: String): Boolean = values[name]?.contains(value) ?: false
 
-    fun names(): Set<String> = values.keys
+    public fun names(): Set<String> = values.keys
 
-    fun isEmpty(): Boolean = values.isEmpty()
+    public fun isEmpty(): Boolean = values.isEmpty()
 
-    fun entries(): Set<Map.Entry<String, List<String>>> = values.entries
+    public fun entries(): Set<Map.Entry<String, List<String>>> = values.entries
 
-    operator fun set(name: String, value: String) {
+    public operator fun set(name: String, value: String) {
         val list = ensureListForKey(name, 1)
         list.clear()
         list.add(value)
     }
 
-    fun setMissing(name: String, value: String) {
+    public fun setMissing(name: String, value: String) {
         if (!this.values.containsKey(name)) set(name, value)
     }
 
-    operator fun get(name: String): String? = getAll(name)?.firstOrNull()
+    public operator fun get(name: String): String? = getAll(name)?.firstOrNull()
 
-    fun append(name: String, value: String) {
+    public fun append(name: String, value: String) {
         ensureListForKey(name, 1).add(value)
     }
 
-    fun appendAll(stringValues: StringValuesMap) {
+    public fun appendAll(stringValues: StringValuesMap) {
         stringValues.forEach { name, values ->
             appendAll(name, values)
         }
     }
 
-    fun appendMissing(stringValues: StringValuesMap) {
+    public fun appendMissing(stringValues: StringValuesMap) {
         stringValues.forEach { name, values ->
             appendMissing(name, values)
         }
     }
 
-    fun appendAll(name: String, values: Iterable<String>) {
+    public fun appendAll(name: String, values: Iterable<String>) {
         ensureListForKey(name, (values as? Collection)?.size ?: 2).let { list ->
             values.forEach { value ->
                 list.add(value)
@@ -142,25 +142,25 @@ open class StringValuesMapBuilder(val caseInsensitiveName: Boolean = false, size
         }
     }
 
-    fun appendMissing(name: String, values: Iterable<String>) {
+    public fun appendMissing(name: String, values: Iterable<String>) {
         val existing = this.values[name]?.toSet() ?: emptySet()
 
         appendAll(name, values.filter { it !in existing })
     }
 
-    fun remove(name: String) = values.remove(name)
+    public fun remove(name: String): MutableList<String>? = values.remove(name)
 
-    fun removeKeysWithNoEntries() {
+    public fun removeKeysWithNoEntries() {
         for ((k, _) in values.filter { it.value.isEmpty() }) {
             remove(k)
         }
     }
 
-    fun remove(name: String, value: String) = values[name]?.remove(value) ?: false
+    public fun remove(name: String, value: String): Boolean = values[name]?.remove(value) ?: false
 
-    fun clear() = values.clear()
+    public fun clear(): Unit = values.clear()
 
-    open fun build(): StringValuesMap = StringValuesMapImpl(caseInsensitiveName, values)
+    public open fun build(): StringValuesMap = StringValuesMapImpl(caseInsensitiveName, values)
 
     private fun ensureListForKey(name: String, size: Int): MutableList<String> =
         values[name] ?: ArrayList<String>(size).also { values[name] = it }

--- a/runtime/protocol/http/jvm/src/aws/smithy/kotlin/runtime/http/UrlJVM.kt
+++ b/runtime/protocol/http/jvm/src/aws/smithy/kotlin/runtime/http/UrlJVM.kt
@@ -18,7 +18,7 @@ internal actual fun platformUrlParse(url: String): Url {
  * Convert a [java.net.URI] to a [Url]
  */
 @InternalApi
-fun URI.toUrl(): Url {
+public fun URI.toUrl(): Url {
     val uri = this
     return UrlBuilder {
         scheme = Protocol.parse(uri.scheme)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
@@ -12,81 +12,81 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 /**
  * Additional metadata about an error
  */
-open class ErrorMetadata {
+public open class ErrorMetadata {
     @InternalApi
-    val attributes: Attributes = Attributes()
+    public val attributes: Attributes = Attributes()
 
-    companion object {
+    public companion object {
         /**
          * Set if an error is retryable
          */
-        val Retryable: AttributeKey<Boolean> = AttributeKey("Retryable")
+        public val Retryable: AttributeKey<Boolean> = AttributeKey("Retryable")
 
         /**
          * Set if an error represents a throttling condition
          */
-        val ThrottlingError: AttributeKey<Boolean> = AttributeKey("ThrottlingError")
+        public val ThrottlingError: AttributeKey<Boolean> = AttributeKey("ThrottlingError")
     }
 
-    val isRetryable: Boolean
+    public val isRetryable: Boolean
         get() = attributes.getOrNull(Retryable) ?: false
 
-    val isThrottling: Boolean
+    public val isThrottling: Boolean
         get() = attributes.getOrNull(ThrottlingError) ?: false
 }
 
 /**
  * Base exception class for all exceptions thrown by the SDK. Exception may be a client side exception or a service exception
  */
-open class SdkBaseException : RuntimeException {
+public open class SdkBaseException : RuntimeException {
 
-    constructor() : super()
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 
     /**
      * Additional metadata about the error
      */
-    open val sdkErrorMetadata: ErrorMetadata = ErrorMetadata()
+    public open val sdkErrorMetadata: ErrorMetadata = ErrorMetadata()
 }
 
 /**
  * Base exception class for any errors that occur while attempting to use an SDK client to make (Smithy) service calls.
  */
-open class ClientException : SdkBaseException {
-    constructor() : super()
+public open class ClientException : SdkBaseException {
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 }
 
 /**
  * Generic interface that any protocol (e.g. HTTP, MQTT, etc) can extend to provide additional access to
  * protocol specific details.
  */
-interface ProtocolResponse
+public interface ProtocolResponse
 
 private object EmptyProtocolResponse : ProtocolResponse
 
-open class ServiceErrorMetadata : ErrorMetadata() {
-    companion object {
-        val ErrorCode: AttributeKey<String> = AttributeKey("ErrorCode")
-        val ErrorType: AttributeKey<ServiceException.ErrorType> = AttributeKey("ErrorType")
-        val ProtocolResponse: AttributeKey<ProtocolResponse> = AttributeKey("ProtocolResponse")
-        val RequestId: AttributeKey<String> = AttributeKey("RequestId")
+public open class ServiceErrorMetadata : ErrorMetadata() {
+    public companion object {
+        public val ErrorCode: AttributeKey<String> = AttributeKey("ErrorCode")
+        public val ErrorType: AttributeKey<ServiceException.ErrorType> = AttributeKey("ErrorType")
+        public val ProtocolResponse: AttributeKey<ProtocolResponse> = AttributeKey("ProtocolResponse")
+        public val RequestId: AttributeKey<String> = AttributeKey("RequestId")
     }
 
     /**
      * The name of the service that sent this error response
      */
-    val serviceName: String
+    public val serviceName: String
         get() = attributes.getOrNull(SdkClientOption.ServiceName) ?: ""
 
     /**
@@ -97,19 +97,19 @@ open class ServiceErrorMetadata : ErrorMetadata() {
      * [restJson1 protocol errors](https://awslabs.github.io/smithy/1.0/spec/aws/aws-restjson1-protocol.html#operation-error-serialization)
      * for details).
      */
-    val errorCode: String?
+    public val errorCode: String?
         get() = attributes.getOrNull(ErrorCode)
 
     /**
      * Indicates who is responsible for this exception (caller, service, or unknown)
      */
-    val errorType: ServiceException.ErrorType
+    public val errorType: ServiceException.ErrorType
         get() = attributes.getOrNull(ErrorType) ?: ServiceException.ErrorType.Unknown
 
     /**
      * The protocol response if available (this will differ depending on the underlying protocol e.g. HTTP, MQTT, etc)
      */
-    val protocolResponse: ProtocolResponse
+    public val protocolResponse: ProtocolResponse
         get() = attributes.getOrNull(ProtocolResponse) ?: EmptyProtocolResponse
 
     /**
@@ -118,7 +118,7 @@ open class ServiceErrorMetadata : ErrorMetadata() {
      * This value is implementation-defined. For example, AWS services trace and return unique request IDs for API
      * calls.
      */
-    val requestId: String?
+    public val requestId: String?
         get() = attributes.getOrNull(RequestId)
 }
 
@@ -127,24 +127,24 @@ open class ServiceErrorMetadata : ErrorMetadata() {
  * type indicates that the caller's request was successfully transmitted to the service and the service sent back an
  * error response.
  */
-open class ServiceException : SdkBaseException {
+public open class ServiceException : SdkBaseException {
 
     /**
      * Indicates who (if known) is at fault for this exception.
      */
-    enum class ErrorType {
+    public enum class ErrorType {
         Client,
         Server,
         Unknown
     }
 
-    constructor() : super()
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 
     override val sdkErrorMetadata: ServiceErrorMetadata = ServiceErrorMetadata()
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/SdkClient.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/SdkClient.kt
@@ -9,8 +9,8 @@ import aws.smithy.kotlin.runtime.io.Closeable
 /**
  * Common interface all generated service clients implement
  */
-interface SdkClient : Closeable {
-    val serviceName: String
+public interface SdkClient : Closeable {
+    public val serviceName: String
 
     override fun close() {}
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ClientOption.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ClientOption.kt
@@ -21,17 +21,17 @@ public interface ClientOptions {
     /**
      * Check if the specified [option] exists
      */
-    operator fun contains(option: ClientOption<*>): Boolean
+    public operator fun contains(option: ClientOption<*>): Boolean
 
     /**
      * Creates or changes an [option] with the specified [value]
      */
-    fun <T : Any> set(option: ClientOption<T>, value: T)
+    public fun <T : Any> set(option: ClientOption<T>, value: T)
 
     /**
      * Removes an option with the specified [option] if it exists
      */
-    fun <T : Any> remove(option: ClientOption<T>)
+    public fun <T : Any> remove(option: ClientOption<T>)
 }
 
 /**
@@ -43,5 +43,5 @@ public class ClientOptionsImpl(private val attributes: Attributes) : ClientOptio
         attributes[option] = value
     }
     override fun contains(option: ClientOption<*>): Boolean = attributes.contains(option)
-    override fun <T : Any> remove(option: ClientOption<T>) = attributes.remove(option)
+    override fun <T : Any> remove(option: ClientOption<T>): Unit = attributes.remove(option)
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ClientOptionsBuilder.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ClientOptionsBuilder.kt
@@ -35,7 +35,7 @@ public abstract class ClientOptionsBuilder(protected val options: Attributes = A
     /**
      * Build the options into an [ExecutionContext]
      */
-    fun build(): ExecutionContext {
+    public fun build(): ExecutionContext {
         val builder = this
 
         // verify the required properties were set

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
@@ -15,20 +15,20 @@ public class ExecutionContext private constructor(builder: ExecutionContextBuild
     /**
      * Default construct an [ExecutionContext]. Note: this is not usually useful without configuring the call attributes
      */
-    constructor() : this(ExecutionContextBuilder())
+    public constructor() : this(ExecutionContextBuilder())
 
     /**
      * Attributes associated with this particular execution/call
      */
-    val attributes: Attributes = builder.attributes
+    public val attributes: Attributes = builder.attributes
 
-    companion object {
-        fun build(block: ExecutionContextBuilder.() -> Unit): ExecutionContext = ExecutionContextBuilder().apply(block).build()
+    public companion object {
+        public fun build(block: ExecutionContextBuilder.() -> Unit): ExecutionContext = ExecutionContextBuilder().apply(block).build()
     }
 
-    class ExecutionContextBuilder {
-        var attributes: Attributes = Attributes()
+    public class ExecutionContextBuilder {
+        public var attributes: Attributes = Attributes()
 
-        fun build(): ExecutionContext = ExecutionContext(this)
+        public fun build(): ExecutionContext = ExecutionContext(this)
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -38,19 +38,19 @@ public object SdkClientOption {
  * Get the [IdempotencyTokenProvider] from the context. If one is not set the default will be returned.
  */
 @InternalApi
-val ExecutionContext.idempotencyTokenProvider: IdempotencyTokenProvider
+public val ExecutionContext.idempotencyTokenProvider: IdempotencyTokenProvider
     get() = getOrNull(SdkClientOption.IdempotencyTokenProvider) ?: IdempotencyTokenProvider.Default
 
 /**
  * Get the [SdkLogMode] from the context. If one is not set a default will be returned
  */
 @InternalApi
-val ExecutionContext.sdkLogMode: SdkLogMode
+public val ExecutionContext.sdkLogMode: SdkLogMode
     get() = getOrNull(SdkClientOption.LogMode) ?: SdkLogMode.Default
 
 /**
  * Get the [OperationName] from the context.
  */
 @InternalApi
-val ExecutionContext.operationName: String?
+public val ExecutionContext.operationName: String?
     get() = getOrNull(SdkClientOption.OperationName)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkLogMode.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/SdkLogMode.kt
@@ -14,63 +14,64 @@ package aws.smithy.kotlin.runtime.client
  * val mode = LogMode.LogRequest + LogMode.LogRetries
  * ```
  */
-sealed class SdkLogMode(private val mask: Int) {
+public sealed class SdkLogMode(private val mask: Int) {
     /**
      * The default logging mode which does not opt-in to anything
      */
-    object Default : SdkLogMode(0x00) {
+    public object Default : SdkLogMode(0x00) {
         override fun toString(): String = "Default"
     }
 
     /**
      * Log the request details, e.g. url, headers, etc.
      */
-    object LogRequest : SdkLogMode(0x01) {
+    public object LogRequest : SdkLogMode(0x01) {
         override fun toString(): String = "LogRequest"
     }
 
     /**
      * Log the request details as well as the body if possible
      */
-    object LogRequestWithBody : SdkLogMode(0x02) {
+    public object LogRequestWithBody : SdkLogMode(0x02) {
         override fun toString(): String = "LogRequestWithBody"
     }
 
     /**
      * Log the response details, e.g. status, headers, etc
      */
-    object LogResponse : SdkLogMode(0x04) {
+    public object LogResponse : SdkLogMode(0x04) {
         override fun toString(): String = "LogResponse"
     }
 
     /**
      * Log the response details as well as the body if possible
      */
-    object LogResponseWithBody : SdkLogMode(0x08) {
+    public object LogResponseWithBody : SdkLogMode(0x08) {
         override fun toString(): String = "LogResponseWithBody"
     }
 
     internal class Composite(mask: Int) : SdkLogMode(mask)
 
-    operator fun plus(mode: SdkLogMode): SdkLogMode = Composite(mask or mode.mask)
-    operator fun minus(mode: SdkLogMode): SdkLogMode = Composite(mask and mode.mask.inv())
+    public operator fun plus(mode: SdkLogMode): SdkLogMode = Composite(mask or mode.mask)
+    public operator fun minus(mode: SdkLogMode): SdkLogMode = Composite(mask and mode.mask.inv())
 
     /**
      * Test if a particular [SdkLogMode] is enabled
      */
-    fun isEnabled(mode: SdkLogMode): Boolean = mask and mode.mask != 0
+    public fun isEnabled(mode: SdkLogMode): Boolean = mask and mode.mask != 0
 
-    companion object {
+    public companion object {
         /**
          * Get a list of all modes
          */
-        fun allModes(): List<SdkLogMode> = listOf(
+        public fun allModes(): List<SdkLogMode> = listOf(
             LogRequest,
             LogRequestWithBody,
             LogResponse,
             LogResponseWithBody,
         )
     }
+
     override fun toString(): String =
         allModes().joinToString(separator = "|", prefix = "SdkLogMode(", postfix = ")") { mode ->
             if (isEnabled(mode)) mode.toString() else ""

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/IdempotencyTokenProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/IdempotencyTokenProvider.kt
@@ -10,30 +10,30 @@ import aws.smithy.kotlin.runtime.util.Uuid.WeakRng
 /**
  * User-accessible configuration for client-side token generation.
  */
-interface IdempotencyTokenConfig {
+public interface IdempotencyTokenConfig {
 
     /**
      * Allows to supply a custom function generate idempotency tokens.
      */
-    val idempotencyTokenProvider: IdempotencyTokenProvider?
+    public val idempotencyTokenProvider: IdempotencyTokenProvider?
 }
 
 /**
  * Describes a function and default implementation to produce a string used as a token to dedupe
  * requests from the client.
  */
-fun interface IdempotencyTokenProvider {
+public fun interface IdempotencyTokenProvider {
 
     /**
      * Generate a unique, UUID-like string that can be used to track unique client-side requests.
      */
-    fun generateToken(): String
+    public fun generateToken(): String
 
-    companion object {
+    public companion object {
         /**
          * Creates the default token provider.
          */
-        val Default: IdempotencyTokenProvider = DefaultIdempotencyTokenProvider()
+        public val Default: IdempotencyTokenProvider = DefaultIdempotencyTokenProvider()
     }
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/SdkClientConfig.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/SdkClientConfig.kt
@@ -9,7 +9,7 @@ import aws.smithy.kotlin.runtime.client.SdkLogMode
 /**
  * Common configuration options for any generated SDK client
  */
-interface SdkClientConfig {
+public interface SdkClientConfig {
     /**
      * Configure events that will be logged. By default clients will not output
      * raw requests or responses. Use this setting to opt-in to additional debug logging.
@@ -20,6 +20,6 @@ interface SdkClientConfig {
      * performance considerations when dumping the request/response body. This is primarily a tool for
      * debug purposes.
      */
-    val sdkLogMode: SdkLogMode
+    public val sdkLogMode: SdkLogMode
         get() = SdkLogMode.Default
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteArrayContent.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteArrayContent.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.content
 /**
  * Container for wrapping a ByteArray as a [ByteStream]
  */
-class ByteArrayContent(private val bytes: ByteArray) : ByteStream.Buffer() {
+public class ByteArrayContent(private val bytes: ByteArray) : ByteStream.Buffer() {
     override val contentLength: Long = bytes.size.toLong()
     override fun bytes(): ByteArray = bytes
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
@@ -9,57 +9,57 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 /**
  * Represents an abstract read-only stream of bytes
  */
-sealed class ByteStream {
+public sealed class ByteStream {
 
     /**
      * The content length if known
      */
-    open val contentLength: Long? = null
+    public open val contentLength: Long? = null
 
     /**
      * Variant of a [ByteStream] with payload represented as an in-memory byte buffer.
      */
-    abstract class Buffer : ByteStream() {
+    public abstract class Buffer : ByteStream() {
         /**
          * Provides [ByteArray] to be consumed. This *MUST* be idempotent as the data may be
          * read multiple times.
          */
-        abstract fun bytes(): ByteArray
+        public abstract fun bytes(): ByteArray
     }
 
     /**
      * Variant of a [ByteStream] with a streaming payload that can only be consumed once.
      */
-    abstract class OneShotStream : ByteStream() {
+    public abstract class OneShotStream : ByteStream() {
         /**
          * Provides [SdkByteReadChannel] to read from/consume. This function MUST be idempotent, implementations must
          * return the same channel every time (or a channel in the equivalent state).
          */
-        abstract fun readFrom(): SdkByteReadChannel
+        public abstract fun readFrom(): SdkByteReadChannel
     }
 
     /**
      * Variant of an [ByteStream] with a streaming payload that can be consumed multiple times.
      */
-    abstract class ReplayableStream : ByteStream() {
+    public abstract class ReplayableStream : ByteStream() {
         /**
          * Provides [SdkByteReadChannel] to read from/consume. Implementations MUST provide a fresh read channel
          * reset to the original state on each invocation of [newReader]. Consumers are allowed
          * to close the stream and ask for a new one.
          */
-        abstract fun newReader(): SdkByteReadChannel
+        public abstract fun newReader(): SdkByteReadChannel
     }
 
-    companion object {
+    public companion object {
         /**
          * Create a [ByteStream] from a [String]
          */
-        fun fromString(str: String): ByteStream = StringContent(str)
+        public fun fromString(str: String): ByteStream = StringContent(str)
 
         /**
          * Create a [ByteStream] from a [ByteArray]
          */
-        fun fromBytes(bytes: ByteArray): ByteStream = ByteArrayContent(bytes)
+        public fun fromBytes(bytes: ByteArray): ByteStream = ByteArrayContent(bytes)
     }
 }
 
@@ -78,15 +78,15 @@ private suspend fun consumeStream(chan: SdkByteReadChannel): ByteArray {
  * Only do this if you are sure the contents fit in-memory as this will read the entire contents
  * of a streaming variant.
  */
-suspend fun ByteStream.toByteArray(): ByteArray = when (val stream = this) {
+public suspend fun ByteStream.toByteArray(): ByteArray = when (val stream = this) {
     is ByteStream.Buffer -> stream.bytes()
     is ByteStream.OneShotStream -> consumeStream(stream.readFrom())
     is ByteStream.ReplayableStream -> consumeStream(stream.newReader())
 }
 
-suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToString()
+public suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToString()
 
-fun ByteStream.cancel() {
+public fun ByteStream.cancel() {
     when (val stream = this) {
         is ByteStream.Buffer -> stream.bytes()
         is ByteStream.OneShotStream -> stream.readFrom().cancel(null)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.content
 /**
  * Container for wrapping a String as a [ByteStream]
  */
-class StringContent(str: String) : ByteStream.Buffer() {
+public class StringContent(str: String) : ByteStream.Buffer() {
     @OptIn(ExperimentalStdlibApi::class)
     private val asBytes: ByteArray = str.encodeToByteArray()
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Exceptions.kt
@@ -16,12 +16,12 @@ import aws.smithy.kotlin.runtime.ClientException
  * @param lastException The exception caught by the retry strategy before this failure was encountered. Note that the
  * [Throwable] in this parameter isn't necessarily the cause of this exception.
  */
-sealed class RetryException(
+public sealed class RetryException(
     message: String,
     cause: Throwable?,
-    val attempts: Int,
-    val lastResponse: Any?,
-    val lastException: Throwable?,
+    public val attempts: Int,
+    public val lastResponse: Any?,
+    public val lastException: Throwable?,
 ) : ClientException(message, cause)
 
 /**
@@ -32,7 +32,7 @@ sealed class RetryException(
  * @param lastException The exception caught by the retry strategy before this failure was encountered. Note that the
  * [Throwable] in this parameter isn't necessarily the cause of this exception.
  */
-class TooManyAttemptsException(
+public class TooManyAttemptsException(
     message: String,
     cause: Throwable?,
     attempts: Int,
@@ -48,7 +48,7 @@ class TooManyAttemptsException(
  * @param lastException The exception caught by the retry strategy before this failure was encountered. Note that the
  * [Throwable] in this parameter isn't necessarily the cause of this exception.
  */
-class TimedOutException(
+public class TimedOutException(
     message: String,
     attempts: Int,
     lastResponse: Any?,
@@ -62,7 +62,7 @@ class TimedOutException(
  * @param attempts The number of attempts made before this failure was encountered.
  * @param lastResponse The last response received from the retry strategy before this failure was encountered.
  */
-class RetryFailureException(
+public class RetryFailureException(
     message: String,
     cause: Throwable?,
     attempts: Int,

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Outcome.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/Outcome.kt
@@ -10,11 +10,11 @@ package aws.smithy.kotlin.runtime.retries
  * no flag for "success" since exceptional outcomes do not necessarily represent "failure".
  * @param T The type of non-exception result (if present).
  */
-sealed class Outcome<out T> {
+public sealed class Outcome<out T> {
     /**
      * The number of attempts executed in order to reach the outcome. Starts at 1.
      */
-    abstract val attempts: Int
+    public abstract val attempts: Int
 
     /**
      * An outcome that includes a normal (i.e., non-exceptional) response.
@@ -22,20 +22,20 @@ sealed class Outcome<out T> {
      * @param attempts The number of attempts executed in order to reach the outcome. Starts at 1.
      * @param response The response to an operation.
      */
-    data class Response<out T>(override val attempts: Int, val response: T) : Outcome<T>()
+    public data class Response<out T>(override val attempts: Int, val response: T) : Outcome<T>()
 
     /**
      * An outcome that includes an exception.
      * @param attempts The number of attempts executed in order to reach the outcome. Starts at 1.
      * @param exception The exception resulting from the operation.
      */
-    data class Exception(override val attempts: Int, val exception: Throwable) : Outcome<Nothing>()
+    public data class Exception(override val attempts: Int, val exception: Throwable) : Outcome<Nothing>()
 }
 
 /**
  * Gets the non-exceptional response in this outcome if it exists. Otherwise, throws the exception in this outcome.
  */
-fun <T> Outcome<T>.getOrThrow(): T = when (this) {
+public fun <T> Outcome<T>.getOrThrow(): T = when (this) {
     is Outcome.Response -> response
     is Outcome.Exception -> throw exception
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
@@ -10,11 +10,11 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 /**
  * A strategy for trying a block of code one or more times.
  */
-interface RetryStrategy {
+public interface RetryStrategy {
     /**
      * Common retry strategy options
      */
-    val options: RetryOptions
+    public val options: RetryOptions
 
     /**
      * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
@@ -23,13 +23,13 @@ interface RetryStrategy {
      * @param block The block of code to retry.
      * @return The successful [Outcome] of the final retry attempt.
      */
-    suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R>
+    public suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R>
 }
 
-interface RetryOptions {
+public interface RetryOptions {
     /**
      * Maximum retry attempts allowed by a strategy
      */
-    val maxAttempts: Int?
+    public val maxAttempts: Int?
         get() = null
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.CancellationException
  * those scopes.
  * @param delayProvider A delayer that can back off after the initial try to spread out the retries.
  */
-class StandardRetryStrategy(
+public class StandardRetryStrategy(
     override val options: StandardRetryStrategyOptions = StandardRetryStrategyOptions.Default,
     private val tokenBucket: RetryTokenBucket = StandardRetryTokenBucket(),
     private val delayProvider: DelayProvider = ExponentialBackoffWithJitter()
@@ -145,11 +145,11 @@ class StandardRetryStrategy(
  * Defines configuration for a [StandardRetryStrategy].
  * @param maxAttempts The maximum number of attempts to make (including the first attempt).
  */
-data class StandardRetryStrategyOptions(override val maxAttempts: Int) : RetryOptions {
-    companion object {
+public data class StandardRetryStrategyOptions(override val maxAttempts: Int) : RetryOptions {
+    public companion object {
         /**
          * The default retry strategy configuration.
          */
-        val Default = StandardRetryStrategyOptions(maxAttempts = 3)
+        public val Default: StandardRetryStrategyOptions = StandardRetryStrategyOptions(maxAttempts = 3)
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
@@ -8,10 +8,10 @@ package aws.smithy.kotlin.runtime.retries.delay
 /**
  * An object that can be used to delay between iterations of code.
  */
-fun interface DelayProvider {
+public fun interface DelayProvider {
     /**
      * Delays for an appropriate amount of time after the given attempt number.
      * @param attempt The ordinal index of the attempt, used in calculating the exact amount of time to delay.
      */
-    suspend fun backoff(attempt: Int)
+    public suspend fun backoff(attempt: Int)
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter.kt
@@ -25,8 +25,8 @@ import kotlin.time.DurationUnit
  *
  * @param options The configuration to use for this delayer.
  */
-class ExponentialBackoffWithJitter(
-    val options: ExponentialBackoffWithJitterOptions = ExponentialBackoffWithJitterOptions.Default
+public class ExponentialBackoffWithJitter(
+    public val options: ExponentialBackoffWithJitterOptions = ExponentialBackoffWithJitterOptions.Default
 ) : DelayProvider {
     private val random = Random.Default
 
@@ -50,11 +50,11 @@ class ExponentialBackoffWithJitter(
  * @param jitter amount of jitter used in calculating delay
  * @param maxBackoff maximum amount of delay
  */
-data class ExponentialBackoffWithJitterOptions(
-    val initialDelay: Duration,
-    val scaleFactor: Double,
-    val jitter: Double,
-    val maxBackoff: Duration,
+public data class ExponentialBackoffWithJitterOptions(
+    public val initialDelay: Duration,
+    public val scaleFactor: Double,
+    public val jitter: Double,
+    public val maxBackoff: Duration,
 ) {
     init {
         require(initialDelay.isPositive()) { "initialDelayMs must be at least 0" }
@@ -63,11 +63,11 @@ data class ExponentialBackoffWithJitterOptions(
         require(!maxBackoff.isNegative()) { "maxBackoffMs must be at least 0" }
     }
 
-    companion object {
+    public companion object {
         /**
          * The default backoff configuration to use.
          */
-        val Default = ExponentialBackoffWithJitterOptions(
+        public val Default: ExponentialBackoffWithJitterOptions = ExponentialBackoffWithJitterOptions(
             initialDelay = 10.milliseconds, // start with 10ms
             scaleFactor = 1.5, // 10ms -> 15ms -> 22.5ms -> 33.8ms -> 50.6ms -> …
             jitter = 1.0, // Full jitter,

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
@@ -11,7 +11,7 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
  * A [RetryTokenBucket] that doesn't actually track tokens, effectively simulating "infinite" token capacity. All
  * operations immediately succeed and no blocking occurs.
  */
-object InfiniteTokenBucket : RetryTokenBucket {
+public object InfiniteTokenBucket : RetryTokenBucket {
     override suspend fun acquireToken(): RetryToken = object : RetryToken {
         override suspend fun notifyFailure() = Unit
         override suspend fun notifySuccess() = Unit

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
@@ -11,13 +11,13 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 /**
  * A rate-limiting token bucket for use in a client-throttled retry strategy.
  */
-interface RetryTokenBucket {
+public interface RetryTokenBucket {
     /**
      * Acquire a token from the token bucket. This method should be called before the initial retry attempt for a block
      * of code. This method may delay if there are already insufficient tokens in the bucket due to prior retry
      * failures or large numbers of simultaneous requests.
      */
-    suspend fun acquireToken(): RetryToken
+    public suspend fun acquireToken(): RetryToken
 }
 
 /**
@@ -26,27 +26,27 @@ interface RetryTokenBucket {
  * either by calling [notifySuccess] or [scheduleRetry].
  *
  */
-interface RetryToken {
+public interface RetryToken {
     /**
      * Completes this token because retrying has been abandoned.
      */
-    suspend fun notifyFailure()
+    public suspend fun notifyFailure()
 
     /**
      * Completes this token because the previous retry attempt was successful.
      */
-    suspend fun notifySuccess()
+    public suspend fun notifySuccess()
 
     /**
      * Completes this token and requests another one because the previous retry attempt was unsuccessful.
      * @param reason The type of error evaluated from the last retry attempt.
      * @return A new token for a subsequent retry attempt.
      */
-    suspend fun scheduleRetry(reason: RetryErrorType): RetryToken
+    public suspend fun scheduleRetry(reason: RetryErrorType): RetryToken
 }
 
 /**
  * Indicates that the token bucket has exhausted its capacity and was configured to throw exceptions (vs delay).
  * @param message A message indicating the failure mode.
  */
-class RetryCapacityExceededException(message: String) : ClientException(message)
+public class RetryCapacityExceededException(message: String) : ClientException(message)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -22,8 +22,8 @@ private const val MS_PER_S = 1_000
  * @param options The configuration to use for this bucket.
  * @param clock A clock to use for time calculations.
  */
-class StandardRetryTokenBucket(
-    val options: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions.Default,
+public class StandardRetryTokenBucket(
+    public val options: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions.Default,
     private val clock: Clock = Clock.System,
 ) : RetryTokenBucket {
     internal var capacity = options.maxCapacity
@@ -80,7 +80,7 @@ class StandardRetryTokenBucket(
      * A standard implementation of a [RetryToken].
      * @param returnSize The amount of capacity to return to the bucket on a successful try.
      */
-    inner class StandardRetryToken(val returnSize: Int) : RetryToken {
+    internal inner class StandardRetryToken(public val returnSize: Int) : RetryToken {
         /**
          * Completes this token because retrying has been abandoned. This implementation doesn't actually increment any
          * capacity upon failure...capacity just refills based on time.
@@ -122,20 +122,20 @@ class StandardRetryTokenBucket(
  * @param initialTryCost The amount of capacity to decrement for the initial try.
  * @param initialTrySuccessIncrement The amount of capacity to return if the initial try is successful.
  */
-data class StandardRetryTokenBucketOptions(
-    val maxCapacity: Int,
-    val refillUnitsPerSecond: Int,
-    val circuitBreakerMode: Boolean,
-    val retryCost: Int,
-    val timeoutRetryCost: Int,
-    val initialTryCost: Int,
-    val initialTrySuccessIncrement: Int,
+public data class StandardRetryTokenBucketOptions(
+    public val maxCapacity: Int,
+    public val refillUnitsPerSecond: Int,
+    public val circuitBreakerMode: Boolean,
+    public val retryCost: Int,
+    public val timeoutRetryCost: Int,
+    public val initialTryCost: Int,
+    public val initialTrySuccessIncrement: Int,
 ) {
-    companion object {
+    public companion object {
         /**
          * The default configuration for a [StandardRetryTokenBucket].
          */
-        val Default = StandardRetryTokenBucketOptions(
+        public val Default: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions(
             maxCapacity = 500,
             refillUnitsPerSecond = 10,
             circuitBreakerMode = false,

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/AcceptorRetryPolicy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/AcceptorRetryPolicy.kt
@@ -14,7 +14,7 @@ package aws.smithy.kotlin.runtime.retries.policy
  * @param input The input to the operation.
  * @param acceptors A list of [Acceptor] instances to be tried in order.
  */
-class AcceptorRetryPolicy<in I, in O>(
+public class AcceptorRetryPolicy<in I, in O>(
     private val input: I,
     private val acceptors: List<Acceptor<I, O>>,
 ) : RetryPolicy<O> {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/Acceptors.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/Acceptors.kt
@@ -14,14 +14,14 @@ import kotlin.reflect.KClass
  * @param O The type of the output from the operation.
  * @param state The [RetryDirective] that applies when the acceptor's condition is matched.
  */
-abstract class Acceptor<in I, in O>(val state: RetryDirective) {
+public abstract class Acceptor<in I, in O>(public val state: RetryDirective) {
     /**
      * Evaluates an operation request and result.
      * @param request The input to the operation.
      * @param result The output of the operation (either a regular response or an exception).
      * @return If this acceptor's condition is matched, then the acceptor's [state] is returned. Otherwise, null.
      */
-    fun evaluate(request: I, result: Result<O>): RetryDirective? =
+    public fun evaluate(request: I, result: Result<O>): RetryDirective? =
         if (matches(request, result)) state else null
 
     /**
@@ -39,7 +39,7 @@ abstract class Acceptor<in I, in O>(val state: RetryDirective) {
  * @param success If true, matches when the response is non-exceptional. Otherwise, matches when the response is
  * exceptional.
  */
-class SuccessAcceptor(state: RetryDirective, val success: Boolean) : Acceptor<Any, Any>(state) {
+public class SuccessAcceptor(state: RetryDirective, public val success: Boolean) : Acceptor<Any, Any>(state) {
     override fun matches(request: Any, result: Result<Any>): Boolean =
         result.isSuccess == success
 }
@@ -49,7 +49,7 @@ class SuccessAcceptor(state: RetryDirective, val success: Boolean) : Acceptor<An
  * @param state The [RetryDirective] that applies when the acceptor's condition is matched.
  * @param errorType The [KClass] of error for this acceptor.
  */
-class ErrorTypeAcceptor(state: RetryDirective, val errorType: String) : Acceptor<Any, Any>(state) {
+public class ErrorTypeAcceptor(state: RetryDirective, public val errorType: String) : Acceptor<Any, Any>(state) {
     override fun matches(request: Any, result: Result<Any>): Boolean =
         (result.exceptionOrNull() as? ServiceException)?.sdkErrorMetadata?.errorCode == errorType
 }
@@ -59,7 +59,7 @@ class ErrorTypeAcceptor(state: RetryDirective, val errorType: String) : Acceptor
  * @param state The [RetryDirective] that applies when the acceptor's condition is matched.
  * @param matcher The logic for determining if this acceptor's condition is matched based on the operation's output.
  */
-class OutputAcceptor<O>(state: RetryDirective, val matcher: (O) -> Boolean) : Acceptor<Any, O>(state) {
+public class OutputAcceptor<O>(state: RetryDirective, public val matcher: (O) -> Boolean) : Acceptor<Any, O>(state) {
     override fun matches(request: Any, result: Result<O>): Boolean =
         result.getOrNull()?.run(matcher) ?: false
 }
@@ -70,14 +70,14 @@ class OutputAcceptor<O>(state: RetryDirective, val matcher: (O) -> Boolean) : Ac
  * @param matcher The logic for determining if this acceptor's condition is matched based on the operation's input and
  * output.
  */
-class InputOutputAcceptor<I, O>(
+public class InputOutputAcceptor<I, O>(
     state: RetryDirective,
-    val matcher: (InputOutput<I, O>) -> Boolean,
+    public val matcher: (InputOutput<I, O>) -> Boolean,
 ) : Acceptor<I, O>(state) {
     /**
      * A utility class holding the input and output to an operation.
      */
-    data class InputOutput<I, O>(val input: I, val output: O)
+    public data class InputOutput<I, O>(public val input: I, public val output: O)
 
     override fun matches(request: I, result: Result<O>): Boolean =
         result.getOrNull()?.let { matcher(InputOutput(request, it)) } ?: false

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryDirective.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryDirective.kt
@@ -8,19 +8,19 @@ package aws.smithy.kotlin.runtime.retries.policy
 /**
  * The evaluation of a single try.
  */
-sealed class RetryDirective {
+public sealed class RetryDirective {
     /**
      * Indicates that retrying should stop as the result indicates a success condition.
      */
-    object TerminateAndSucceed : RetryDirective()
+    public object TerminateAndSucceed : RetryDirective()
 
     /**
      * Indicates that retrying should stop as the result indicates a non-retryable failure condition.
      */
-    object TerminateAndFail : RetryDirective()
+    public object TerminateAndFail : RetryDirective()
 
     /**
      * Indicates that retrying should continue as the result indicates a retryable failure condition.
      */
-    data class RetryError(val reason: RetryErrorType) : RetryDirective()
+    public data class RetryError(public val reason: RetryErrorType) : RetryDirective()
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
@@ -8,7 +8,7 @@ package aws.smithy.kotlin.runtime.retries.policy
 /**
  * A type of error that may be retried.
  */
-enum class RetryErrorType {
+public enum class RetryErrorType {
     /**
      * A general server-side error.
      */

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryPolicy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryPolicy.kt
@@ -8,11 +8,11 @@ package aws.smithy.kotlin.runtime.retries.policy
 /**
  * A policy that evaluates a [Result] from a retry attempt and indicates the action a [RetryStrategy] should take next.
  */
-interface RetryPolicy<in R> {
+public interface RetryPolicy<in R> {
     /**
      * Evaluate the given retry attempt.
      * @param result The [Result] of the retry attempt.
      * @return A [RetryDirective] indicating what action the [RetryStrategy] should take next.
      */
-    fun evaluate(result: Result<R>): RetryDirective
+    public fun evaluate(result: Result<R>): RetryDirective
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/StandardRetryPolicy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/StandardRetryPolicy.kt
@@ -15,9 +15,9 @@ import kotlin.reflect.safeCast
 /**
  * A standard retry policy which attempts to derive information from the Smithy exception hierarchy.
  */
-open class StandardRetryPolicy : RetryPolicy<Any?> {
-    companion object {
-        val Default = StandardRetryPolicy()
+public open class StandardRetryPolicy : RetryPolicy<Any?> {
+    public companion object {
+        public val Default: StandardRetryPolicy = StandardRetryPolicy()
     }
 
     private val evaluationStrategies = sequenceOf(

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smithy/Document.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smithy/Document.kt
@@ -9,11 +9,11 @@ package aws.smithy.kotlin.runtime.smithy
  *
  * The provided casting functions (eg. [asInt], [asMap]) allow callers to unwrap contents of the Document at runtime.
  */
-sealed class Document {
+public sealed class Document {
     /**
      * Wraps a [kotlin.Number] of arbitrary precision.
      */
-    data class Number(val value: kotlin.Number) : Document() {
+    public data class Number(val value: kotlin.Number) : Document() {
         init {
             if (value is Double && !value.isFinite() || value is Float && !value.isFinite()) {
                 throw IllegalArgumentException(
@@ -22,37 +22,37 @@ sealed class Document {
             }
         }
 
-        override fun toString() = value.toString()
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**
      * Wraps a [kotlin.String].
      */
-    data class String(val value: kotlin.String) : Document() {
-        override fun toString() = "\"$value\""
+    public data class String(val value: kotlin.String) : Document() {
+        override fun toString(): kotlin.String = "\"$value\""
     }
 
     /**
      * Wraps a [kotlin.Boolean].
      */
-    data class Boolean(val value: kotlin.Boolean) : Document() {
-        override fun toString() = value.toString()
+    public data class Boolean(val value: kotlin.Boolean) : Document() {
+        override fun toString(): kotlin.String = value.toString()
     }
 
     /**
      * Wraps a [kotlin.collections.List].
      */
-    data class List(val value: kotlin.collections.List<Document?>) :
+    public data class List(val value: kotlin.collections.List<Document?>) :
         Document(), kotlin.collections.List<Document?> by value {
-        override fun toString() = value.joinToString(separator = ",", prefix = "[", postfix = "]")
+        override fun toString(): kotlin.String = value.joinToString(separator = ",", prefix = "[", postfix = "]")
     }
 
     /**
      * Wraps a [kotlin.collections.Map].
      */
-    data class Map(val value: kotlin.collections.Map<kotlin.String, Document?>) :
+    public data class Map(val value: kotlin.collections.Map<kotlin.String, Document?>) :
         Document(), kotlin.collections.Map<kotlin.String, Document?> by value {
-        override fun toString() = value
+        override fun toString(): kotlin.String = value
             .entries
             .joinToString(
                 separator = ",",
@@ -65,58 +65,58 @@ sealed class Document {
     private fun asNumber(): kotlin.Number = (this as Number).value
     private fun asNumberOrNull(): kotlin.Number? = (this as? Number)?.value
 
-    fun asString(): kotlin.String = (this as String).value
-    fun asStringOrNull(): kotlin.String? = (this as? String)?.value
+    public fun asString(): kotlin.String = (this as String).value
+    public fun asStringOrNull(): kotlin.String? = (this as? String)?.value
 
-    fun asBoolean(): kotlin.Boolean = (this as Boolean).value
-    fun asBooleanOrNull(): kotlin.Boolean? = (this as? Boolean)?.value
+    public fun asBoolean(): kotlin.Boolean = (this as Boolean).value
+    public fun asBooleanOrNull(): kotlin.Boolean? = (this as? Boolean)?.value
 
-    fun asList(): kotlin.collections.List<Document?> = (this as List).value
-    fun asListOrNull(): kotlin.collections.List<Document?>? = (this as? List)?.value
+    public fun asList(): kotlin.collections.List<Document?> = (this as List).value
+    public fun asListOrNull(): kotlin.collections.List<Document?>? = (this as? List)?.value
 
-    fun asMap(): kotlin.collections.Map<kotlin.String, Document?> = (this as Map).value
-    fun asMapOrNull(): kotlin.collections.Map<kotlin.String, Document?>? = (this as? Map)?.value
+    public fun asMap(): kotlin.collections.Map<kotlin.String, Document?> = (this as Map).value
+    public fun asMapOrNull(): kotlin.collections.Map<kotlin.String, Document?>? = (this as? Map)?.value
 
-    fun asInt(): Int = asNumber().toInt()
-    fun asIntOrNull(): Int? = asNumberOrNull()?.toInt()
+    public fun asInt(): Int = asNumber().toInt()
+    public fun asIntOrNull(): Int? = asNumberOrNull()?.toInt()
 
-    fun asByte(): Byte = asNumber().toByte()
-    fun asByteOrNull(): Byte? = asNumberOrNull()?.toByte()
+    public fun asByte(): Byte = asNumber().toByte()
+    public fun asByteOrNull(): Byte? = asNumberOrNull()?.toByte()
 
-    fun asShort(): Short = asNumber().toShort()
-    fun asShortOrNull(): Short? = asNumberOrNull()?.toShort()
+    public fun asShort(): Short = asNumber().toShort()
+    public fun asShortOrNull(): Short? = asNumberOrNull()?.toShort()
 
-    fun asLong(): Long = asNumber().toLong()
-    fun asLongOrNull(): Long? = asNumberOrNull()?.toLong()
+    public fun asLong(): Long = asNumber().toLong()
+    public fun asLongOrNull(): Long? = asNumberOrNull()?.toLong()
 
-    fun asFloat(): Float = asNumber().toFloat()
-    fun asFloatOrNull(): Float? = asNumberOrNull()?.toFloat()
+    public fun asFloat(): Float = asNumber().toFloat()
+    public fun asFloatOrNull(): Float? = asNumberOrNull()?.toFloat()
 
-    fun asDouble(): Double = asNumber().toDouble()
-    fun asDoubleOrNull(): Double? = asNumberOrNull()?.toDouble()
+    public fun asDouble(): Double = asNumber().toDouble()
+    public fun asDoubleOrNull(): Double? = asNumberOrNull()?.toDouble()
 }
 
 /**
  * Construct a [Document] from a [Number] of arbitrary precision.
  */
-fun Document(value: Number): Document = Document.Number(value)
+public fun Document(value: Number): Document = Document.Number(value)
 
 /**
  * Construct a [Document] from a [String].
  */
-fun Document(value: String): Document = Document.String(value)
+public fun Document(value: String): Document = Document.String(value)
 
 /**
  * Construct a [Document] from a [Boolean].
  */
-fun Document(value: Boolean): Document = Document.Boolean(value)
+public fun Document(value: Boolean): Document = Document.Boolean(value)
 
 /**
  * Construct a [Document] from a [List].
  */
-fun Document(value: List<Document?>): Document = Document.List(value)
+public fun Document(value: List<Document?>): Document = Document.List(value)
 
 /**
  * Construct a [Document] from a [Map].
  */
-fun Document(value: Map<String, Document?>): Document = Document.Map(value)
+public fun Document(value: Map<String, Document?>): Document = Document.Map(value)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smithy/DocumentBuilder.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/smithy/DocumentBuilder.kt
@@ -6,58 +6,58 @@ package aws.smithy.kotlin.runtime.smithy
 
 import kotlin.jvm.JvmName
 
-class DocumentBuilder internal constructor() {
-    val content: MutableMap<String, Document?> = linkedMapOf()
+public class DocumentBuilder internal constructor() {
+    public val content: MutableMap<String, Document?> = linkedMapOf()
 
-    infix fun String.to(value: Number?) {
+    public infix fun String.to(value: Number?) {
         require(this !in content) { "Key $this is already registered in builder" }
         content[this] = if (value != null) Document(value) else null
     }
 
-    infix fun String.to(value: String?) {
+    public infix fun String.to(value: String?) {
         require(this !in content) { "Key $this is already registered in builder" }
         content[this] = if (value != null) Document(value) else null
     }
 
-    infix fun String.to(value: Boolean?) {
+    public infix fun String.to(value: Boolean?) {
         require(this !in content) { "Key $this is already registered in builder" }
         content[this] = if (value != null) Document(value) else null
     }
 
-    infix fun String.to(value: Document?) {
+    public infix fun String.to(value: Document?) {
         require(this !in content) { "Key $this is already registered in builder" }
         content[this] = value
     }
 
-    infix fun String.to(@Suppress("UNUSED_PARAMETER") value: Nothing?) {
+    public infix fun String.to(@Suppress("UNUSED_PARAMETER") value: Nothing?) {
         require(this !in content) { "Key $this is already registered in builder" }
         content[this] = null
     }
 
-    class ListBuilder internal constructor() {
-        val content: MutableList<Document?> = mutableListOf()
+    public class ListBuilder internal constructor() {
+        public val content: MutableList<Document?> = mutableListOf()
 
-        fun add(value: Number?): Boolean =
+        public fun add(value: Number?): Boolean =
             content.add(if (value != null) Document(value) else null)
-        fun add(value: String?): Boolean =
+        public fun add(value: String?): Boolean =
             content.add(if (value != null) Document(value) else null)
-        fun add(value: Boolean?): Boolean =
+        public fun add(value: Boolean?): Boolean =
             content.add(if (value != null) Document(value) else null)
-        fun add(value: Document?): Boolean =
+        public fun add(value: Document?): Boolean =
             content.add(value)
-        fun add(@Suppress("UNUSED_PARAMETER") value: Nothing?): Boolean =
+        public fun add(@Suppress("UNUSED_PARAMETER") value: Nothing?): Boolean =
             content.add(null)
 
-        @JvmName("addAllNumbers") fun addAll(value: List<Number?>) = value.forEach(::add)
-        @JvmName("addAllStrings") fun addAll(value: List<String?>) = value.forEach(::add)
-        @JvmName("addAllBooleans") fun addAll(value: List<Boolean?>) = value.forEach(::add)
-        @JvmName("addAllDocuments") fun addAll(value: List<Document?>) = value.forEach(::add)
+        @JvmName("addAllNumbers") public fun addAll(value: List<Number?>): Unit = value.forEach(::add)
+        @JvmName("addAllStrings") public fun addAll(value: List<String?>): Unit = value.forEach(::add)
+        @JvmName("addAllBooleans") public fun addAll(value: List<Boolean?>): Unit = value.forEach(::add)
+        @JvmName("addAllDocuments") public fun addAll(value: List<Document?>): Unit = value.forEach(::add)
     }
 
     /**
      * Builds a [Document] list with the given builder.
      */
-    fun buildList(init: ListBuilder.() -> Unit): Document =
+    public fun buildList(init: ListBuilder.() -> Unit): Document =
         ListBuilder().let {
             it.init()
             Document(it.content)
@@ -67,7 +67,7 @@ class DocumentBuilder internal constructor() {
 /**
  * Builds a [Document] with the given builder.
  */
-fun buildDocument(init: DocumentBuilder.() -> Unit): Document =
+public fun buildDocument(init: DocumentBuilder.() -> Unit): Document =
     DocumentBuilder().let {
         it.init()
         Document(it.content)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Clock.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Clock.kt
@@ -21,5 +21,5 @@ public interface Clock {
         override fun now(): Instant = Instant.now()
     }
 
-    public companion object {}
+    public companion object
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -20,16 +20,16 @@ internal const val MILLISEC_PER_SEC = 1_000
 internal const val NS_PER_MILLISEC = 1_000_000
 
 // represents a moment on the UTC-SLS time scale
-expect class Instant : Comparable<Instant> {
-    val epochSeconds: Long
-    val nanosecondsOfSecond: Int
+public expect class Instant : Comparable<Instant> {
+    public val epochSeconds: Long
+    public val nanosecondsOfSecond: Int
 
     override operator fun compareTo(other: Instant): Int
 
     /**
      * Encode the [Instant] as a string into the format specified by [TimestampFormat]
      */
-    fun format(fmt: TimestampFormat): String
+    public fun format(fmt: TimestampFormat): String
 
     /**
      * Returns an instant that is the result of adding the specified [duration] to this instant.
@@ -43,49 +43,49 @@ expect class Instant : Comparable<Instant> {
      */
     public operator fun minus(duration: Duration): Instant
 
-    companion object {
+    public companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]
          */
-        fun fromIso8601(ts: String): Instant
+        public fun fromIso8601(ts: String): Instant
 
         /**
          * Parse an RFC5322/RFC-822 formatted string into an [Instant]
          */
-        fun fromRfc5322(ts: String): Instant
+        public fun fromRfc5322(ts: String): Instant
 
         /**
          * Create an [Instant] from its parts
          */
-        fun fromEpochSeconds(seconds: Long, ns: Int = 0): Instant
+        public fun fromEpochSeconds(seconds: Long, ns: Int = 0): Instant
 
         /**
          * Parse a string formatted as epoch-seconds into an [Instant]
          */
-        fun fromEpochSeconds(ts: String): Instant
+        public fun fromEpochSeconds(ts: String): Instant
 
         /**
          * Create an [Instant] from the current system time
          */
-        fun now(): Instant
+        public fun now(): Instant
     }
 }
 
 /**
  * Convert [Instant] to a double representing seconds and milliseconds since the epoch
  */
-fun Instant.toEpochDouble(): Double = epochSeconds.toDouble() + (nanosecondsOfSecond.toDouble() / NS_PER_SEC)
+public fun Instant.toEpochDouble(): Double = epochSeconds.toDouble() + (nanosecondsOfSecond.toDouble() / NS_PER_SEC)
 
 /**
  * Get the epoch milliseconds representation of the [Instant]
  */
-val Instant.epochMilliseconds: Long
+public val Instant.epochMilliseconds: Long
     get() = epochSeconds * MILLISEC_PER_SEC + (nanosecondsOfSecond / NS_PER_MILLISEC)
 
 /**
  * Create an [Instant] from epoch millisecond timestamp
  */
-fun Instant.Companion.fromEpochMilliseconds(milliseconds: Long): Instant {
+public fun Instant.Companion.fromEpochMilliseconds(milliseconds: Long): Instant {
     val secs = milliseconds / MILLISEC_PER_SEC
     val ns = (milliseconds - secs * MILLISEC_PER_SEC) * NS_PER_MILLISEC
     return fromEpochSeconds(secs, ns.toInt())

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/ParserCombinators.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/ParserCombinators.kt
@@ -13,10 +13,10 @@ import aws.smithy.kotlin.runtime.SdkBaseException
  * @property pos The current position parsed to (i.e. the next position to continue parsing the input from)
  * @property result The result type of the parse function
  */
-data class ParseResult<out T>(val pos: Int, val result: T)
+public data class ParseResult<out T>(public val pos: Int, public val result: T)
 
 // takes the input string and the current position to parse from, must return a tuple of (nestPosition, parsed result)
-typealias Parser<T> = (str: String, pos: Int) -> ParseResult<T>
+public typealias Parser<T> = (str: String, pos: Int) -> ParseResult<T>
 
 /**
  * Base parsing exception
@@ -24,21 +24,26 @@ typealias Parser<T> = (str: String, pos: Int) -> ParseResult<T>
  * @param message Additional contextual message around what the failure was
  * @param position The position where the parse failure happened
  */
-open class ParseException(input: String, message: String, position: Int) :
+public open class ParseException(input: String, message: String, position: Int) :
     SdkBaseException("parse `$input`: error at $position: $message")
 
 // internal marker exception
-class TakeWhileMNException(input: String, val lastPos: Int, val expected: Int, val matched: Int) : ParseException(input, "expected at least $expected matches of predicate; only matched $matched", lastPos)
+public class TakeWhileMNException(
+    input: String,
+    lastPos: Int,
+    public val expected: Int,
+    public val matched: Int,
+) : ParseException(input, "expected at least $expected matches of predicate; only matched $matched", lastPos)
 
 /**
  * Contains information on needed data if a parser throws [IncompleteException]
  */
-sealed class Needed {
-    object Unknown : Needed() {
+public sealed class Needed {
+    public object Unknown : Needed() {
         override fun toString(): String = "incomplete input"
     }
 
-    data class Size(val size: Int) : Needed() {
+    public data class Size(public val size: Int) : Needed() {
         override fun toString(): String = "incomplete input needed ($size)"
     }
 }
@@ -49,7 +54,10 @@ sealed class Needed {
  * @param input The input string being parsed
  * @param needed Description of the number of chars still needed (if known)
  */
-class IncompleteException(input: String, val needed: Needed) : ParseException(input, needed.toString(), input.length - 1)
+public class IncompleteException(
+    input: String,
+    public val needed: Needed,
+) : ParseException(input, needed.toString(), input.length - 1)
 
 // parser precondition check. Ensure that the current position is in bounds of the input
 internal fun precond(input: String, pos: Int, need: Int = 0) {
@@ -66,7 +74,7 @@ internal fun precond(input: String, pos: Int, need: Int = 0) {
 /**
  * Test whether the input character is a digit or not
  */
-fun isDigit(chr: Char): Boolean = chr in '0'..'9'
+public fun isDigit(chr: Char): Boolean = chr in '0'..'9'
 
 /**
  * Parse a literal character

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/TimestampFormat.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/TimestampFormat.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.time
 /**
  * Timestamp formats supported
  */
-enum class TimestampFormat {
+public enum class TimestampFormat {
     /**
      * ISO-8601/RFC5399 timestamp including fractional seconds at microsecond precision (e.g.,
      * "2022-04-25T16:44:13.667307Z")

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -16,12 +16,12 @@ import java.nio.file.Path
 /**
  * Create a [ByteStream] from a file
  */
-fun ByteStream.Companion.fromFile(file: File): ByteStream = file.asByteStream()
+public fun ByteStream.Companion.fromFile(file: File): ByteStream = file.asByteStream()
 
 /**
  * Create a [ByteStream] from a file
  */
-fun File.asByteStream(start: Long = 0, endInclusive: Long = length() - 1): ByteStream {
+public fun File.asByteStream(start: Long = 0, endInclusive: Long = length() - 1): ByteStream {
     require(start >= 0) { "start index $start cannot be negative" }
     require(endInclusive == -1L || endInclusive >= start) {
         "end index $endInclusive must be greater than or equal to start index $start"
@@ -36,12 +36,12 @@ fun File.asByteStream(start: Long = 0, endInclusive: Long = length() - 1): ByteS
 /**
  * Create a [ByteStream] from a file with the given range
  */
-fun File.asByteStream(range: LongRange) = asByteStream(range.first, range.last)
+public fun File.asByteStream(range: LongRange): ByteStream = asByteStream(range.first, range.last)
 
 /**
  * Create a [ByteStream] from a path
  */
-fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
+public fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
     val f = toFile()
     require(f.exists()) { "cannot create ByteStream, file does not exist: $this" }
     require(f.isFile) { "cannot create a ByteStream from a directory: $this" }
@@ -51,13 +51,13 @@ fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStream {
 /**
  * Create a [ByteStream] from a path with the given range
  */
-fun Path.asByteStream(range: LongRange) = asByteStream(range.first, range.last)
+public fun Path.asByteStream(range: LongRange): ByteStream = asByteStream(range.first, range.last)
 
 /**
  * Write the contents of this ByteStream to file and close it
  * @return the number of bytes written
  */
-suspend fun ByteStream.writeToFile(file: File): Long {
+public suspend fun ByteStream.writeToFile(file: File): Long {
     val writer = file.writeChannel()
     val src = when (this) {
         is ByteStream.Buffer -> SdkByteReadChannel(bytes())
@@ -77,4 +77,4 @@ suspend fun ByteStream.writeToFile(file: File): Long {
  * Write the contents of this ByteStream to file at the given path
  * @return the number of bytes written
  */
-suspend fun ByteStream.writeToFile(path: Path): Long = writeToFile(path.toFile())
+public suspend fun ByteStream.writeToFile(path: Path): Long = writeToFile(path.toFile())

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/Converters.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/Converters.kt
@@ -7,9 +7,9 @@ package aws.smithy.kotlin.runtime.time
 /**
  * Converts this [aws.smithy.kotlin.runtime.time.Instant] to a [java.time.Instant].
  */
-fun Instant.toJvmInstant(): java.time.Instant = value
+public fun Instant.toJvmInstant(): java.time.Instant = value
 
 /**
  * Converts this [java.time.Instant] to a [aws.smithy.kotlin.runtime.time.Instant].
  */
-fun java.time.Instant.toSdkInstant(): Instant = Instant(this)
+public fun java.time.Instant.toSdkInstant(): Instant = Instant(this)

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -24,10 +24,10 @@ import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
 import java.time.Instant as jtInstant
 
-actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
-    actual val epochSeconds: Long
+public actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
+    public actual val epochSeconds: Long
         get() = value.epochSecond
-    actual val nanosecondsOfSecond: Int
+    public actual val nanosecondsOfSecond: Int
         get() = value.nano
 
     actual override operator fun compareTo(other: Instant): Int = value.compareTo(other.value)
@@ -45,7 +45,7 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
      * If the [duration] is positive, the returned instant is later than this instant.
      * If the [duration] is negative, the returned instant is earlier than this instant.
      */
-    actual operator fun plus(duration: Duration): Instant = duration.toComponents { seconds, nanoseconds ->
+    public actual operator fun plus(duration: Duration): Instant = duration.toComponents { seconds, nanoseconds ->
         fromEpochSeconds(epochSeconds + seconds, nanosecondsOfSecond + nanoseconds)
     }
 
@@ -55,12 +55,12 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
      * If the [duration] is positive, the returned instant is earlier than this instant.
      * If the [duration] is negative, the returned instant is later than this instant.
      */
-    actual operator fun minus(duration: Duration): Instant = plus(-duration)
+    public actual operator fun minus(duration: Duration): Instant = plus(-duration)
 
     /**
      * Encode the [Instant] as a string into the format specified by [TimestampFormat]
      */
-    actual fun format(fmt: TimestampFormat): String = when (fmt) {
+    public actual fun format(fmt: TimestampFormat): String = when (fmt) {
         TimestampFormat.ISO_8601 -> ISO_INSTANT.format(value.truncatedTo(ChronoUnit.MICROS))
         TimestampFormat.ISO_8601_CONDENSED -> ISO_8601_CONDENSED.format(value)
         TimestampFormat.ISO_8601_CONDENSED_DATE -> ISO_8601_CONDENSED_DATE.format(value)
@@ -80,7 +80,7 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
         }
     }
 
-    actual companion object {
+    public actual companion object {
 
         private val RFC_5322_FIXED_DATE_TIME: DateTimeFormatter = buildRfc5322Formatter()
 
@@ -97,7 +97,7 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]
          */
-        actual fun fromIso8601(ts: String): Instant {
+        public actual fun fromIso8601(ts: String): Instant {
             val parsed = parseIso8601(ts)
             return fromParsedDateTime(parsed)
         }
@@ -105,7 +105,7 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
         /**
          * Parse an RFC5322/RFC-822 formatted string into an [Instant]
          */
-        actual fun fromRfc5322(ts: String): Instant {
+        public actual fun fromRfc5322(ts: String): Instant {
             val parsed = parseRfc5322(ts)
             return fromParsedDateTime(parsed)
         }
@@ -113,18 +113,18 @@ actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
         /**
          * Create an [Instant] from it's parts
          */
-        actual fun fromEpochSeconds(seconds: Long, ns: Int): Instant =
+        public actual fun fromEpochSeconds(seconds: Long, ns: Int): Instant =
             Instant(jtInstant.ofEpochSecond(seconds, ns.toLong()))
 
         /**
          * Parse a string formatted as epoch-seconds into an [Instant]
          */
-        actual fun fromEpochSeconds(ts: String): Instant = parseEpoch(ts)
+        public actual fun fromEpochSeconds(ts: String): Instant = parseEpoch(ts)
 
         /**
          * Create an [Instant] from the current system time
          */
-        actual fun now(): Instant = Instant(jtInstant.now())
+        public actual fun now(): Instant = Instant(jtInstant.now())
     }
 }
 
@@ -167,7 +167,7 @@ private fun fromParsedDateTime(parsed: ParsedDatetime): Instant {
  *
  * See also: https: *tools.ietf.org/html/rfc7231.html#section-7.1.1.1
  */
-fun buildRfc5322Formatter(): DateTimeFormatter {
+public fun buildRfc5322Formatter(): DateTimeFormatter {
     // manually code maps to ensure correct data always used
     // (locale data can be changed by application code)
     val dow: Map<Long, String> = mapOf(

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
@@ -53,7 +53,7 @@ import aws.smithy.kotlin.runtime.smithy.Document
  * until it is exhausted and for each element/entry call the appropriate `deserialize*` methods.
  *
  */
-interface Deserializer {
+public interface Deserializer {
     /**
      * Begin deserialization of a structured type. Use the returned [FieldIterator] to drive
      * the deserialization process of the struct to completion.
@@ -64,7 +64,7 @@ interface Deserializer {
      *
      * @param descriptor SdkObjectDescriptor the structure descriptor
      */
-    fun deserializeStruct(descriptor: SdkObjectDescriptor): FieldIterator
+    public fun deserializeStruct(descriptor: SdkObjectDescriptor): FieldIterator
 
     /**
      * Begin deserialization of a list type. Use the returned [ElementIterator] to drive
@@ -75,7 +75,7 @@ interface Deserializer {
      *
      * @param descriptor SdkFieldDescriptor the structure descriptor
      */
-    fun deserializeList(descriptor: SdkFieldDescriptor): ElementIterator
+    public fun deserializeList(descriptor: SdkFieldDescriptor): ElementIterator
 
     /**
      * Begin deserialization of a map type. Use the returned [EntryIterator] to drive
@@ -86,64 +86,64 @@ interface Deserializer {
      *
      * @param descriptor SdkFieldDescriptor the structure descriptor
      */
-    fun deserializeMap(descriptor: SdkFieldDescriptor): EntryIterator
+    public fun deserializeMap(descriptor: SdkFieldDescriptor): EntryIterator
 
     /**
      * Iterator over raw elements in a collection
      */
-    interface ElementIterator : PrimitiveDeserializer {
+    public interface ElementIterator : PrimitiveDeserializer {
         /**
          * Advance to the next element. Returns false when no more elements are in the list
          * or the document has been read completely.
          */
-        fun hasNextElement(): Boolean
+        public fun hasNextElement(): Boolean
 
         /**
          * Returns true if the next token contains a value, or false otherwise.
          */
-        fun nextHasValue(): Boolean
+        public fun nextHasValue(): Boolean
     }
 
     /**
      * Iterator over map entries
      */
-    interface EntryIterator : PrimitiveDeserializer {
+    public interface EntryIterator : PrimitiveDeserializer {
         /**
          * Advance to the next element. Returns false when no more elements are in the map
          * or the document has been read completely.
          */
-        fun hasNextEntry(): Boolean
+        public fun hasNextEntry(): Boolean
 
         /**
          * Read the next key
          */
-        fun key(): String
+        public fun key(): String
 
         /**
          * Returns true if the next token contains a value, or false otherwise.
          */
-        fun nextHasValue(): Boolean
+        public fun nextHasValue(): Boolean
     }
 
     /**
      * Iterator over struct fields
      */
-    interface FieldIterator : PrimitiveDeserializer {
+    public interface FieldIterator : PrimitiveDeserializer {
         /**
          * Returns the index of the next field found, null if fields exhausted, or [UNKNOWN_FIELD].
          */
-        fun findNextFieldIndex(): Int?
+        public fun findNextFieldIndex(): Int?
 
         /**
          * Skip the next field value recursively. Meant for discarding unknown fields
          */
-        fun skipValue()
+        public fun skipValue()
 
-        companion object {
+        public companion object {
             /**
              * An unknown field was encountered
              */
-            const val UNKNOWN_FIELD = -1
+            public const val UNKNOWN_FIELD: Int = -1
         }
     }
 }
@@ -151,46 +151,46 @@ interface Deserializer {
 /**
  * Common interface for deserializing primitive values
  */
-interface PrimitiveDeserializer {
+public interface PrimitiveDeserializer {
     /**
      * Deserialize and return the next token as a [Byte]
      */
-    fun deserializeByte(): Byte
+    public fun deserializeByte(): Byte
 
     /**
      * Deserialize and return the next token as an [Int]
      */
-    fun deserializeInt(): Int
+    public fun deserializeInt(): Int
 
     /**
      * Deserialize and return the next token as a [Short]
      */
-    fun deserializeShort(): Short
+    public fun deserializeShort(): Short
 
     /**
      * Deserialize and return the next token as a [Long]
      */
-    fun deserializeLong(): Long
+    public fun deserializeLong(): Long
 
     /**
      * Deserialize and return the next token as a [Float]
      */
-    fun deserializeFloat(): Float
+    public fun deserializeFloat(): Float
 
     /**
      * Deserialize and return the next token as a [Double]
      */
-    fun deserializeDouble(): Double
+    public fun deserializeDouble(): Double
 
     /**
      * Deserialize and return the next token as a [String]
      */
-    fun deserializeString(): String
+    public fun deserializeString(): String
 
     /**
      * Deserialize and return the next token as a [Boolean]
      */
-    fun deserializeBoolean(): Boolean
+    public fun deserializeBoolean(): Boolean
 
     /**
      * Deserialize and return the next token as a [Document].
@@ -198,25 +198,25 @@ interface PrimitiveDeserializer {
      * If the document's value is a list or map, this method will deserialize all elements or fields recursively - the
      * caller need not further inspect the value to attempt to do so manually.
      */
-    fun deserializeDocument(): Document
+    public fun deserializeDocument(): Document
 
     /**
      * Consume the next token if represents a null value. Always returns null.
      */
-    fun deserializeNull(): Nothing?
+    public fun deserializeNull(): Nothing?
 }
 
-inline fun Deserializer.deserializeStruct(descriptor: SdkObjectDescriptor, block: Deserializer.FieldIterator.() -> Unit) {
+public inline fun Deserializer.deserializeStruct(descriptor: SdkObjectDescriptor, block: Deserializer.FieldIterator.() -> Unit) {
     val deserializer = deserializeStruct(descriptor)
     block(deserializer)
 }
 
-inline fun <T> Deserializer.deserializeList(descriptor: SdkFieldDescriptor, block: Deserializer.ElementIterator.() -> T): T {
+public inline fun <T> Deserializer.deserializeList(descriptor: SdkFieldDescriptor, block: Deserializer.ElementIterator.() -> T): T {
     val deserializer = deserializeList(descriptor)
     return block(deserializer)
 }
 
-inline fun <T> Deserializer.deserializeMap(descriptor: SdkFieldDescriptor, block: Deserializer.EntryIterator.() -> T): T {
+public inline fun <T> Deserializer.deserializeMap(descriptor: SdkFieldDescriptor, block: Deserializer.EntryIterator.() -> T): T {
     val deserializer = deserializeMap(descriptor)
     return block(deserializer)
 }

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Exceptions.kt
@@ -9,27 +9,27 @@ import aws.smithy.kotlin.runtime.ClientException
 /**
  * Exception class for all serialization errors
  */
-class SerializationException : ClientException {
+public class SerializationException : ClientException {
 
-    constructor() : super()
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 }
 
 /**
  * Exception class for all deserialization errors
  */
-class DeserializationException : ClientException {
+public class DeserializationException : ClientException {
 
-    constructor() : super()
+    public constructor() : super()
 
-    constructor(message: String?) : super(message)
+    public constructor(message: String?) : super(message)
 
-    constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
 
-    constructor(cause: Throwable?) : super(cause)
+    public constructor(cause: Throwable?) : super(cause)
 }

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor.kt
@@ -11,35 +11,35 @@ package aws.smithy.kotlin.runtime.serde
  * For example, to specify that a list should be serialized in XML such that values are wrapped
  * in a tag called "boo", pass an instance of XmlList to the FieldDescriptor of `XmlList(elementName="boo")`.
  */
-interface FieldTrait
+public interface FieldTrait
 
 /**
  * Denotes that a Map or List may contain null values
  * Details at https://awslabs.github.io/smithy/1.0/spec/core/type-refinement-traits.html#sparse-trait
  */
-object SparseValues : FieldTrait
+public object SparseValues : FieldTrait
 
 /**
  * A protocol-agnostic type description of a field.
  */
-sealed class SerialKind {
-    object Unit : SerialKind()
-    object Integer : SerialKind()
-    object Long : SerialKind()
-    object Double : SerialKind()
-    object String : SerialKind()
-    object Boolean : SerialKind()
-    object Byte : SerialKind()
-    object Char : SerialKind()
-    object Short : SerialKind()
-    object Float : SerialKind()
-    object Map : SerialKind()
-    object List : SerialKind()
-    object Struct : SerialKind()
-    object Timestamp : SerialKind()
-    object Blob : SerialKind()
-    object Document : SerialKind()
-    object BigNumber : SerialKind()
+public sealed class SerialKind {
+    public object Unit : SerialKind()
+    public object Integer : SerialKind()
+    public object Long : SerialKind()
+    public object Double : SerialKind()
+    public object String : SerialKind()
+    public object Boolean : SerialKind()
+    public object Byte : SerialKind()
+    public object Char : SerialKind()
+    public object Short : SerialKind()
+    public object Float : SerialKind()
+    public object Map : SerialKind()
+    public object List : SerialKind()
+    public object Struct : SerialKind()
+    public object Timestamp : SerialKind()
+    public object Blob : SerialKind()
+    public object Document : SerialKind()
+    public object BigNumber : SerialKind()
 
     override fun toString(): kotlin.String = this::class.simpleName ?: "SerialKind"
 }
@@ -47,12 +47,16 @@ sealed class SerialKind {
 /**
  * Metadata to describe how a given member property maps to serialization.
  */
-open class SdkFieldDescriptor(val kind: SerialKind, var index: Int = 0, val traits: Set<FieldTrait> = emptySet()) {
-    constructor(kind: SerialKind, vararg trait: FieldTrait) : this(kind, 0, trait.toSet())
-    constructor(kind: SerialKind, traits: Set<FieldTrait>) : this(kind, 0, traits)
+public open class SdkFieldDescriptor(
+    public val kind: SerialKind,
+    public var index: Int = 0,
+    public val traits: Set<FieldTrait> = emptySet(),
+) {
+    public constructor(kind: SerialKind, vararg trait: FieldTrait) : this(kind, 0, trait.toSet())
+    public constructor(kind: SerialKind, traits: Set<FieldTrait>) : this(kind, 0, traits)
 
     // Reserved for format-specific companion extension functions
-    companion object;
+    public companion object;
 
     override fun toString(): String = "SdkFieldDescriptor.$kind(traits=${traits.joinToString(separator = ",") })"
 }
@@ -60,14 +64,14 @@ open class SdkFieldDescriptor(val kind: SerialKind, var index: Int = 0, val trai
 /**
  * Returns the singleton instance of required Trait, or IllegalArgumentException if does not exist.
  */
-inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.expectTrait(): TExpected {
+public inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.expectTrait(): TExpected {
     val x = traits.find { it::class == TExpected::class }
     requireNotNull(x) { "Expected to find trait ${TExpected::class} in $this but was not present." }
 
     return x as TExpected
 }
 
-inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.findTrait(): TExpected? {
+public inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.findTrait(): TExpected? {
     val x = traits.find { it::class == TExpected::class }
 
     return x as? TExpected
@@ -76,9 +80,10 @@ inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.findTrait(): TExp
 /**
  * Find a set of traits of the given type.
  */
-inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.findTraits(): Set<TExpected> = traits
+public inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.findTraits(): Set<TExpected> = traits
     .filter { it::class == TExpected::class }
     .map { it as TExpected }
     .toSet()
 
-inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.hasTrait() = traits.any { it is TExpected }
+public inline fun <reified TExpected : FieldTrait> SdkFieldDescriptor.hasTrait(): Boolean =
+    traits.any { it is TExpected }

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor.kt
@@ -7,25 +7,25 @@ package aws.smithy.kotlin.runtime.serde
 /**
  * Metadata container for all fields of an object/class
  */
-class SdkObjectDescriptor private constructor(builder: Builder) : SdkFieldDescriptor(
+public class SdkObjectDescriptor private constructor(builder: Builder) : SdkFieldDescriptor(
     kind = SerialKind.Struct, traits = builder.traits
 ) {
-    val fields: List<SdkFieldDescriptor> = builder.fields
+    public val fields: List<SdkFieldDescriptor> = builder.fields
 
-    companion object {
-        inline fun build(block: Builder.() -> Unit): SdkObjectDescriptor = Builder().apply(block).build()
+    public companion object {
+        public inline fun build(block: Builder.() -> Unit): SdkObjectDescriptor = Builder().apply(block).build()
     }
 
-    class Builder {
+    public class Builder {
         internal val fields: MutableList<SdkFieldDescriptor> = mutableListOf()
         internal val traits: MutableSet<FieldTrait> = mutableSetOf()
 
-        fun field(field: SdkFieldDescriptor) {
+        public fun field(field: SdkFieldDescriptor) {
             field.index = fields.size
             fields.add(field)
         }
 
-        fun trait(trait: FieldTrait) {
+        public fun trait(trait: FieldTrait) {
             traits.add(trait)
         }
 

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkSerializable.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkSerializable.kt
@@ -4,16 +4,16 @@
  */
 package aws.smithy.kotlin.runtime.serde
 
-interface SdkSerializable {
-    fun serialize(serializer: Serializer)
+public interface SdkSerializable {
+    public fun serialize(serializer: Serializer)
 }
 
 // FIXME - baby steps
 // Glue code for marrying raw serialize functions to SdkSerializable
 
-typealias SerializeFn<T> = (serializer: Serializer, input: T) -> Unit
+public typealias SerializeFn<T> = (serializer: Serializer, input: T) -> Unit
 
-fun <T> StructSerializer.field(descriptor: SdkFieldDescriptor, input: T, serializeFn: SerializeFn<T>) {
+public fun <T> StructSerializer.field(descriptor: SdkFieldDescriptor, input: T, serializeFn: SerializeFn<T>) {
     field(descriptor, SdkSerializableLambda(input, serializeFn))
 }
 
@@ -27,4 +27,4 @@ private data class SdkSerializableLambda<T>(
 }
 
 // FIXME - this causes backing classes to be generated behind the scenes and contributes to the overall jar size
-fun <T> asSdkSerializable(input: T, serializeFn: SerializeFn<T>): SdkSerializable = SdkSerializableLambda(input, serializeFn)
+public fun <T> asSdkSerializable(input: T, serializeFn: SerializeFn<T>): SdkSerializable = SdkSerializableLambda(input, serializeFn)

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
@@ -7,27 +7,27 @@ import aws.smithy.kotlin.runtime.smithy.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 
-interface Serializer : PrimitiveSerializer {
+public interface Serializer : PrimitiveSerializer {
     /**
      * Begin a struct (i.e. in JSON this would be a '{') and return a [StructSerializer] that can be used to serialize the struct's fields.
      *
      * @param descriptor SdkFieldDescriptor of container for formats that require them.
      */
-    fun beginStruct(descriptor: SdkFieldDescriptor): StructSerializer
+    public fun beginStruct(descriptor: SdkFieldDescriptor): StructSerializer
 
     /**
      * Begin a list (i.e. in JSON this would be a '[') and return a [ListSerializer] that can be used to serialize the list's elements.
      *
      * @param descriptor SdkFieldDescriptor of container for formats that require them.
      */
-    fun beginList(descriptor: SdkFieldDescriptor): ListSerializer
+    public fun beginList(descriptor: SdkFieldDescriptor): ListSerializer
 
     /**
      * Begin a map (i.e. in JSON this would be a '{') and return a [MapSerializer] that can be used to serialize the map's entries.
      *
      * @param descriptor SdkFieldDescriptor of container for formats that require them.
      */
-    fun beginMap(descriptor: SdkFieldDescriptor): MapSerializer
+    public fun beginMap(descriptor: SdkFieldDescriptor): MapSerializer
 
     // FIXME - we should commonize how we deal with buffers internally and rely on `SdkBuffer`
     //  (likely once we roll our own json/xml serializers). Until then this should probably return a ByteStream?
@@ -35,10 +35,10 @@ interface Serializer : PrimitiveSerializer {
     /**
      * Consume the serializer and get the payload as a [ByteArray]
      */
-    fun toByteArray(): ByteArray
+    public fun toByteArray(): ByteArray
 }
 
-interface StructSerializer : PrimitiveSerializer {
+public interface StructSerializer : PrimitiveSerializer {
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -47,7 +47,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Boolean)
+    public fun field(descriptor: SdkFieldDescriptor, value: Boolean)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -56,7 +56,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Byte)
+    public fun field(descriptor: SdkFieldDescriptor, value: Byte)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -65,7 +65,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Short)
+    public fun field(descriptor: SdkFieldDescriptor, value: Short)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -74,7 +74,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Char)
+    public fun field(descriptor: SdkFieldDescriptor, value: Char)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -83,7 +83,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Int)
+    public fun field(descriptor: SdkFieldDescriptor, value: Int)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -92,7 +92,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Long)
+    public fun field(descriptor: SdkFieldDescriptor, value: Long)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -101,7 +101,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Float)
+    public fun field(descriptor: SdkFieldDescriptor, value: Float)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -110,7 +110,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Double)
+    public fun field(descriptor: SdkFieldDescriptor, value: Double)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -119,7 +119,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: String)
+    public fun field(descriptor: SdkFieldDescriptor, value: String)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -128,7 +128,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Instant, format: TimestampFormat)
+    public fun field(descriptor: SdkFieldDescriptor, value: Instant, format: TimestampFormat)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -137,7 +137,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: Document?)
+    public fun field(descriptor: SdkFieldDescriptor, value: Document?)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -146,7 +146,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param value
      */
-    fun field(descriptor: SdkFieldDescriptor, value: SdkSerializable)
+    public fun field(descriptor: SdkFieldDescriptor, value: SdkSerializable)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -155,7 +155,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param block
      */
-    fun structField(descriptor: SdkFieldDescriptor, block: StructSerializer.() -> Unit)
+    public fun structField(descriptor: SdkFieldDescriptor, block: StructSerializer.() -> Unit)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -164,7 +164,7 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param block
      */
-    fun listField(descriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit)
+    public fun listField(descriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -173,35 +173,35 @@ interface StructSerializer : PrimitiveSerializer {
      * @param descriptor
      * @param block
      */
-    fun mapField(descriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit)
+    public fun mapField(descriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit)
 
     /**
      * Writes the field name given in the descriptor, and then
      * serializes null.
      */
-    fun nullField(descriptor: SdkFieldDescriptor)
+    public fun nullField(descriptor: SdkFieldDescriptor)
 
     /**
      * Ends the struct that was started (i.e. in JSON this would be a '}').
      */
-    fun endStruct()
+    public fun endStruct()
 }
 
 /**
  * Serializes a list.
  */
-interface ListSerializer : PrimitiveSerializer {
+public interface ListSerializer : PrimitiveSerializer {
 
     /**
      * Ends the list that was started (i.e. in JSON this would be a ']').
      */
-    fun endList()
+    public fun endList()
 }
 
 /**
  * Serializes a map. In Smithy, keys in maps are always Strings.
  */
-interface MapSerializer : PrimitiveSerializer {
+public interface MapSerializer : PrimitiveSerializer {
 
     /**
      * Writes the key given in the descriptor, and then
@@ -210,7 +210,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Boolean?)
+    public fun entry(key: String, value: Boolean?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -219,7 +219,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Byte?)
+    public fun entry(key: String, value: Byte?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -228,7 +228,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Short?)
+    public fun entry(key: String, value: Short?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -237,7 +237,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Char?)
+    public fun entry(key: String, value: Char?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -246,7 +246,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Int?)
+    public fun entry(key: String, value: Int?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -255,7 +255,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Long?)
+    public fun entry(key: String, value: Long?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -264,7 +264,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Float?)
+    public fun entry(key: String, value: Float?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -273,7 +273,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Double?)
+    public fun entry(key: String, value: Double?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -282,7 +282,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: String?)
+    public fun entry(key: String, value: String?)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -291,7 +291,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: Instant?, format: TimestampFormat)
+    public fun entry(key: String, value: Instant?, format: TimestampFormat)
 
     /**
      * Writes the key given in the descriptor, and then
@@ -300,7 +300,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param key
      * @param value
      */
-    fun entry(key: String, value: SdkSerializable?)
+    public fun entry(key: String, value: SdkSerializable?)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -310,7 +310,7 @@ interface MapSerializer : PrimitiveSerializer {
      * @param listDescriptor
      * @param block
      */
-    fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit)
+    public fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit)
 
     /**
      * Writes the field name given in the descriptor, and then
@@ -320,111 +320,111 @@ interface MapSerializer : PrimitiveSerializer {
      * @param mapDescriptor
      * @param block
      */
-    fun mapEntry(key: String, mapDescriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit)
+    public fun mapEntry(key: String, mapDescriptor: SdkFieldDescriptor, block: MapSerializer.() -> Unit)
 
     /**
      * Ends the map that was started (i.e. in JSON this would be a '}').
      */
-    fun endMap()
+    public fun endMap()
 }
 
 /**
  * Used to serialize primitive values.
  */
-interface PrimitiveSerializer {
+public interface PrimitiveSerializer {
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeBoolean(value: Boolean)
+    public fun serializeBoolean(value: Boolean)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeByte(value: Byte)
+    public fun serializeByte(value: Byte)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeShort(value: Short)
+    public fun serializeShort(value: Short)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeChar(value: Char)
+    public fun serializeChar(value: Char)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeInt(value: Int)
+    public fun serializeInt(value: Int)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeLong(value: Long)
+    public fun serializeLong(value: Long)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeFloat(value: Float)
+    public fun serializeFloat(value: Float)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeDouble(value: Double)
+    public fun serializeDouble(value: Double)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeString(value: String)
+    public fun serializeString(value: String)
 
     /**
      * Serializes the given value.
      *
      * @param value
      */
-    fun serializeInstant(value: Instant, format: TimestampFormat)
+    public fun serializeInstant(value: Instant, format: TimestampFormat)
 
     /**
      * Calls the serialize method on the given object.
      *
      * @param value
      */
-    fun serializeSdkSerializable(value: SdkSerializable)
+    public fun serializeSdkSerializable(value: SdkSerializable)
 
     /**
      * Serializes the given value.
      */
-    fun serializeNull()
+    public fun serializeNull()
 
     /**
      * Serializes the given value.
      */
-    fun serializeDocument(value: Document?)
+    public fun serializeDocument(value: Document?)
 }
 
 /**
  * All components of a struct are expected to be serialized in the given block.
  */
-inline fun Serializer.serializeStruct(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: StructSerializer.() -> Unit) {
+public inline fun Serializer.serializeStruct(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: StructSerializer.() -> Unit) {
     val struct = beginStruct(sdkFieldDescriptor)
     struct.block()
     struct.endStruct()
@@ -433,7 +433,7 @@ inline fun Serializer.serializeStruct(sdkFieldDescriptor: SdkFieldDescriptor, cr
 /**
  * All elements of a list are expected to be serialized in the given block.
  */
-inline fun Serializer.serializeList(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: ListSerializer.() -> Unit) {
+public inline fun Serializer.serializeList(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: ListSerializer.() -> Unit) {
     val list = beginList(sdkFieldDescriptor)
     list.block()
     list.endList()
@@ -442,7 +442,7 @@ inline fun Serializer.serializeList(sdkFieldDescriptor: SdkFieldDescriptor, cros
 /**
  * All entries of a map are expected to be serialized in the given block.
  */
-inline fun Serializer.serializeMap(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: MapSerializer.() -> Unit) {
+public inline fun Serializer.serializeMap(sdkFieldDescriptor: SdkFieldDescriptor, crossinline block: MapSerializer.() -> Unit) {
     val map = beginMap(sdkFieldDescriptor)
     map.block()
     map.endMap()

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
@@ -16,7 +16,7 @@ import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-fun FormUrlSerializer(): Serializer = FormUrlSerializer(SdkByteBuffer(256u))
+public fun FormUrlSerializer(): Serializer = FormUrlSerializer(SdkByteBuffer(256u))
 
 private class FormUrlSerializer(
     val buffer: SdkByteBuffer,

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/Traits.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/Traits.kt
@@ -11,7 +11,7 @@ import aws.smithy.kotlin.runtime.serde.SdkFieldDescriptor
 /**
  * Specifies a name that a field is encoded into for form-url elements.
  */
-data class FormUrlSerialName(val name: String) : FieldTrait
+public data class FormUrlSerialName(public val name: String) : FieldTrait
 
 /**
  * Trait that adds a static `key=value` pair to a form-url encoded object
@@ -27,13 +27,13 @@ data class FormUrlSerialName(val name: String) : FieldTrait
  * }
  * ```
  */
-data class QueryLiteral(val key: String, val value: String) : FieldTrait
+public data class QueryLiteral(public val key: String, public val value: String) : FieldTrait
 
 /**
  * Indicates that the container should be serialized in "flattened" form.
  * See: https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#collections
  */
-object FormUrlFlattened : FieldTrait
+public object FormUrlFlattened : FieldTrait
 
 /**
  * Specifies member name used when encoding a List/Set structure.
@@ -44,15 +44,13 @@ object FormUrlFlattened : FieldTrait
  *
  * @param name the name to use which prefixes each list or set member
  */
-data class FormUrlCollectionName(
-    val member: String
-) : FieldTrait {
-    companion object {
+public data class FormUrlCollectionName(public val member: String) : FieldTrait {
+    public companion object {
         /**
          * The default serialized name for a list or set member.
          * This default is specified here: https://awslabs.github.io/smithy/1.0/spec/aws/aws-query-protocol.html#query-key-resolution
          */
-        val Default = FormUrlCollectionName("member")
+        public val Default: FormUrlCollectionName = FormUrlCollectionName("member")
     }
 }
 /**
@@ -65,15 +63,15 @@ data class FormUrlCollectionName(
  * @param key the name of the key field
  * @param value the name of the value field
  */
-data class FormUrlMapName(
-    val key: String = Default.key,
-    val value: String = Default.value
+public data class FormUrlMapName(
+    public val key: String = Default.key,
+    public val value: String = Default.value,
 ) : FieldTrait {
-    companion object {
+    public companion object {
         /**
          * The default serialized names for aspects of a Map in XML.
          * These defaults are specified here: https://awslabs.github.io/smithy/spec/xml.html#map-serialization
          */
-        val Default = FormUrlMapName("key", "value")
+        public val Default: FormUrlMapName = FormUrlMapName("key", "value")
     }
 }

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -12,8 +12,8 @@ import aws.smithy.kotlin.runtime.smithy.Document
  *
  * @param payload underlying document from which tokens are read
  */
-class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementIterator, Deserializer.EntryIterator, PrimitiveDeserializer {
-    companion object {
+public class JsonDeserializer(payload: ByteArray) : Deserializer, Deserializer.ElementIterator, Deserializer.EntryIterator, PrimitiveDeserializer {
+    public companion object {
         private val validNumberStrings = setOf("Infinity", "-Infinity", "NaN")
     }
 

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonFieldTraits.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonFieldTraits.kt
@@ -12,10 +12,10 @@ import aws.smithy.kotlin.runtime.serde.expectTrait
 /**
  * Specifies a name that a field is encoded into for Json elements.
  */
-data class JsonSerialName(val name: String) : FieldTrait
+public data class JsonSerialName(public val name: String) : FieldTrait
 
 /**
  * Provides the serialized name of the field.
  */
-val SdkFieldDescriptor.serialName: String
+public val SdkFieldDescriptor.serialName: String
     get() = expectTrait<JsonSerialName>().name

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
@@ -9,8 +9,8 @@ import aws.smithy.kotlin.runtime.smithy.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 
-class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructSerializer {
-    companion object {
+public class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructSerializer {
+    public companion object {
         private val doublesToStringify = setOf(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN)
         private val floatsToStringify = setOf(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NaN)
     }

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamReader.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamReader.kt
@@ -10,34 +10,34 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 /**
  * Interface for deserializing JSON documents as a stream of tokens
  */
-interface JsonStreamReader {
+public interface JsonStreamReader {
     /**
      * Grab the next token in the stream
      */
-    fun nextToken(): JsonToken
+    public fun nextToken(): JsonToken
 
     /**
      * Recursively skip the next token. Meant for discarding unwanted/unrecognized properties in a JSON document
      */
-    fun skipNext()
+    public fun skipNext()
 
     /**
      * Peek at the next token type
      */
-    fun peek(): JsonToken
+    public fun peek(): JsonToken
 }
 
 /*
 * Creates a [JsonStreamReader] instance
 */
 @InternalApi
-fun jsonStreamReader(payload: ByteArray): JsonStreamReader = JsonLexer(payload)
+public fun jsonStreamReader(payload: ByteArray): JsonStreamReader = JsonLexer(payload)
 
 /**
  * Return the next token and require that it be of type [TExpected] or else throw an exception
  */
 @InternalApi
-inline fun <reified TExpected : JsonToken> JsonStreamReader.nextTokenOf(): TExpected {
+public inline fun <reified TExpected : JsonToken> JsonStreamReader.nextTokenOf(): TExpected {
     val token = this.nextToken()
     requireToken<TExpected>(token)
     return token as TExpected
@@ -47,7 +47,7 @@ inline fun <reified TExpected : JsonToken> JsonStreamReader.nextTokenOf(): TExpe
  * Require that the given token be of type [TExpected] or else throw an exception
  */
 @InternalApi
-inline fun <reified TExpected> requireToken(token: JsonToken) {
+public inline fun <reified TExpected> requireToken(token: JsonToken) {
     if (token::class != TExpected::class) {
         throw DeserializationException("expected ${TExpected::class}; found ${token::class}")
     }

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamWriter.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonStreamWriter.kt
@@ -10,63 +10,63 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * Interface for serialization. Specific formats should implement this interface according to their
  * own requirements. Currently only aws.smithy.kotlin.runtime.serde.json.JsonSerializer implements this interface.
  */
-interface JsonStreamWriter {
+public interface JsonStreamWriter {
 
     /**
      * Begins encoding a new array. Each call to this method must be paired with
      * a call to {@link #endArray}.
      */
-    fun beginArray()
+    public fun beginArray()
 
     /**
      * Ends encoding the current array.
      */
-    fun endArray()
+    public fun endArray()
 
     /**
      * Encodes {@code null}.
      */
-    fun writeNull()
+    public fun writeNull()
 
     /**
      * Begins encoding a new object. Each call to this method must be paired
      * with a call to {@link #endObject}.
      */
-    fun beginObject()
+    public fun beginObject()
 
     /**
      * Ends encoding the current object.
      */
-    fun endObject()
+    public fun endObject()
 
     /**
      * Encodes the property name.
      *
      * @param name the name of the forthcoming value. May not be null.
      */
-    fun writeName(name: String)
+    public fun writeName(name: String)
 
     /**
      * Encodes {@code value}.
      *
      * @param value the literal string value, or null to encode a null literal.
      */
-    fun writeValue(value: String)
+    public fun writeValue(value: String)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(bool: Boolean)
+    public fun writeValue(bool: Boolean)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Number)
+    public fun writeValue(value: Number)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Long)
+    public fun writeValue(value: Long)
 
     /**
      * Encodes {@code value}.
@@ -74,41 +74,41 @@ interface JsonStreamWriter {
      * @param value a finite value. May not be {@link Double#isNaN() NaNs} or
      *     {@link Double#isInfinite() infinities}.
      */
-    fun writeValue(value: Double)
+    public fun writeValue(value: Double)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Float)
+    public fun writeValue(value: Float)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Short)
+    public fun writeValue(value: Short)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Int)
+    public fun writeValue(value: Int)
 
     /**
      * Encodes {@code value}.
      */
-    fun writeValue(value: Byte)
+    public fun writeValue(value: Byte)
 
     /**
      * Appends the contents of [value] *without* any additional formatting or escaping. Use with caution
      */
-    fun writeRawValue(value: String)
+    public fun writeRawValue(value: String)
 
     /**
      * Json content will be constructed in this UTF-8 encoded byte array.
      */
-    val bytes: ByteArray?
+    public val bytes: ByteArray?
 }
 
 /**
  * Creates a [JsonStreamWriter] instance to write JSON
  */
 @InternalApi
-fun jsonStreamWriter(pretty: Boolean = false): JsonStreamWriter = JsonEncoder(pretty)
+public fun jsonStreamWriter(pretty: Boolean = false): JsonStreamWriter = JsonEncoder(pretty)

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonToken.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonToken.kt
@@ -7,58 +7,58 @@ package aws.smithy.kotlin.runtime.serde.json
 /**
  * Raw tokens produced when reading a JSON document as a stream
  */
-sealed class JsonToken {
+public sealed class JsonToken {
     /**
      * The opening of a JSON array '['
      */
-    object BeginArray : JsonToken()
+    public object BeginArray : JsonToken()
 
     /**
      * The closing of a JSON array ']'
      */
-    object EndArray : JsonToken()
+    public object EndArray : JsonToken()
 
     /**
      * The opening of a JSON object '{'
      */
-    object BeginObject : JsonToken()
+    public object BeginObject : JsonToken()
 
     /**
      * The closing of a JSON object '}'
      */
-    object EndObject : JsonToken()
+    public object EndObject : JsonToken()
 
     /**
      * A JSON property name
      */
-    data class Name(val value: kotlin.String) : JsonToken()
+    public data class Name(val value: kotlin.String) : JsonToken()
 
     /**
      * A JSON string
      */
-    data class String(val value: kotlin.String) : JsonToken()
+    public data class String(val value: kotlin.String) : JsonToken()
 
     /**
      * A JSON number (note the raw string value of the number is returned, you are responsible for converting
      * to a concrete [Number] type)
      */
-    data class Number(val value: kotlin.String) : JsonToken()
+    public data class Number(val value: kotlin.String) : JsonToken()
 
     /**
      * A JSON boolean
      */
-    data class Bool(val value: Boolean) : JsonToken()
+    public data class Bool(val value: Boolean) : JsonToken()
 
     /**
      * A JSON 'null'
      */
-    object Null : JsonToken()
+    public object Null : JsonToken()
 
     /**
      * The end of the JSON stream to signal that the JSON-encoded value has no more
      * tokens
      */
-    object EndDocument : JsonToken()
+    public object EndDocument : JsonToken()
 
     override fun toString(): kotlin.String = when (this) {
         BeginArray -> "BeginArray"

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -26,12 +26,12 @@ internal sealed class FieldLocation {
  * restXml based services DO NOT always send documents with a root element name that matches the shape ID name
  * (S3 in particular). This means there is nothing in the model that gives you enough information to validate the tag.
  */
-class XmlDeserializer(
+public class XmlDeserializer(
     private val reader: XmlStreamReader,
     private val validateRootElement: Boolean = false
 ) : Deserializer {
 
-    constructor(input: ByteArray, validateRootElement: Boolean = false) : this(xmlStreamReader(input), validateRootElement)
+    public constructor(input: ByteArray, validateRootElement: Boolean = false) : this(xmlStreamReader(input), validateRootElement)
 
     private var firstStructCall = true
 

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlFieldTraits.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlFieldTraits.kt
@@ -20,17 +20,17 @@ import aws.smithy.kotlin.runtime.serde.*
  * @param key the name of the key field
  * @param value the name of the value field
  */
-data class XmlMapName(
-    val entry: String? = Default.entry,
-    val key: String = Default.key,
-    val value: String = Default.value
+public data class XmlMapName(
+    public val entry: String? = Default.entry,
+    public val key: String = Default.key,
+    public val value: String = Default.value
 ) : FieldTrait {
-    companion object {
+    public companion object {
         /**
          * The default serialized names for aspects of a Map in XML.
          * These defaults are specified here: https://awslabs.github.io/smithy/spec/xml.html#map-serialization
          */
-        val Default = XmlMapName("entry", "key", "value")
+        public val Default: XmlMapName = XmlMapName("entry", "key", "value")
     }
 }
 
@@ -43,15 +43,15 @@ data class XmlMapName(
  *
  * @param element the name of the XML node which wraps each list or set entry.
  */
-data class XmlCollectionName(
-    val element: String
+public data class XmlCollectionName(
+    public val element: String
 ) : FieldTrait {
-    companion object {
+    public companion object {
         /**
          * The default serialized name for a list or set element.
          * This default is specified here: https://awslabs.github.io/smithy/spec/xml.html#list-and-set-serialization
          */
-        val Default = XmlCollectionName("member")
+        public val Default: XmlCollectionName = XmlCollectionName("member")
     }
 }
 
@@ -59,7 +59,7 @@ data class XmlCollectionName(
  * Denotes a collection type that uses a flattened XML representation
  * see: [xmlflattened trait](https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html#xmlflattened-trait)
  */
-object Flattened : FieldTrait
+public object Flattened : FieldTrait
 
 /**
  * Denotes a structure that represents an error.  There are special rules for error deserialization
@@ -71,15 +71,15 @@ object Flattened : FieldTrait
  * NOTE/FIXME: This type was written to handle the restXml protocol handling but could be refactored to be more
  *       general purpose if/when necessary to support other XML-based protocols.
  */
-object XmlError : FieldTrait {
-    val errorTag: XmlToken.QualifiedName = XmlToken.QualifiedName("Error")
+public object XmlError : FieldTrait {
+    public val errorTag: XmlToken.QualifiedName = XmlToken.QualifiedName("Error")
 }
 
 /**
  * Base class for more specific XML namespace traits
  */
-open class AbstractXmlNamespaceTrait(val uri: String, val prefix: String? = null) {
-    fun isDefault() = prefix == null
+public open class AbstractXmlNamespaceTrait(public val uri: String, public val prefix: String? = null) {
+    public fun isDefault(): Boolean = prefix == null
     override fun toString(): String = "AbstractXmlNamespace(uri=$uri, prefix=$prefix)"
 }
 
@@ -87,30 +87,32 @@ open class AbstractXmlNamespaceTrait(val uri: String, val prefix: String? = null
  * Describes the namespace associated with a field.
  * See https://awslabs.github.io/smithy/spec/xml.html#xmlnamespace-trait
  */
-class XmlNamespace(uri: String, prefix: String? = null) : AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
+public class XmlNamespace(uri: String, prefix: String? = null) : AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
 
 /**
  * Describes the namespace of a list or map's value element
  * Applies to [SerialKind.List] or [SerialKind.Map]
  */
-class XmlCollectionValueNamespace(uri: String, prefix: String? = null) : AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
+public class XmlCollectionValueNamespace(uri: String, prefix: String? = null) :
+    AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
 
 /**
  * Describes the namespace associated with a map's key element
  * Applies to [SerialKind.Map]
  */
-class XmlMapKeyNamespace(uri: String, prefix: String? = null) : AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
+public class XmlMapKeyNamespace(uri: String, prefix: String? = null) :
+    AbstractXmlNamespaceTrait(uri, prefix), FieldTrait
 
 /**
  * Specifies the name that a field is encoded into for Xml nodes.
  * See https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html?highlight=xmlname#xmlname-trait
  */
-data class XmlSerialName(val name: String) : FieldTrait
+public data class XmlSerialName(public val name: String) : FieldTrait
 
 /**
  * Specifies an alternate name that can be used to match an XML node.
  */
-data class XmlAliasName(val name: String) : FieldTrait
+public data class XmlAliasName(public val name: String) : FieldTrait
 
 private fun toQualifiedName(xmlNamespace: XmlNamespace?, name: String?): XmlToken.QualifiedName {
     val (localName, prefix) = name
@@ -182,7 +184,7 @@ internal fun String.parseNodeWithPrefix(): Pair<String, String?> =
  * Specifies that a field is encoded into an XML attribute and describes the XML.
  * See https://awslabs.github.io/smithy/spec/xml.html#xmlattribute-trait
  */
-object XmlAttribute : FieldTrait
+public object XmlAttribute : FieldTrait
 
 /**
  * Provides the serialized name of the field.

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
@@ -15,7 +15,7 @@ import aws.smithy.kotlin.runtime.util.*
  * @param xmlWriter where content is serialize to
  */
 // TODO - mark class internal and remove integration tests once serde is stable
-class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) : Serializer, StructSerializer {
+public class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) : Serializer, StructSerializer {
 
     // FIXME - clean up stack to distinguish between mutable/immutable and move to utils? (e.g. MutableStack<T> = mutableStackOf())
     private var nodeStack: ListStack<String> = mutableListOf()
@@ -98,28 +98,29 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
     private fun numberField(descriptor: SdkFieldDescriptor, value: Number) =
         tagOrAttribute(descriptor, value, ::serializeNumber)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Boolean) =
+    override fun field(descriptor: SdkFieldDescriptor, value: Boolean): Unit =
         tagOrAttribute(descriptor, value, ::serializeBoolean)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Byte) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Byte): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Char) =
+    override fun field(descriptor: SdkFieldDescriptor, value: Char): Unit =
         tagOrAttribute(descriptor, value, ::serializeChar)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Short) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Short): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Int) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Int): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Long) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Long): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Float) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Float): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Double) = numberField(descriptor, value)
+    override fun field(descriptor: SdkFieldDescriptor, value: Double): Unit = numberField(descriptor, value)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: String) =
+    override fun field(descriptor: SdkFieldDescriptor, value: String): Unit =
         tagOrAttribute(descriptor, value, ::serializeString)
 
-    override fun field(descriptor: SdkFieldDescriptor, value: Instant, format: TimestampFormat) = field(descriptor, value.format(format))
+    override fun field(descriptor: SdkFieldDescriptor, value: Instant, format: TimestampFormat): Unit =
+        field(descriptor, value.format(format))
 
     override fun field(descriptor: SdkFieldDescriptor, value: Document?) {
         throw SerializationException(
@@ -155,21 +156,21 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
 
     override fun serializeBoolean(value: Boolean) { xmlWriter.text(value.toString()) }
 
-    override fun serializeByte(value: Byte) = serializeNumber(value)
+    override fun serializeByte(value: Byte): Unit = serializeNumber(value)
 
     override fun serializeChar(value: Char) { xmlWriter.text(value.toString()) }
 
-    override fun serializeShort(value: Short) = serializeNumber(value)
+    override fun serializeShort(value: Short): Unit = serializeNumber(value)
 
-    override fun serializeInt(value: Int) = serializeNumber(value)
+    override fun serializeInt(value: Int): Unit = serializeNumber(value)
 
-    override fun serializeLong(value: Long) = serializeNumber(value)
+    override fun serializeLong(value: Long): Unit = serializeNumber(value)
 
-    override fun serializeFloat(value: Float) = serializeNumber(value)
+    override fun serializeFloat(value: Float): Unit = serializeNumber(value)
 
-    override fun serializeDouble(value: Double) = serializeNumber(value)
+    override fun serializeDouble(value: Double): Unit = serializeNumber(value)
 
-    private fun serializeNumber(value: Number) = xmlWriter.text(value)
+    private fun serializeNumber(value: Number): Unit = xmlWriter.text(value)
 
     override fun serializeString(value: String) {
         xmlWriter.text(value)
@@ -179,7 +180,7 @@ class XmlSerializer(private val xmlWriter: XmlStreamWriter = xmlStreamWriter()) 
         xmlWriter.text(value.format(format))
     }
 
-    override fun serializeSdkSerializable(value: SdkSerializable) = value.serialize(this)
+    override fun serializeSdkSerializable(value: SdkSerializable): Unit = value.serialize(this)
 }
 
 private class XmlMapSerializer(
@@ -214,15 +215,15 @@ private class XmlMapSerializer(
         }
     }
 
-    override fun entry(key: String, value: Int?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Int?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Long?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Long?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Float?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Float?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: String?) = writeEntry(key) { xmlWriter.text(value ?: "") }
+    override fun entry(key: String, value: String?): Unit = writeEntry(key) { xmlWriter.text(value ?: "") }
 
-    override fun entry(key: String, value: SdkSerializable?) = writeEntry(key) {
+    override fun entry(key: String, value: SdkSerializable?): Unit = writeEntry(key) {
         if (value == null) {
             xmlWriter.text("")
             return@writeEntry
@@ -233,17 +234,17 @@ private class XmlMapSerializer(
         xmlSerializer.parentDescriptorStack.pop()
     }
 
-    override fun entry(key: String, value: Double?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Double?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Boolean?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Boolean?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Byte?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Byte?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Short?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Short?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Char?) = writeEntry(key) { xmlWriter.text(value.toString()) }
+    override fun entry(key: String, value: Char?): Unit = writeEntry(key) { xmlWriter.text(value.toString()) }
 
-    override fun entry(key: String, value: Instant?, format: TimestampFormat) = entry(key, value?.format(format))
+    override fun entry(key: String, value: Instant?, format: TimestampFormat): Unit = entry(key, value?.format(format))
 
     override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
         writeEntry(key) {
@@ -262,27 +263,27 @@ private class XmlMapSerializer(
         }
     }
 
-    override fun serializeBoolean(value: Boolean) = serializePrimitive(value)
+    override fun serializeBoolean(value: Boolean): Unit = serializePrimitive(value)
 
-    override fun serializeByte(value: Byte) = serializePrimitive(value)
+    override fun serializeByte(value: Byte): Unit = serializePrimitive(value)
 
-    override fun serializeShort(value: Short) = serializePrimitive(value)
+    override fun serializeShort(value: Short): Unit = serializePrimitive(value)
 
-    override fun serializeChar(value: Char) = serializePrimitive(value)
+    override fun serializeChar(value: Char): Unit = serializePrimitive(value)
 
-    override fun serializeInt(value: Int) = serializePrimitive(value)
+    override fun serializeInt(value: Int): Unit = serializePrimitive(value)
 
-    override fun serializeLong(value: Long) = serializePrimitive(value)
+    override fun serializeLong(value: Long): Unit = serializePrimitive(value)
 
-    override fun serializeFloat(value: Float) = serializePrimitive(value)
+    override fun serializeFloat(value: Float): Unit = serializePrimitive(value)
 
-    override fun serializeDouble(value: Double) = serializePrimitive(value)
+    override fun serializeDouble(value: Double): Unit = serializePrimitive(value)
 
-    override fun serializeString(value: String) = serializePrimitive(value)
+    override fun serializeString(value: String): Unit = serializePrimitive(value)
 
-    override fun serializeSdkSerializable(value: SdkSerializable) = value.serialize(xmlSerializer)
+    override fun serializeSdkSerializable(value: SdkSerializable): Unit = value.serialize(xmlSerializer)
 
-    override fun serializeInstant(value: Instant, format: TimestampFormat) = serializeString(value.format(format))
+    override fun serializeInstant(value: Instant, format: TimestampFormat): Unit = serializeString(value.format(format))
 
     override fun serializeNull() {
         val tagName = descriptor.findTrait<XmlMapName>()?.value ?: XmlMapName.Default.value
@@ -320,23 +321,23 @@ private class XmlListSerializer(
             else -> descriptor.findTrait<XmlCollectionName>()?.element ?: XmlCollectionName.Default.element
         }
 
-    override fun serializeBoolean(value: Boolean) = serializePrimitive(value)
+    override fun serializeBoolean(value: Boolean): Unit = serializePrimitive(value)
 
-    override fun serializeByte(value: Byte) = serializePrimitive(value)
+    override fun serializeByte(value: Byte): Unit = serializePrimitive(value)
 
-    override fun serializeShort(value: Short) = serializePrimitive(value)
+    override fun serializeShort(value: Short): Unit = serializePrimitive(value)
 
-    override fun serializeChar(value: Char) = serializePrimitive(value)
+    override fun serializeChar(value: Char): Unit = serializePrimitive(value)
 
-    override fun serializeInt(value: Int) = serializePrimitive(value)
+    override fun serializeInt(value: Int): Unit = serializePrimitive(value)
 
-    override fun serializeLong(value: Long) = serializePrimitive(value)
+    override fun serializeLong(value: Long): Unit = serializePrimitive(value)
 
-    override fun serializeFloat(value: Float) = serializePrimitive(value)
+    override fun serializeFloat(value: Float): Unit = serializePrimitive(value)
 
-    override fun serializeDouble(value: Double) = serializePrimitive(value)
+    override fun serializeDouble(value: Double): Unit = serializePrimitive(value)
 
-    override fun serializeString(value: String) = serializePrimitive(value)
+    override fun serializeString(value: String): Unit = serializePrimitive(value)
 
     override fun serializeSdkSerializable(value: SdkSerializable) {
         xmlSerializer.parentDescriptorStack.push(descriptor)
@@ -356,7 +357,7 @@ private class XmlListSerializer(
         throw SerializationException("document values not supported by xml serializer")
     }
 
-    override fun serializeInstant(value: Instant, format: TimestampFormat) = serializeString(value.format(format))
+    override fun serializeInstant(value: Instant, format: TimestampFormat): Unit = serializeString(value.format(format))
 
     private fun serializePrimitive(value: Any) {
         val ns = descriptor.findTrait<XmlCollectionValueNamespace>()

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
@@ -14,11 +14,11 @@ import aws.smithy.kotlin.runtime.serde.xml.deserialization.XmlLexer
  * supports the ability to look ahead an arbitrary number of elements.  It can also
  * create "views" to subtrees of the document, guaranteeing that clients do not exceed bounds.
  */
-interface XmlStreamReader {
+public interface XmlStreamReader {
     /**
      * Specify the depth for which a subtree is created.
      */
-    enum class SubtreeStartDepth {
+    public enum class SubtreeStartDepth {
         /**
          * The subtree's minimum depth is the same as the current node depth.
          */
@@ -31,33 +31,33 @@ interface XmlStreamReader {
     /**
      * Return the last token that was consumed by the reader.
      */
-    val lastToken: XmlToken?
+    public val lastToken: XmlToken?
 
     /**
      * Return another reader that starts and terminates at the current level (CURRENT) or the
      * current level + 1 (CHILD), starting at the next node to be read from the stream.
      * @param subtreeStartDepth Determines minimum depth of the subtree
      */
-    fun subTreeReader(subtreeStartDepth: SubtreeStartDepth = SubtreeStartDepth.CHILD): XmlStreamReader
+    public fun subTreeReader(subtreeStartDepth: SubtreeStartDepth = SubtreeStartDepth.CHILD): XmlStreamReader
 
     /**
      * Return the next actionable token or null if stream is exhausted.
      *
      * @throws [aws.smithy.kotlin.runtime.serde.DeserializationException] upon any error.
      */
-    fun nextToken(): XmlToken?
+    public fun nextToken(): XmlToken?
 
     /**
      * Recursively skip the next token. Meant for discarding unwanted/unrecognized nodes in an XML document
      */
-    fun skipNext()
+    public fun skipNext()
 
     /**
      * Peek at the next token type.  Successive calls will return the same value, meaning there is only one
      * look-ahead at any given time during the parsing of input data.
      * @param index a positive integer representing index of node from current to peek.  Index of 1 is the next node.
      */
-    fun peek(index: Int = 1): XmlToken?
+    public fun peek(index: Int = 1): XmlToken?
 }
 
 /**
@@ -65,7 +65,7 @@ interface XmlStreamReader {
  *
  * @param selectionPredicate predicate that evaluates nodes of the required type to match
  */
-inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate: (T) -> Boolean = { true }): T? {
+public inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate: (T) -> Boolean = { true }): T? {
     var token: XmlToken? = lastToken
 
     do {
@@ -79,7 +79,7 @@ inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate: (T) -
 /**
  * Creates an [XmlStreamReader] instance
  */
-fun xmlStreamReader(payload: ByteArray): XmlStreamReader {
+public fun xmlStreamReader(payload: ByteArray): XmlStreamReader {
     val stream = StringTextStream(payload.decodeToString())
     val lexer = XmlLexer(stream)
     return LexingXmlStreamReader(lexer)

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter.kt
@@ -11,18 +11,18 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 /**
  * Defines an interface to serialization of an XML Infoset.
  */
-interface XmlStreamWriter {
+public interface XmlStreamWriter {
 
     /**
      * Write the XML declaration.
      */
-    fun startDocument()
+    public fun startDocument()
 
     /**
      * Finish writing. All unclosed start tags will be closed and output
      * will be flushed.
      */
-    fun endDocument()
+    public fun endDocument()
 
     /**
      * Writes a start tag with the given namespace and name.
@@ -36,7 +36,7 @@ interface XmlStreamWriter {
      * or throw IllegalStateException if default namespace is already bound
      * to non-empty string.
      */
-    fun startTag(name: String, namespace: String? = null): XmlStreamWriter
+    public fun startTag(name: String, namespace: String? = null): XmlStreamWriter
 
     /**
      * Write an attribute. Calls to attribute() MUST follow a call to
@@ -45,35 +45,35 @@ interface XmlStreamWriter {
      * If namespace is null or empty string
      * no namespace prefix is printed but just name.
      */
-    fun attribute(name: String, value: String?, namespace: String? = null): XmlStreamWriter
+    public fun attribute(name: String, value: String?, namespace: String? = null): XmlStreamWriter
 
     /**
      * Write end tag. Repetition of namespace and name is just for avoiding errors.
      */
-    fun endTag(name: String, namespace: String? = null): XmlStreamWriter
+    public fun endTag(name: String, namespace: String? = null): XmlStreamWriter
 
     /**
      * Writes text, where special XML chars are escaped automatically
      */
-    fun text(text: String): XmlStreamWriter
+    public fun text(text: String): XmlStreamWriter
 
     /**
      * Set the namespace prefix
      */
-    fun namespacePrefix(uri: String, prefix: String? = null)
+    public fun namespacePrefix(uri: String, prefix: String? = null)
 
     /**
      * Gets the byte serialization for this writer. Note that this will call [endDocument] first, closing all open tags.
      */
-    val bytes: ByteArray
+    public val bytes: ByteArray
 
     /**
      *
      */
-    val text: String
+    public val text: String
 }
 
-fun XmlStreamWriter.text(text: Number) {
+public fun XmlStreamWriter.text(text: Number) {
     this.text(text.toString())
 }
 
@@ -81,4 +81,4 @@ fun XmlStreamWriter.text(text: Number) {
 * Creates a [XmlStreamWriter] instance to write XML
 */
 @InternalApi
-fun xmlStreamWriter(pretty: Boolean = false): XmlStreamWriter = BufferingXmlStreamWriter(pretty)
+public fun xmlStreamWriter(pretty: Boolean = false): XmlStreamWriter = BufferingXmlStreamWriter(pretty)

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlToken.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlToken.kt
@@ -8,24 +8,24 @@ package aws.smithy.kotlin.runtime.serde.xml
 /**
  * Raw tokens produced when reading an XML document as a stream
  */
-sealed class XmlToken {
+public sealed class XmlToken {
 
-    abstract val depth: Int
+    public abstract val depth: Int
 
     /**
      * An namespace declaration (xmlns)
      */
-    data class Namespace(val uri: String, val prefix: String? = null)
+    public data class Namespace(public val uri: String, public val prefix: String? = null)
 
     /**
      * Defines the name and namespace of an element
      * @property local The localized name of an element
      * @property prefix The namespace this element belongs to
      */
-    data class QualifiedName(val local: String, val prefix: String? = null) {
+    public data class QualifiedName(public val local: String, public val prefix: String? = null) {
         override fun toString(): String = tag
 
-        val tag: String get() = when (prefix) {
+        public val tag: String get() = when (prefix) {
             null -> local
             else -> "$prefix:$local"
         }
@@ -34,16 +34,16 @@ sealed class XmlToken {
     /**
      * The opening of an XML element
      */
-    data class BeginElement(
+    public data class BeginElement(
         override val depth: Int,
-        val name: QualifiedName,
-        val attributes: Map<QualifiedName, String> = emptyMap(),
-        val nsDeclarations: List<Namespace> = emptyList()
+        public val name: QualifiedName,
+        public val attributes: Map<QualifiedName, String> = emptyMap(),
+        public val nsDeclarations: List<Namespace> = emptyList()
     ) : XmlToken() {
         // Convenience constructor for name-only nodes.
-        constructor(depth: Int, name: String) : this(depth, QualifiedName(name))
+        public constructor(depth: Int, name: String) : this(depth, QualifiedName(name))
         // Convenience constructor for name-only nodes with attributes.
-        constructor(depth: Int, name: String, attributes: Map<QualifiedName, String>) : this(depth, QualifiedName(name), attributes)
+        public constructor(depth: Int, name: String, attributes: Map<QualifiedName, String>) : this(depth, QualifiedName(name), attributes)
 
         override fun toString(): String = "<${this.name} (${this.depth})>"
     }
@@ -51,9 +51,9 @@ sealed class XmlToken {
     /**
      * The closing of an XML element
      */
-    data class EndElement(override val depth: Int, val name: QualifiedName) : XmlToken() {
+    public data class EndElement(override val depth: Int, public val name: QualifiedName) : XmlToken() {
         // Convenience constructor for name-only nodes.
-        constructor(depth: Int, name: String) : this(depth, QualifiedName(name))
+        public constructor(depth: Int, name: String) : this(depth, QualifiedName(name))
 
         override fun toString(): String = "</${this.name}> (${this.depth})"
     }
@@ -61,11 +61,11 @@ sealed class XmlToken {
     /**
      * An XML element text as string
      */
-    data class Text(override val depth: Int, val value: String?) : XmlToken() {
+    public data class Text(override val depth: Int, public val value: String?) : XmlToken() {
         override fun toString(): String = "${this.value} (${this.depth})"
     }
 
-    object StartDocument : XmlToken() {
+    public object StartDocument : XmlToken() {
         override val depth: Int = 0
     }
 
@@ -73,7 +73,7 @@ sealed class XmlToken {
      * The end of the XML stream to signal that the XML-encoded value has no more
      * tokens
      */
-    object EndDocument : XmlToken() {
+    public object EndDocument : XmlToken() {
         override val depth: Int
             get() = 0
     }

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/LexingXmlStreamReader.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/LexingXmlStreamReader.kt
@@ -14,7 +14,7 @@ import aws.smithy.kotlin.runtime.serde.xml.terminates
  * state, [lastToken], etc., but delegates all parsing operations to the scanner.
  * @param source The [XmlLexer] to use for XML parsing.
  */
-class LexingXmlStreamReader(private val source: XmlLexer) : XmlStreamReader {
+public class LexingXmlStreamReader(private val source: XmlLexer) : XmlStreamReader {
     private val peekQueue = ArrayDeque<XmlToken>()
 
     /**

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/StringTextStream.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/StringTextStream.kt
@@ -16,7 +16,7 @@ private val nonAscii = """[^\x20-\x7E]""".toRegex()
  * stream is **not** advanced by `peek` operations.
  * @param source The source text for this stream.
  */
-class StringTextStream(private val source: String) {
+public class StringTextStream(private val source: String) {
     private val end = source.length
     private var offset = 0
 
@@ -25,7 +25,7 @@ class StringTextStream(private val source: String) {
      * stream.
      * @param length The length by which to advance the stream position.
      */
-    fun advance(length: Int, errCondition: String) {
+    public fun advance(length: Int, errCondition: String) {
         checkBounds(length, errCondition)
         offset += length
     }
@@ -35,7 +35,7 @@ class StringTextStream(private val source: String) {
      * @param text The text to look for at the current offset.
      * @return True if the given [text] was found and the offset was advanced; otherwise, false.
      */
-    fun advanceIf(text: String): Boolean =
+    public fun advanceIf(text: String): Boolean =
         if (source.startsWith(text, offset)) {
             offset += text.length
             true
@@ -46,7 +46,7 @@ class StringTextStream(private val source: String) {
     /**
      * Advances the position until a whitespace character is found (i.e., one of ' ', '\r', '\n', '\t').
      */
-    fun advanceUntilSpace() {
+    public fun advanceUntilSpace() {
         while (offset < end) {
             val ch = source[offset]
             if (ch == ' ' || ch == '\r' || ch == '\n' || ch == '\t') return
@@ -57,7 +57,7 @@ class StringTextStream(private val source: String) {
     /**
      * Advances the position until a non-whitespace character is found (i.e., not one of ' ', '\r', '\n', '\t').
      */
-    fun advanceWhileSpace() {
+    public fun advanceWhileSpace() {
         while (offset < end) {
             val ch = source[offset]
             if (ch != ' ' && ch != '\r' && ch != '\n' && ch != '\t') return
@@ -106,7 +106,7 @@ class StringTextStream(private val source: String) {
     /**
      * Determines if the next several characters in the stream match the given text without advancing the position.
      */
-    fun peekMatches(text: String): Boolean {
+    public fun peekMatches(text: String): Boolean {
         val actualLength = min(text.length, end - offset)
         return sliceByLength(actualLength) == text
     }
@@ -116,7 +116,7 @@ class StringTextStream(private val source: String) {
      * would be exceeded.
      * @param errCondition The condition to include in an error message if necessary.
      */
-    fun readOrThrow(errCondition: String): Char {
+    public fun readOrThrow(errCondition: String): Char {
         checkBounds(1, errCondition)
         return source[offset++]
     }
@@ -128,7 +128,7 @@ class StringTextStream(private val source: String) {
      * @param errCondition The condition to include in an error message if necessary.
      * @return The stream contents from the current position up to and including [text].
      */
-    fun readThrough(text: String, errCondition: String): String {
+    public fun readThrough(text: String, errCondition: String): String {
         val charIndex = source.indexOf(text, startIndex = offset)
         if (charIndex < 0) error("Unexpected end-of-doc while $errCondition")
 
@@ -145,7 +145,7 @@ class StringTextStream(private val source: String) {
      * @param errCondition The condition to include in an error message if necessary.
      * @return The stream contents from the current position up to but not including [text].
      */
-    fun readUntil(text: String, errCondition: String): String {
+    public fun readUntil(text: String, errCondition: String): String {
         val charIndex = source.indexOf(text, startIndex = offset)
         if (charIndex < 0) error("Unexpected end-of-doc while $errCondition")
 
@@ -158,7 +158,7 @@ class StringTextStream(private val source: String) {
      * Returns an XML name from the stream and advances the position. Throws an exception if unable to find a valid XML
      * name start character. See https://www.w3.org/TR/xml/#NT-Name for name character rules.
      */
-    fun readWhileXmlName(): String {
+    public fun readWhileXmlName(): String {
         val c = source[offset]
         if (
             !(
@@ -221,7 +221,7 @@ class StringTextStream(private val source: String) {
      * @param length The amount of characters to go back.
      * @param errCondition The condition to include in an error message if necessary.
      */
-    fun rewind(length: Int, errCondition: String) {
+    public fun rewind(length: Int, errCondition: String) {
         checkBounds(-length, errCondition)
         offset -= length
     }

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer.kt
@@ -34,10 +34,10 @@ private fun AttributeMap.extractNsDeclarations(): Pair<AttributeMap, List<XmlTok
 /**
  * A lexer that scans a [StringTextStream] and reads [XmlToken] elements.
  */
-class XmlLexer(internal val source: StringTextStream) {
+public class XmlLexer(internal val source: StringTextStream) {
     private var state: LexerState = LexerState.Initial
 
-    val endOfDocument: Boolean
+    public val endOfDocument: Boolean
         get() = state == LexerState.EndOfDocument
 
     /**
@@ -51,7 +51,7 @@ class XmlLexer(internal val source: StringTextStream) {
      * Parses the next token from the source.
      * @return The next [XmlToken] in the source, or null if the end of the source has been reached.
      */
-    fun parseNext(): XmlToken? = when (val currentState = this.state) {
+    public fun parseNext(): XmlToken? = when (val currentState = this.state) {
         LexerState.EndOfDocument -> null
 
         is LexerState.Tag.EmptyTag -> {

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode.kt
@@ -15,27 +15,27 @@ import aws.smithy.kotlin.runtime.util.*
  * DOM representation of an XML document
  */
 @InternalApi
-class XmlNode {
-    val name: XmlToken.QualifiedName
+public class XmlNode {
+    public val name: XmlToken.QualifiedName
 
     // child element name (local) -> children
-    val children: MutableMap<String, MutableList<XmlNode>> = linkedMapOf()
-    var text: String? = null
-    val attributes: MutableMap<XmlToken.QualifiedName, String> = linkedMapOf()
+    public val children: MutableMap<String, MutableList<XmlNode>> = linkedMapOf()
+    public var text: String? = null
+    public val attributes: MutableMap<XmlToken.QualifiedName, String> = linkedMapOf()
     // namespaces declared by this node
-    val namespaces: MutableList<XmlToken.Namespace> = mutableListOf()
-    var parent: XmlNode? = null
+    public val namespaces: MutableList<XmlToken.Namespace> = mutableListOf()
+    public var parent: XmlNode? = null
 
-    constructor(name: String) : this(XmlToken.QualifiedName(name))
-    constructor(name: XmlToken.QualifiedName) {
+    public constructor(name: String) : this(XmlToken.QualifiedName(name))
+    public constructor(name: XmlToken.QualifiedName) {
         this.name = name
     }
 
     override fun toString(): String = "XmlNode($name)"
 
-    companion object {
+    public companion object {
 
-        fun parse(xmlpayload: ByteArray): XmlNode {
+        public fun parse(xmlpayload: ByteArray): XmlNode {
             val reader = xmlStreamReader(xmlpayload)
             return parseDom(reader)
         }
@@ -46,7 +46,7 @@ class XmlNode {
         }
     }
 
-    fun addChild(child: XmlNode) {
+    public fun addChild(child: XmlNode) {
         val name = requireNotNull(child.name) { "child must have a name" }
         val childNodes = children.getOrPut(name.local) {
             mutableListOf()
@@ -58,7 +58,7 @@ class XmlNode {
 }
 
 // parse a string into a dom representation
-fun parseDom(reader: XmlStreamReader): XmlNode {
+public fun parseDom(reader: XmlStreamReader): XmlNode {
 
     val nodeStack: ListStack<XmlNode> = mutableListOf()
 
@@ -101,7 +101,7 @@ fun parseDom(reader: XmlStreamReader): XmlNode {
     return nodeStack.pop()
 }
 
-fun XmlNode.toXmlString(pretty: Boolean = false): String {
+public fun XmlNode.toXmlString(pretty: Boolean = false): String {
     val sb = StringBuilder()
     formatXmlNode(this, 0, sb, pretty)
     return sb.toString()

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/FormUrlAssertions.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/FormUrlAssertions.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 /**
  * Assert x-www-form-url strings for equality ignoring key order
  */
-fun assertFormUrlStringsEqual(expected: String, actual: String) {
+public fun assertFormUrlStringsEqual(expected: String, actual: String) {
     val expectedAsMap = expected.parseAsFormUrlMap()
     val actualAsMap = actual.parseAsFormUrlMap()
 
@@ -25,7 +25,7 @@ fun assertFormUrlStringsEqual(expected: String, actual: String) {
 /**
  * Assert HTTP bodies are equal as x-www-form-url documents
  */
-suspend fun assertFormUrlBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
+public suspend fun assertFormUrlBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
     val expectedStr = expected?.readAll()?.decodeToString()
     val actualStr = actual?.readAll()?.decodeToString()
     if (expectedStr == null && actualStr == null) {

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
@@ -17,6 +17,7 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -50,7 +51,7 @@ private class MockEngineException : RuntimeException()
  * }
  * ```
  */
-fun httpRequestTest(block: HttpRequestTestBuilder.() -> Unit) = runTest {
+public fun httpRequestTest(block: HttpRequestTestBuilder.() -> Unit): TestResult = runTest {
     // setup expectations
     val testBuilder = HttpRequestTestBuilder().apply(block)
 
@@ -142,31 +143,31 @@ private suspend fun assertRequest(expected: ExpectedHttpRequest, actual: HttpReq
     expected.bodyAssert?.invoke(expectedBody, actual.body)
 }
 
-data class ExpectedHttpRequest(
+public data class ExpectedHttpRequest(
     // the HTTP method expected
-    val method: HttpMethod = HttpMethod.GET,
+    public val method: HttpMethod = HttpMethod.GET,
     // expected path without the query string (e.g. /foo/bar)
-    val uri: String = "",
+    public val uri: String = "",
     // query parameter names AND the associated values that must appear
-    val queryParams: List<Pair<String, String>> = listOf(),
+    public val queryParams: List<Pair<String, String>> = listOf(),
     // query parameter names that MUST not appear
-    val forbiddenQueryParams: List<String> = listOf(),
+    public val forbiddenQueryParams: List<String> = listOf(),
     // query parameter names that MUST appear but no assertion on values
-    val requiredQueryParams: List<String> = listOf(),
+    public val requiredQueryParams: List<String> = listOf(),
     // header names AND values that must appear
-    val headers: Map<String, String> = mapOf(),
+    public val headers: Map<String, String> = mapOf(),
     // header names that must not appear
-    val forbiddenHeaders: List<String> = listOf(),
+    public val forbiddenHeaders: List<String> = listOf(),
     // header names that must appear but no assertion on values
-    val requiredHeaders: List<String> = listOf(),
+    public val requiredHeaders: List<String> = listOf(),
     // the host / endpoint that the client should send to, not including the path or scheme
-    var resolvedHost: String? = null,
+    public var resolvedHost: String? = null,
     // if no body is defined no assertions are made about it
-    val body: String? = null,
+    public val body: String? = null,
     // actual function to use for the assertion
-    val bodyAssert: BodyAssertFn? = null,
+    public val bodyAssert: BodyAssertFn? = null,
     // if not defined no assertion is made
-    val bodyMediaType: String? = null
+    public val bodyMediaType: String? = null
 )
 
 /**
@@ -177,23 +178,23 @@ data class ExpectedHttpRequest(
  * The function will be passed the [expected] contents and the [actual] read contents
  * from the built request as a string.
  */
-typealias BodyAssertFn = suspend (expected: HttpBody?, actual: HttpBody?) -> Unit
+public typealias BodyAssertFn = suspend (expected: HttpBody?, actual: HttpBody?) -> Unit
 
-class ExpectedHttpRequestBuilder {
-    var method: HttpMethod = HttpMethod.GET
-    var uri: String = ""
-    var queryParams: List<Pair<String, String>> = listOf()
-    var forbiddenQueryParams: List<String> = listOf()
-    var requiredQueryParams: List<String> = listOf()
-    var headers: Map<String, String> = mapOf()
-    var forbiddenHeaders: List<String> = listOf()
-    var requiredHeaders: List<String> = listOf()
-    var resolvedHost: String? = null
-    var body: String? = null
-    var bodyAssert: BodyAssertFn? = null
-    var bodyMediaType: String? = null
+public class ExpectedHttpRequestBuilder {
+    public var method: HttpMethod = HttpMethod.GET
+    public var uri: String = ""
+    public var queryParams: List<Pair<String, String>> = listOf()
+    public var forbiddenQueryParams: List<String> = listOf()
+    public var requiredQueryParams: List<String> = listOf()
+    public var headers: Map<String, String> = mapOf()
+    public var forbiddenHeaders: List<String> = listOf()
+    public var requiredHeaders: List<String> = listOf()
+    public var resolvedHost: String? = null
+    public var body: String? = null
+    public var bodyAssert: BodyAssertFn? = null
+    public var bodyMediaType: String? = null
 
-    fun build(): ExpectedHttpRequest =
+    public fun build(): ExpectedHttpRequest =
         ExpectedHttpRequest(
             this.method,
             this.uri,
@@ -210,14 +211,14 @@ class ExpectedHttpRequestBuilder {
         )
 }
 
-class HttpRequestTestBuilder {
+public class HttpRequestTestBuilder {
     internal var runOperation: suspend (mockEngine: HttpClientEngine) -> Unit = {}
     internal var expected = ExpectedHttpRequestBuilder()
 
     /**
      * Setup the expected HTTP request that the service operation should produce
      */
-    fun expected(block: ExpectedHttpRequestBuilder.() -> Unit) {
+    public fun expected(block: ExpectedHttpRequestBuilder.() -> Unit) {
         expected.apply(block)
     }
 
@@ -227,7 +228,7 @@ class HttpRequestTestBuilder {
      * service client with the provided engine, providing the input, and executing the
      * operation (which *MUST* be the last statement in the block).
      */
-    fun operation(block: suspend (mockEngine: HttpClientEngine) -> Unit) {
+    public fun operation(block: suspend (mockEngine: HttpClientEngine) -> Unit) {
         runOperation = block
     }
 }

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -16,26 +16,27 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
-typealias HttpResponseTestFn<T> = suspend (expectedResponse: T?, mockEngine: HttpClientEngine) -> Unit
+public typealias HttpResponseTestFn<T> = suspend (expectedResponse: T?, mockEngine: HttpClientEngine) -> Unit
 
-class ExpectedHttpResponse<T> {
-    var statusCode: HttpStatusCode = HttpStatusCode.OK
-    var headers: Map<String, String> = mapOf()
-    var body: String? = null
-    var bodyMediaType: String? = null
-    var response: T? = null
+public class ExpectedHttpResponse<T> {
+    public var statusCode: HttpStatusCode = HttpStatusCode.OK
+    public var headers: Map<String, String> = mapOf()
+    public var body: String? = null
+    public var bodyMediaType: String? = null
+    public var response: T? = null
 }
 
-class HttpResponseTestBuilder<T> {
+public class HttpResponseTestBuilder<T> {
     internal var expected: ExpectedHttpResponse<T> = ExpectedHttpResponse()
     internal var testFn: HttpResponseTestFn<T> = { _, _ -> }
 
     /**
      * Setup the expected HTTP response that the service operation should consume
      */
-    fun expected(block: ExpectedHttpResponse<T>.() -> Unit) {
+    public fun expected(block: ExpectedHttpResponse<T>.() -> Unit) {
         expected.apply(block)
     }
 
@@ -45,7 +46,7 @@ class HttpResponseTestBuilder<T> {
      * service client with the provided engine, providing the input, and executing the
      * operation.
      */
-    fun test(block: HttpResponseTestFn<T>) {
+    public fun test(block: HttpResponseTestFn<T>) {
         testFn = block
     }
 }
@@ -77,7 +78,7 @@ class HttpResponseTestBuilder<T> {
  * ```
  */
 @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
-fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit) = runTest {
+public fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit): TestResult = runTest {
     val testBuilder = HttpResponseTestBuilder<T>().apply(block)
 
     // provide the mock engine

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/JsonAssertions.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/JsonAssertions.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
  * Assert JSON strings for equality ignoring key order
  */
 @OptIn(UnstableDefault::class)
-fun assertJsonStringsEqual(expected: String, actual: String) {
+public fun assertJsonStringsEqual(expected: String, actual: String) {
     val config = JsonConfiguration()
     val expectedElement = Json(config).parseJson(expected)
     val actualElement = Json(config).parseJson(actual)
@@ -26,7 +26,7 @@ fun assertJsonStringsEqual(expected: String, actual: String) {
 /**
  * Assert HTTP bodies are equal as JSON documents
  */
-suspend fun assertJsonBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
+public suspend fun assertJsonBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
     val expectedStr = expected?.readAll()?.decodeToString()
     val actualStr = actual?.readAll()?.decodeToString()
     if (expectedStr == null && actualStr == null) {

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/Utils.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/Utils.kt
@@ -15,13 +15,13 @@ import kotlin.test.fail
  * with opt-in requirements
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun String.encodeAsByteArray(): ByteArray = encodeToByteArray()
+public fun String.encodeAsByteArray(): ByteArray = encodeToByteArray()
 
 /**
  * Assert that the [actual] body is empty
  */
 @OptIn(ExperimentalStdlibApi::class)
-suspend fun assertEmptyBody(@Suppress("UNUSED_PARAMETER") expected: HttpBody?, actual: HttpBody?) {
+public suspend fun assertEmptyBody(@Suppress("UNUSED_PARAMETER") expected: HttpBody?, actual: HttpBody?) {
     if (actual !is HttpBody.Empty) {
         val actualBody = actual?.readAll()?.decodeToString()
         fail("expected an empty HttpBody; found: `$actualBody`")
@@ -32,7 +32,7 @@ suspend fun assertEmptyBody(@Suppress("UNUSED_PARAMETER") expected: HttpBody?, a
  * Assert that [actual] == [expected]
  */
 @OptIn(ExperimentalStdlibApi::class)
-suspend fun assertBytesEqual(expected: HttpBody?, actual: HttpBody?) {
+public suspend fun assertBytesEqual(expected: HttpBody?, actual: HttpBody?) {
     val actualRead = actual?.readAll()
     val expectedRead = expected?.readAll()
     assertBytesEqual(expectedRead, actualRead)
@@ -42,7 +42,7 @@ suspend fun assertBytesEqual(expected: HttpBody?, actual: HttpBody?) {
  * Assert that [actual] == [expected]
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun assertBytesEqual(expected: ByteArray?, actual: ByteArray?) {
+public fun assertBytesEqual(expected: ByteArray?, actual: ByteArray?) {
 
     if (expected == null) {
         assertNull(actual, "expected no content; found ${actual?.decodeToString()}")

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/XmlAssertions.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/XmlAssertions.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 /**
  * Assert XML strings for equality ignoring key order
  */
-suspend fun assertXmlStringsEqual(expected: String, actual: String) {
+public suspend fun assertXmlStringsEqual(expected: String, actual: String) {
     // parse into a dom representation and sort the dom into a canonical form for comparison
     val expectedNode = XmlNode.parse(expected.encodeToByteArray()).apply { toCanonicalForm() }
     val actualNode = XmlNode.parse(actual.encodeToByteArray()).apply { toCanonicalForm() }
@@ -27,7 +27,7 @@ suspend fun assertXmlStringsEqual(expected: String, actual: String) {
 /**
  * Assert HTTP bodies are equal as XML documents
  */
-suspend fun assertXmlBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
+public suspend fun assertXmlBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
     val expectedStr = expected?.readAll()?.decodeToString()
     val actualStr = actual?.readAll()?.decodeToString()
     if (expectedStr == null && actualStr == null) {
@@ -43,7 +43,7 @@ suspend fun assertXmlBodiesEqual(expected: HttpBody?, actual: HttpBody?) {
 /**
  * Sort the XML dom node into a canonical representation
  */
-fun XmlNode.toCanonicalForm() = toCanonical(this)
+public fun XmlNode.toCanonicalForm(): Unit = toCanonical(this)
 
 private fun toCanonical(root: XmlNode) {
     // attributes by name

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TestAnnotations.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TestAnnotations.kt
@@ -10,4 +10,4 @@ package aws.smithy.kotlin.runtime.testing
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-expect annotation class IgnoreWindows(val reason: String = "")
+public expect annotation class IgnoreWindows(val reason: String = "")

--- a/runtime/testing/jvm/src/aws/smithy/kotlin/runtime/testing/TestAnnotationsJVM.kt
+++ b/runtime/testing/jvm/src/aws/smithy/kotlin/runtime/testing/TestAnnotationsJVM.kt
@@ -8,4 +8,4 @@ import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 
 @DisabledOnOs(OS.WINDOWS)
-actual annotation class IgnoreWindows(actual val reason: String)
+public actual annotation class IgnoreWindows(actual val reason: String)

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Annotations.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Annotations.kt
@@ -25,4 +25,4 @@ package aws.smithy.kotlin.runtime.util
     AnnotationTarget.FIELD,
     AnnotationTarget.CONSTRUCTOR
 )
-annotation class InternalApi
+public annotation class InternalApi

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -11,85 +11,85 @@ package aws.smithy.kotlin.runtime.util
  * @param T is the type of the vale stored in the attribute
  * @param name the name of the attribute (for diagnostics)
  */
-class AttributeKey<T>(val name: String) {
+public class AttributeKey<T>(public val name: String) {
     override fun toString(): String = if (name.isBlank()) super.toString() else "ExecutionAttributeKey: $name"
 }
 
 /**
  * Generic type safe property bag
  */
-interface Attributes {
+public interface Attributes {
     /**
      * Get a value of the attribute for the specified [key] or null
      */
-    fun <T : Any> getOrNull(key: AttributeKey<T>): T?
+    public fun <T : Any> getOrNull(key: AttributeKey<T>): T?
 
     /**
      * Check if an attribute with the specified [key] exists
      */
-    operator fun contains(key: AttributeKey<*>): Boolean
+    public operator fun contains(key: AttributeKey<*>): Boolean
 
     /**
      * Creates or changes an attribute with the specified [key] using [value]
      */
-    operator fun <T : Any> set(key: AttributeKey<T>, value: T)
+    public operator fun <T : Any> set(key: AttributeKey<T>, value: T)
 
     /**
      * Removes an attribute with the specified [key]
      */
-    fun <T : Any> remove(key: AttributeKey<T>)
+    public fun <T : Any> remove(key: AttributeKey<T>)
 
     /**
      * Gets a value of the attribute for the specified [key], or calls supplied [block] to compute its value
      */
-    fun <T : Any> computeIfAbsent(key: AttributeKey<T>, block: () -> T): T
+    public fun <T : Any> computeIfAbsent(key: AttributeKey<T>, block: () -> T): T
 
     /**
      * Get a set of all the keys
      */
-    val keys: Set<AttributeKey<*>>
+    public val keys: Set<AttributeKey<*>>
 
-    companion object {
+    public companion object {
         /**
          * Create an attributes instance
          */
-        operator fun invoke(): Attributes = AttributesImpl()
+        public operator fun invoke(): Attributes = AttributesImpl()
     }
 }
 
 /**
  * Gets a value of the attribute for the specified [key] or throws an [IllegalStateException] if key does not exist
  */
-operator fun <T : Any> Attributes.get(key: AttributeKey<T>): T = getOrNull(key) ?: throw IllegalStateException("No instance for $key")
+public operator fun <T : Any> Attributes.get(key: AttributeKey<T>): T = getOrNull(key) ?: throw IllegalStateException("No instance for $key")
 
 /**
  * Removes an attribute with the specified [key] and returns its current value, throws an exception if an attribute doesn't exist
  */
-fun <T : Any> Attributes.take(key: AttributeKey<T>): T = get(key).also { remove(key) }
+public fun <T : Any> Attributes.take(key: AttributeKey<T>): T = get(key).also { remove(key) }
 
 /**
  * Set a value for [key] only if it is not already set
  */
-fun <T : Any> Attributes.putIfAbsent(key: AttributeKey<T>, value: T) {
+public fun <T : Any> Attributes.putIfAbsent(key: AttributeKey<T>, value: T) {
     if (!contains(key)) set(key, value)
 }
 
 /**
  * Set a value for [key] only if [value] is not null
  */
-fun <T : Any> Attributes.setIfValueNotNull(key: AttributeKey<T>, value: T?) {
+public fun <T : Any> Attributes.setIfValueNotNull(key: AttributeKey<T>, value: T?) {
     if (value != null) set(key, value)
 }
 
 /**
  * Removes an attribute with the specified [key] and returns its current value, returns `null` if an attribute doesn't exist
  */
-fun <T : Any> Attributes.takeOrNull(key: AttributeKey<T>): T? = getOrNull(key).also { remove(key) }
+public fun <T : Any> Attributes.takeOrNull(key: AttributeKey<T>): T? = getOrNull(key).also { remove(key) }
 
 /**
  * Merge another attributes instance into this set of attributes favoring [other]
  */
-fun Attributes.merge(other: Attributes) {
+public fun Attributes.merge(other: Attributes) {
     other.keys.forEach {
         @Suppress("UNCHECKED_CAST")
         set(it as AttributeKey<Any>, other[it])

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Base64.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Base64.kt
@@ -47,18 +47,18 @@ private fun base64DecodedLen(encoded: ByteArray): Int {
  * Encode [String] in base64 format and UTF-8 character encoding.
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun String.encodeBase64(): String = encodeToByteArray().encodeBase64().decodeToString()
+public fun String.encodeBase64(): String = encodeToByteArray().encodeBase64().decodeToString()
 
 /**
  * Encode [ByteArray] in base64 format and UTF-8 character encoding as a [String].
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun ByteArray.encodeBase64String(): String = encodeBase64().decodeToString()
+public fun ByteArray.encodeBase64String(): String = encodeBase64().decodeToString()
 
 /**
  * Encode [ByteArray] in base64 format and UTF-8 character encoding.
  */
-fun ByteArray.encodeBase64(): ByteArray {
+public fun ByteArray.encodeBase64(): ByteArray {
     val output = ByteArray(base64EncodedLen(size))
     val remainderCnt = size % 3
     val blockCnt = (size + 2) / 3
@@ -91,18 +91,18 @@ fun ByteArray.encodeBase64(): ByteArray {
  * Decode [String] from base64 format
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun String.decodeBase64(): String = decodeBase64Bytes().decodeToString()
+public fun String.decodeBase64(): String = decodeBase64Bytes().decodeToString()
 
 /**
  * Decode [String] from base64 format to a [ByteArray]
  */
 @OptIn(ExperimentalStdlibApi::class)
-fun String.decodeBase64Bytes(): ByteArray = encodeToByteArray().decodeBase64()
+public fun String.decodeBase64Bytes(): ByteArray = encodeToByteArray().decodeBase64()
 
 /**
  * Decode [ByteArray] from base64 format
  */
-fun ByteArray.decodeBase64(): ByteArray {
+public fun ByteArray.decodeBase64(): ByteArray {
     val encoded = this
     val decodedLen = base64DecodedLen(encoded)
     val decoded = ByteArray(decodedLen)

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Convenience.kt
@@ -10,20 +10,20 @@ import kotlin.jvm.JvmName
 /**
  * Determines the length of a collection. This is a synonym for [Collection.size].
  */
-val <T> Collection<T>.length: Int
+public val <T> Collection<T>.length: Int
     get() = size
 
 @JvmName("noOpUnnestedCollection")
-inline fun <reified T> Collection<T>.flattenIfPossible(): Collection<T> = this
+public inline fun <reified T> Collection<T>.flattenIfPossible(): Collection<T> = this
 
 @JvmName("flattenNestedCollection")
-inline fun <reified T> Collection<Collection<T>>.flattenIfPossible(): Collection<T> = flatten()
+public inline fun <reified T> Collection<Collection<T>>.flattenIfPossible(): Collection<T> = flatten()
 
 /**
  * Evaluates the "truthiness" of a value based on
  * [JMESPath definitions](https://jmespath.org/specification.html#or-expressions).
  */
-fun truthiness(value: Any?): Boolean = when (value) {
+public fun truthiness(value: Any?): Boolean = when (value) {
     is Boolean -> value
     is Collection<*> -> value.isNotEmpty()
     is Map<*, *> -> value.isNotEmpty()

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Filesystem.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Filesystem.kt
@@ -14,7 +14,7 @@ public interface Filesystem {
      * The delimiter of segments in a path. For example in Linux: /home/user/documents
      * or Windows: C:\Program Files\Notepad.EXE
      */
-    val filePathSeparator: String
+    public val filePathSeparator: String
 
     /**
      * Read the contents of a file as a [String] or return null on any error.
@@ -24,11 +24,11 @@ public interface Filesystem {
      */
     public suspend fun readFileOrNull(path: String): ByteArray?
 
-    companion object {
+    public companion object {
         /**
          * Construct a fake filesystem from a mapping of paths to contents
          */
-        fun fromMap(data: Map<String, ByteArray>, filePathSeparator: String = "/"): Filesystem = MapFilesystem(data, filePathSeparator)
+        public fun fromMap(data: Map<String, ByteArray>, filePathSeparator: String = "/"): Filesystem = MapFilesystem(data, filePathSeparator)
     }
 }
 

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/LazyAsyncValue.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/LazyAsyncValue.kt
@@ -17,11 +17,11 @@ import kotlinx.coroutines.sync.withLock
  * NOTE: Properties cannot be loaded asynchronously so unlike `Lazy<T>` a `LazyAsyncValue<T>` cannot be a property
  * delegate.
  */
-interface LazyAsyncValue<out T> {
+public interface LazyAsyncValue<out T> {
     /**
      * Get the cached value or initialize it for the first time. Subsequent calls will return the same value.
      */
-    suspend fun get(): T
+    public suspend fun get(): T
 }
 
 /**

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Platform.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Platform.kt
@@ -10,7 +10,7 @@ public interface PlatformProvider : PlatformEnvironProvider, Filesystem {
     /**
      * Get the operating system info
      */
-    fun osInfo(): OperatingSystem
+    public fun osInfo(): OperatingSystem
 }
 
 /**
@@ -18,14 +18,14 @@ public interface PlatformProvider : PlatformEnvironProvider, Filesystem {
  */
 @InternalApi
 public expect object Platform : PlatformProvider {
-    val isJvm: Boolean
-    val isAndroid: Boolean
-    val isBrowser: Boolean
-    val isNode: Boolean
-    val isNative: Boolean
+    public val isJvm: Boolean
+    public val isAndroid: Boolean
+    public val isBrowser: Boolean
+    public val isNode: Boolean
+    public val isNative: Boolean
 }
 
-data class OperatingSystem(val family: OsFamily, val version: String?)
+public data class OperatingSystem(val family: OsFamily, val version: String?)
 
 public enum class OsFamily {
     Linux,

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Stack.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Stack.kt
@@ -8,37 +8,37 @@ package aws.smithy.kotlin.runtime.util
 /**
  * Convenience type for treating a list like stack
  */
-typealias ListStack<T> = MutableList<T>
+public typealias ListStack<T> = MutableList<T>
 
 /**
  * Push an item to top of stack
  */
-fun <T> ListStack<T>.push(item: T) = add(item)
+public fun <T> ListStack<T>.push(item: T): Boolean = add(item)
 
 /**
  * Pop the top of the stack or throw [NoSuchElementException]
  */
-fun <T> ListStack<T>.pop(): T = removeLast()
+public fun <T> ListStack<T>.pop(): T = removeLast()
 
 /**
  * Pop the top of the stack or return null if stack is empty
  */
-fun <T> ListStack<T>.popOrNull(): T? = removeLastOrNull()
+public fun <T> ListStack<T>.popOrNull(): T? = removeLastOrNull()
 
 /**
  * Return top of stack or throws exception if stack is empty
  */
-fun <T> ListStack<T>.top(): T = this[count() - 1]
+public fun <T> ListStack<T>.top(): T = this[count() - 1]
 
 /**
  * Return top of stack or null if stack is empty
  */
-fun <T> ListStack<T>.topOrNull(): T? = if (isNotEmpty()) top() else null
+public fun <T> ListStack<T>.topOrNull(): T? = if (isNotEmpty()) top() else null
 
 /**
  * Pop the top of the stack and push a [item]
  */
-fun <T> ListStack<T>.replaceTop(item: T): T? {
+public fun <T> ListStack<T>.replaceTop(item: T): T? {
     val lastTop = popOrNull()
     push(item)
     return lastTop

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/Uuid.kt
@@ -9,8 +9,8 @@ import kotlin.random.Random
 /**
  * A KMP-compatible implementation of UUID, necessary because no cross-platform implementation exists yet.
  */
-data class Uuid(val high: Long, val low: Long) {
-    companion object {
+public data class Uuid(val high: Long, val low: Long) {
+    public companion object {
         private val nibbleChars = "0123456789abcdef".toCharArray()
         private val random = Random
 
@@ -26,7 +26,7 @@ data class Uuid(val high: Long, val low: Long) {
          * UUIDs are not generated with a cryptographically-strong random number generator.
          */
         @WeakRng
-        fun random(): Uuid {
+        public fun random(): Uuid {
             val high = random.nextLong() and v4Mask.inv() or v4Set
             val low = random.nextLong() and type2Mask.inv() or type2Set
             return Uuid(high, low)
@@ -82,5 +82,5 @@ data class Uuid(val high: Long, val low: Long) {
     @RequiresOptIn("This API doesn't use cryptographically-strong random number generation.")
     @Retention(AnnotationRetention.BINARY)
     @Target(AnnotationTarget.FUNCTION)
-    annotation class WeakRng
+    public annotation class WeakRng
 }

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Text.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * https://tools.ietf.org/html/rfc3986#section-2
  */
 @InternalApi
-fun String.urlEncodeComponent(
+public fun String.urlEncodeComponent(
     formUrlEncode: Boolean = false
 ): String {
     val sb = StringBuilder(this.length)
@@ -36,7 +36,7 @@ fun String.urlEncodeComponent(
  * See 'pchar': https://tools.ietf.org/html/rfc3986#section-3.3
  */
 @InternalApi
-val VALID_PCHAR_DELIMS = setOf(
+public val VALID_PCHAR_DELIMS: Set<Char> = setOf(
     '/',
     ':', '@',
     // sub-delims from section-2.2
@@ -58,7 +58,7 @@ private fun isPercentEncodedAt(d: ByteArray, i: Int): Boolean =
  * https://tools.ietf.org/html/rfc3986#section-3.3
  */
 @InternalApi
-fun String.encodeUrlPath() = encodeUrlPath(VALID_PCHAR_DELIMS, checkPercentEncoded = true)
+public fun String.encodeUrlPath(): String = encodeUrlPath(VALID_PCHAR_DELIMS, checkPercentEncoded = true)
 
 /**
  * Encode a string that represents a raw URL path component. Everything EXCEPT alphanumeric characters
@@ -69,7 +69,7 @@ fun String.encodeUrlPath() = encodeUrlPath(VALID_PCHAR_DELIMS, checkPercentEncod
  * characters and pass them through as is or not.
  */
 @InternalApi
-fun String.encodeUrlPath(validDelimiters: Set<Char>, checkPercentEncoded: Boolean): String {
+public fun String.encodeUrlPath(validDelimiters: Set<Char>, checkPercentEncoded: Boolean): String {
     val sb = StringBuilder(this.length)
     val data = this.encodeToByteArray()
 
@@ -137,15 +137,12 @@ private val upperHexSet = upperHex.toSet()
 
 // $2.1 Percent-Encoding
 @InternalApi
-fun Byte.percentEncodeTo(out: Appendable) {
+public fun Byte.percentEncodeTo(out: Appendable) {
     val code = toInt() and 0xff
     out.append('%')
     out.append(upperHex[code shr 4])
     out.append(upperHex[code and 0x0f])
 }
-
-@InternalApi
-fun Byte.percentEncode(): String = StringBuilder(3).also(::percentEncodeTo).toString()
 
 /**
  * Split a (decoded) query string "foo=baz&bar=quux" into it's component parts

--- a/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Utf8.kt
+++ b/runtime/utils/common/src/aws/smithy/kotlin/runtime/util/text/Utf8.kt
@@ -9,7 +9,7 @@ import aws.smithy.kotlin.runtime.util.InternalApi
 
 @InternalApi
 @Suppress("NOTHING_TO_INLINE")
-inline fun byteCountUtf8(start: Byte): Int {
+public inline fun byteCountUtf8(start: Byte): Int {
     val x = start.toUInt()
     return when {
         x <= 0x7fu -> 1 // 0xxx xxxx one byte
@@ -34,7 +34,7 @@ private const val MAX_CODEPOINT: Int = 0X10FFFF
  * Checks to see if a codepoint is in the supplementary plane or not (surrogate pair)
  */
 @InternalApi
-fun Char.Companion.isSupplementaryCodePoint(codePoint: Int): Boolean = codePoint in SUPPLEMENTARY_PLANE_LOW..MAX_CODEPOINT
+public fun Char.Companion.isSupplementaryCodePoint(codePoint: Int): Boolean = codePoint in SUPPLEMENTARY_PLANE_LOW..MAX_CODEPOINT
 
 /**
  * Converts the [codePoint] to a char array. If the codepoint is in the supplementary plane then it will
@@ -42,7 +42,7 @@ fun Char.Companion.isSupplementaryCodePoint(codePoint: Int): Boolean = codePoint
  * array with a single character.
  */
 @InternalApi
-fun Char.Companion.codePointToChars(codePoint: Int): CharArray = when (codePoint) {
+public fun Char.Companion.codePointToChars(codePoint: Int): CharArray = when (codePoint) {
     in 0 until SUPPLEMENTARY_PLANE_LOW -> charArrayOf(codePoint.toChar())
     in SUPPLEMENTARY_PLANE_LOW..MAX_CODEPOINT -> {
         val low = MIN_LOW_SURROGATE.code + ((codePoint - 0x10000) and 0x3FF)

--- a/runtime/utils/jvm/src/aws/smithy/kotlin/runtime/util/PlatformJVM.kt
+++ b/runtime/utils/jvm/src/aws/smithy/kotlin/runtime/util/PlatformJVM.kt
@@ -20,11 +20,11 @@ public actual object Platform : PlatformProvider {
      */
     override fun getenv(key: String): String? = System.getenv()[key]
 
-    actual val isJvm: Boolean = true
-    actual val isAndroid: Boolean by lazy { isAndroid() }
-    actual val isBrowser: Boolean = false
-    actual val isNode: Boolean = false
-    actual val isNative: Boolean = false
+    public actual val isJvm: Boolean = true
+    public actual val isAndroid: Boolean by lazy { isAndroid() }
+    public actual val isBrowser: Boolean = false
+    public actual val isNode: Boolean = false
+    public actual val isNative: Boolean = false
 
     override fun osInfo(): OperatingSystem = getOsInfo()
 
@@ -42,8 +42,8 @@ public actual object Platform : PlatformProvider {
         null
     }
 
-    suspend fun readFileOrNull(path: Path): ByteArray? = readFileOrNull(path.toAbsolutePath().toString())
-    suspend fun readFileOrNull(file: File): ByteArray? = readFileOrNull(file.absolutePath)
+    public suspend fun readFileOrNull(path: Path): ByteArray? = readFileOrNull(path.toAbsolutePath().toString())
+    public suspend fun readFileOrNull(file: File): ByteArray? = readFileOrNull(file.absolutePath)
 
     override fun getAllProperties(): Map<String, String> = System
         .getProperties()


### PR DESCRIPTION
## Issue \#

Addresses #216

## Description of changes

Enables [explicit API mode](https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md) for **smithy-kotlin** runtime components, similar to the [recent PR enabling it for codegen](https://github.com/awslabs/smithy-kotlin/pull/675).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
