### PR TITLE
chore: upgrade Smithy to 1.23.0, upgrade Smithy Gradle to 0.6.0

### DIFF
--- a/.changes/633e3063-4089-41fe-a7a2-bb742910478c.json
+++ b/.changes/633e3063-4089-41fe-a7a2-bb742910478c.json
@@ -1,0 +1,5 @@
+{
+    "id": "633e3063-4089-41fe-a7a2-bb742910478c",
+    "type": "misc",
+    "description": "Upgrade Smithy to 1.23.0, upgrade Smithy Gradle to 0.6.0"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,8 +24,8 @@ jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.9
 
 # codegen
-smithyVersion=1.22.0
-smithyGradleVersion=0.5.3
+smithyVersion=1.23.0
+smithyGradleVersion=0.6.0
 
 # testing/utility
 junitVersion=5.8.2

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
@@ -22,7 +22,6 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.neighbor.Walker
 import software.amazon.smithy.model.shapes.*
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.transform.ModelTransformer
 import java.util.*
 import java.util.logging.Logger
@@ -156,7 +155,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
     }
 
     override fun stringShape(shape: StringShape) {
-        if (shape.hasTrait<EnumTrait>()) {
+        if (shape.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()) {
             writers.useShapeWriter(shape) { EnumGenerator(shape, symbolProvider.toSymbol(shape), it).render() }
         }
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.kotlin.codegen.lang.kotlinReservedWords
 import software.amazon.smithy.kotlin.codegen.model.*
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.*
-import software.amazon.smithy.model.traits.BoxTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import java.util.logging.Logger
@@ -251,7 +250,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
             .putProperty(SymbolProperty.SHAPE_KEY, shape)
             .name(typeName)
 
-        val explicitlyBoxed = shape?.hasTrait<BoxTrait>() ?: false
+        val explicitlyBoxed = shape?.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.BoxTrait>() ?: false
         if (explicitlyBoxed || boxed) {
             builder.boxed()
         }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -154,7 +154,7 @@ val Shape.isDeprecated: Boolean
  * https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait
  */
 val Shape.isEnum: Boolean
-    get() = isStringShape && hasTrait<EnumTrait>()
+    get() = isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
 
 /**
  * Test if a shape is an error.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.kotlin.codegen.model.expectTrait
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.traits.EnumDefinition
-import software.amazon.smithy.model.traits.EnumTrait
 
 /**
  * Generates a Kotlin sealed class from a Smithy enum string
@@ -98,10 +97,9 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
     private val generatedNames = mutableSetOf<String>()
 
     init {
-        assert(shape.hasTrait<EnumTrait>())
+        assert(shape.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>())
     }
-
-    val enumTrait: EnumTrait by lazy {
+    val enumTrait: @Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait by lazy {
         shape.expectTrait()
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.kotlin.codegen.model.hasTrait
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.*
 import software.amazon.smithy.model.shapes.*
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 
 /**
@@ -100,7 +99,7 @@ class ShapeValueGenerator(
         )
         val suffix = when (shape.type) {
             ShapeType.STRING -> {
-                if (shape.hasTrait<EnumTrait>()) {
+                if (shape.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()) {
                     val symbol = symbolProvider.toSymbol(shape)
                     writer.writeInline("#L.fromValue(", symbol.name)
                     ")"

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
@@ -144,14 +144,15 @@ class HttpStringValuesMapSerializer(
             writer.write("append(\"#L\", (input.$memberName ?: context.idempotencyTokenProvider.generateToken()))", paramName)
         } else {
             val cond =
-                if (location == HttpBinding.Location.QUERY || memberTarget.hasTrait<EnumTrait>()) {
+                if (location == HttpBinding.Location.QUERY ||
+                    memberTarget.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()) {
                     "input.$memberName != null"
                 } else {
                     "input.$memberName?.isNotEmpty() == true"
                 }
 
             val suffix = when {
-                memberTarget.hasTrait<EnumTrait>() -> {
+                memberTarget.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() -> {
                     ".value"
                 }
                 memberTarget.hasTrait<MediaTypeTrait>() -> {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.kotlin.codegen.model.isSparse
 import software.amazon.smithy.kotlin.codegen.model.targetOrSelf
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.*
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 
@@ -539,7 +538,7 @@ open class DeserializeStructGenerator(
                 }
             }
             ShapeType.STRING -> when {
-                target.hasTrait<EnumTrait>() -> {
+                target.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() -> {
                     val enumSymbol = ctx.symbolProvider.toSymbol(target)
                     writer.addImport(enumSymbol)
                     "deserializeString().let { ${enumSymbol.name}.fromValue(it) }"

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -635,7 +635,7 @@ open class SerializeStructGenerator(
                 "$defaultIdentifier.encodeBase64String()"
             }
             ShapeType.STRING -> when {
-                target.hasTrait<EnumTrait>() -> "$defaultIdentifier.value"
+                target.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() -> "$defaultIdentifier.value"
                 else -> defaultIdentifier
             }
             else -> throw CodegenException("unknown serializer for member: $shape; target: $target")
@@ -647,7 +647,8 @@ open class SerializeStructGenerator(
     /**
      * @return true if shape is a String with enum trait, false otherwise.
      */
-    private fun Shape.isEnum() = isStringShape && hasTrait<EnumTrait>()
+    private fun Shape.isEnum() =
+        isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
 
     /**
      * Generate key and value names for iteration based on nesting level


### PR DESCRIPTION
## Summary
<!--- Provide a general summary of your changes in the Title above -->
Upgrade to Smithy IDL 2.0:

- Upgrade Smithy dependency to 1.23.0
- Upgrade Smithy Gradle dependency to 0.6.0
- Add `@Suppress("DEPRECATION")` to deprecated classes `EnumTrait` and `BoxTrait`

## Issue
<!--- If it fixes an open issue, please link to the issue here -->

N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

To prep for upgrading aws-sdk-kotlin to Smithy 2.0, upgrading Smithy and Smithy Gradle is needed.

## Testing

Ran `./gradlew clean build check assemble --parallel --no-build-cache --no-daemon` with `local.properties` file:

```text
kotlinWarningsAsErrors=true
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
