### PR TITLE
fix: add missing codegen support for Smithy 1.23 upgrade

### DIFF
--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor.kt
@@ -33,6 +33,8 @@ public sealed class SerialKind {
     public object Char : SerialKind()
     public object Short : SerialKind()
     public object Float : SerialKind()
+    public object Enum : SerialKind()
+    public object IntEnum : SerialKind()
     public object Map : SerialKind()
     public object List : SerialKind()
     public object Struct : SerialKind()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -154,7 +154,10 @@ val Shape.isDeprecated: Boolean
  * https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait
  */
 val Shape.isEnum: Boolean
-    get() = isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
+    get() =
+        isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() ||
+            isEnumShape ||
+            isIntEnumShape
 
 /**
  * Test if a shape is an error.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -437,6 +437,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                     writer.write("builder.body = #T(input.#L)", RuntimeTypes.Http.ByteArrayContent, memberName)
                 }
             }
+
             ShapeType.STRING -> {
                 val contents = if (target.isEnum) {
                     "$memberName.value"
@@ -445,13 +446,24 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 }
                 writer.write("builder.body = #T(input.#L.#T())", RuntimeTypes.Http.ByteArrayContent, contents, KotlinTypes.Text.encodeToByteArray)
             }
+
+            ShapeType.ENUM, ShapeType.INT_ENUM ->
+                writer.write(
+                    "builder.body = #T(input.#L.value.#T())",
+                    RuntimeTypes.Http.ByteArrayContent,
+                    memberName,
+                    KotlinTypes.Text.encodeToByteArray,
+                )
+
             ShapeType.STRUCTURE, ShapeType.UNION, ShapeType.DOCUMENT -> {
                 val sdg = structuredDataSerializer(ctx)
                 val payloadSerializerFn = sdg.payloadSerializer(ctx, binding.member)
                 writer.write("val payload = #T(input.#L)", payloadSerializerFn, memberName)
                 writer.write("builder.body = #T(payload)", RuntimeTypes.Http.ByteArrayContent)
             }
-            else -> throw CodegenException("member shape ${binding.member} serializer not implemented yet")
+
+            else ->
+                throw CodegenException("member shape ${binding.member} (${target.type}) serializer not implemented yet")
         }
         writer.closeBlock("}")
     }
@@ -869,16 +881,19 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         val targetSymbol = ctx.symbolProvider.toSymbol(target)
         when (target.type) {
             ShapeType.STRING -> {
-                writer
-                    .addImport(RuntimeTypes.Http.readAll)
-                    .write("val contents = response.body.#T()?.decodeToString()", RuntimeTypes.Http.readAll)
+                writer.write("val contents = response.body.#T()?.decodeToString()", RuntimeTypes.Http.readAll)
                 if (target.isEnum) {
-                    writer.addImport(targetSymbol)
                     writer.write("builder.$memberName = contents?.let { #T.fromValue(it) }", targetSymbol)
                 } else {
                     writer.write("builder.$memberName = contents")
                 }
             }
+
+            ShapeType.ENUM, ShapeType.INT_ENUM -> {
+                writer.write("val contents = response.body.#T()?.decodeToString()", RuntimeTypes.Http.readAll)
+                writer.write("builder.#L = contents?.let { #T.fromValue(it) }", memberName, targetSymbol)
+            }
+
             ShapeType.BLOB -> {
                 val isBinaryStream = target.hasTrait<StreamingTrait>()
                 val conversion = if (isBinaryStream) {
@@ -890,6 +905,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 }
                 writer.write("builder.$memberName = response.body.$conversion")
             }
+
             ShapeType.STRUCTURE, ShapeType.UNION, ShapeType.DOCUMENT -> {
                 // delegate to the payload deserializer
                 val sdg = structuredDataParser(ctx)
@@ -900,7 +916,9 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                         write("builder.#L = #T(payload)", memberName, payloadDeserializerFn)
                     }
             }
-            else -> throw CodegenException("member shape ${binding.member} deserializer not implemented")
+
+            else ->
+                throw CodegenException("member shape ${binding.member} (${target.type}) deserializer not implemented")
         }
 
         writer.openBlock("")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -447,13 +447,15 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 writer.write("builder.body = #T(input.#L.#T())", RuntimeTypes.Http.ByteArrayContent, contents, KotlinTypes.Text.encodeToByteArray)
             }
 
-            ShapeType.ENUM, ShapeType.INT_ENUM ->
+            ShapeType.ENUM ->
                 writer.write(
                     "builder.body = #T(input.#L.value.#T())",
                     RuntimeTypes.Http.ByteArrayContent,
                     memberName,
                     KotlinTypes.Text.encodeToByteArray,
                 )
+
+            ShapeType.INT_ENUM -> throw CodegenException("IntEnum is not supported until Smithy 2.0")
 
             ShapeType.STRUCTURE, ShapeType.UNION, ShapeType.DOCUMENT -> {
                 val sdg = structuredDataSerializer(ctx)
@@ -889,10 +891,12 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 }
             }
 
-            ShapeType.ENUM, ShapeType.INT_ENUM -> {
+            ShapeType.ENUM -> {
                 writer.write("val contents = response.body.#T()?.decodeToString()", RuntimeTypes.Http.readAll)
                 writer.write("builder.#L = contents?.let { #T.fromValue(it) }", memberName, targetSymbol)
             }
+
+            ShapeType.INT_ENUM -> throw CodegenException("IntEnum is not supported until Smithy 2.0")
 
             ShapeType.BLOB -> {
                 val isBinaryStream = target.hasTrait<StreamingTrait>()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -103,8 +103,9 @@ open class DeserializeStructGenerator(
             ShapeType.BIG_DECIMAL,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderShapeDeserializer(memberShape)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unexpected shape type: ${targetShape.type}")
         }
@@ -180,7 +181,6 @@ open class DeserializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.TIMESTAMP,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderEntry(elementShape, nestingLevel, isSparse, parentMemberName)
 
             ShapeType.SET,
@@ -191,6 +191,8 @@ open class DeserializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureEntry(elementShape, nestingLevel, isSparse, parentMemberName)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }
@@ -390,7 +392,6 @@ open class DeserializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.TIMESTAMP,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderElement(elementShape, nestingLevel, isSparse, parentMemberName)
 
             ShapeType.LIST,
@@ -401,6 +402,8 @@ open class DeserializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureElement(elementShape, nestingLevel, isSparse, parentMemberName)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerdeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerdeExt.kt
@@ -235,6 +235,8 @@ fun Shape.serialKind(): String = when (this.type) {
     ShapeType.FLOAT -> "SerialKind.Float"
     ShapeType.DOUBLE -> "SerialKind.Double"
     ShapeType.STRING -> "SerialKind.String"
+    ShapeType.ENUM -> "SerialKind.Enum"
+    ShapeType.INT_ENUM -> "SerialKind.IntEnum"
     ShapeType.BLOB -> "SerialKind.Blob"
     ShapeType.TIMESTAMP -> "SerialKind.Timestamp"
     ShapeType.DOCUMENT -> "SerialKind.Document"

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -89,10 +89,12 @@ open class SerializeStructGenerator(
             ShapeType.LIST,
             ShapeType.SET,
             -> renderListMemberSerializer(memberShape, targetShape as CollectionShape)
+
             ShapeType.MAP -> renderMapMemberSerializer(memberShape, targetShape as MapShape)
             ShapeType.STRUCTURE,
             ShapeType.UNION,
             -> renderPrimitiveShapeSerializer(memberShape, ::serializerForStructureShape)
+
             ShapeType.TIMESTAMP -> renderTimestampMemberSerializer(memberShape)
             ShapeType.BLOB,
             ShapeType.BOOLEAN,
@@ -106,7 +108,10 @@ open class SerializeStructGenerator(
             ShapeType.BIG_DECIMAL,
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
+            ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveShapeSerializer(memberShape, ::serializerForPrimitiveShape)
+
             else -> error("Unexpected shape type: ${targetShape.type}")
         }
     }
@@ -174,16 +179,21 @@ open class SerializeStructGenerator(
             ShapeType.BIG_DECIMAL,
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
+            ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveEntry(elementShape, nestingLevel, parentMemberName)
+
             ShapeType.BLOB -> renderBlobEntry(nestingLevel, parentMemberName)
             ShapeType.TIMESTAMP -> renderTimestampEntry(mapShape.value, elementShape, nestingLevel, parentMemberName)
             ShapeType.SET,
             ShapeType.LIST,
             -> renderListEntry(rootMemberShape, elementShape as CollectionShape, nestingLevel, isSparse, parentMemberName)
+
             ShapeType.MAP -> renderMapEntry(rootMemberShape, elementShape as MapShape, nestingLevel, isSparse, parentMemberName)
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureEntry(elementShape, nestingLevel, parentMemberName, isSparse)
+
             else -> error("Unhandled type ${elementShape.type}")
         }
     }
@@ -207,16 +217,21 @@ open class SerializeStructGenerator(
             ShapeType.BIG_DECIMAL,
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
+            ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveElement(elementShape, nestingLevel, parentMemberName, isSparse)
+
             ShapeType.BLOB -> renderBlobElement(nestingLevel, parentMemberName)
             ShapeType.TIMESTAMP -> renderTimestampElement(listShape.member, elementShape, nestingLevel, parentMemberName)
             ShapeType.LIST,
             ShapeType.SET,
             -> renderListElement(rootMemberShape, elementShape as CollectionShape, nestingLevel, parentMemberName)
+
             ShapeType.MAP -> renderMapElement(rootMemberShape, elementShape as MapShape, nestingLevel, parentMemberName)
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureElement(elementShape, nestingLevel, parentMemberName)
+
             else -> error("Unhandled type ${elementShape.type}")
         }
     }
@@ -393,7 +408,7 @@ open class SerializeStructGenerator(
      */
     private fun renderPrimitiveEntry(elementShape: Shape, nestingLevel: Int, listMemberName: String) {
         val containerName = if (nestingLevel == 0) "input." else ""
-        val enumPostfix = if (elementShape.isEnum()) ".value" else ""
+        val enumPostfix = if (elementShape.isEnum) ".value" else ""
         val (keyName, valueName) = keyValueNames(nestingLevel)
 
         writer.write("$containerName$listMemberName.forEach { ($keyName, $valueName) -> entry($keyName, $valueName$enumPostfix) }")
@@ -462,7 +477,7 @@ open class SerializeStructGenerator(
     ) {
         val serializerFnName = elementShape.type.primitiveSerializerFunctionName()
         val iteratorName = nestingLevel.variableNameFor(NestedIdentifierType.ELEMENT)
-        val elementName = when (elementShape.isEnum()) {
+        val elementName = when (elementShape.isEnum) {
             true -> "$iteratorName.value"
             false -> iteratorName
         }
@@ -617,38 +632,19 @@ open class SerializeStructGenerator(
     private fun serializerForPrimitiveShape(shape: Shape): SerializeInfo {
         // target shape type to deserialize is either the shape itself or member.target
         val target = shape.targetOrSelf(ctx.model)
-        val defaultIdentifier = valueToSerializeName("it")
-        var serializerFn = "field"
+        val valueSuffix = if (target.isEnum) ".value" else ""
+        val defaultIdentifier = valueToSerializeName("it") + valueSuffix
+        val serializerFn = "field"
 
-        val encoded = when (target.type) {
-            ShapeType.BOOLEAN,
-            ShapeType.BYTE,
-            ShapeType.SHORT,
-            ShapeType.INTEGER,
-            ShapeType.LONG,
-            ShapeType.FLOAT,
-            ShapeType.DOCUMENT,
-            ShapeType.DOUBLE,
-            -> defaultIdentifier
-            ShapeType.BLOB -> {
-                writer.addImport("encodeBase64String", KotlinDependency.UTILS)
-                "$defaultIdentifier.encodeBase64String()"
-            }
-            ShapeType.STRING -> when {
-                target.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() -> "$defaultIdentifier.value"
-                else -> defaultIdentifier
-            }
-            else -> throw CodegenException("unknown serializer for member: $shape; target: $target")
+        val encoded = if (target.type == ShapeType.BLOB) {
+            writer.addImport("encodeBase64String", KotlinDependency.UTILS)
+            "$defaultIdentifier.encodeBase64String()"
+        } else {
+            defaultIdentifier
         }
 
         return SerializeInfo(serializerFn, encoded)
     }
-
-    /**
-     * @return true if shape is a String with enum trait, false otherwise.
-     */
-    private fun Shape.isEnum() =
-        isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
 
     /**
      * Generate key and value names for iteration based on nesting level
@@ -669,10 +665,10 @@ open class SerializeStructGenerator(
     private fun ShapeType.primitiveSerializerFunctionName(): String {
         val suffix = when (this) {
             ShapeType.BOOLEAN -> "Boolean"
-            ShapeType.STRING -> "String"
+            ShapeType.STRING, ShapeType.ENUM -> "String"
             ShapeType.BYTE -> "Byte"
             ShapeType.SHORT -> "Short"
-            ShapeType.INTEGER -> "Int"
+            ShapeType.INTEGER, ShapeType.INT_ENUM -> "Int"
             ShapeType.LONG -> "Long"
             ShapeType.FLOAT -> "Float"
             ShapeType.DOUBLE -> "Double"

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -109,8 +109,9 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderPrimitiveShapeSerializer(memberShape, ::serializerForPrimitiveShape)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unexpected shape type: ${targetShape.type}")
         }
@@ -180,7 +181,6 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderPrimitiveEntry(elementShape, nestingLevel, parentMemberName)
 
             ShapeType.BLOB -> renderBlobEntry(nestingLevel, parentMemberName)
@@ -193,6 +193,8 @@ open class SerializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureEntry(elementShape, nestingLevel, parentMemberName, isSparse)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }
@@ -218,7 +220,6 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
-            ShapeType.INT_ENUM,
             -> renderPrimitiveElement(elementShape, nestingLevel, parentMemberName, isSparse)
 
             ShapeType.BLOB -> renderBlobElement(nestingLevel, parentMemberName)
@@ -231,6 +232,8 @@ open class SerializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureElement(elementShape, nestingLevel, parentMemberName)
+
+            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Downstream CI is broken in **main** right now due to [an incomplete Smithy 1.23 upgrade](https://github.com/awslabs/smithy-kotlin/commit/fa24af948f356b52e3d42a62b386cf0e18aa86da). This change adds support for the new `enum` and `intEnum` shapes that appear in updated Smithy protocol tests.

**Companion PR**: [aws-sdk-kotlin#684](https://github.com/awslabs/aws-sdk-kotlin/pull/684)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
