### PR TITLE
chore: upgrade aws-crt-kotlin to version 0.6.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,4 +46,4 @@ kotlinLoggingVersion=2.1.21
 slf4jVersion=1.7.36
 
 # crt
-crtKotlinVersion=0.6.4-SNAPSHOT
+crtKotlinVersion=0.6.4


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Sync with latest version of **aws-crt-kotlin**, 0.6.4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.