### PR TITLE
fix: upgrade aws-crt-kotlin dependency to fix Mac dlopen issue

### DIFF
--- a/.changes/48905e3f-f57e-4265-ad34-98c65ec4bb46.json
+++ b/.changes/48905e3f-f57e-4265-ad34-98c65ec4bb46.json
@@ -1,0 +1,8 @@
+{
+    "id": "48905e3f-f57e-4265-ad34-98c65ec4bb46",
+    "type": "bugfix",
+    "description": "Upgrade aws-crt-kotlin dependency to fix Mac dlopen issue",
+    "issues": [
+        "awslabs/aws-crt-kotlin#55"
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,4 @@ kotlinLoggingVersion=2.1.21
 slf4jVersion=1.7.36
 
 # crt
-crtKotlinVersion=0.6.3
+crtKotlinVersion=0.6.4-SNAPSHOT


### PR DESCRIPTION
## Issue \#

Closes [aws-crt-kotlin#55](https://github.com/awslabs/aws-crt-kotlin/issues/55)

## Description of changes

Upgrades the **aws-crt-kotlin** dependency get the latest version of CRT and the fix for the Mac dlopen issue.

**Companion PRs**: [aws-crt-kotlin#56](https://github.com/awslabs/aws-crt-kotlin/pull/56), [aws-sdk-kotlin#682](https://github.com/awslabs/aws-sdk-kotlin/pull/682)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
