### PR TITLE
chore: bump package version to 0.12.4 after broken 0.12.3 release

### DIFF
--- a/.changes/dc281a10-9a1a-4121-b699-1d0ad8271b58.json
+++ b/.changes/dc281a10-9a1a-4121-b699-1d0ad8271b58.json
@@ -1,5 +1,0 @@
-{
-    "id": "dc281a10-9a1a-4121-b699-1d0ad8271b58",
-    "type": "misc",
-    "description": "Bump package version to 0.12.4 after broken publish of 0.12.3."
-}

--- a/.changes/dc281a10-9a1a-4121-b699-1d0ad8271b58.json
+++ b/.changes/dc281a10-9a1a-4121-b699-1d0ad8271b58.json
@@ -1,0 +1,5 @@
+{
+    "id": "dc281a10-9a1a-4121-b699-1d0ad8271b58",
+    "type": "misc",
+    "description": "Bump package version to 0.12.4 after broken publish of 0.12.3."
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.hierarchicalStructureSupport=false
 
 # SDK
-sdkVersion=0.12.3-SNAPSHOT
+sdkVersion=0.12.4-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.7.10


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
