### PR TITLE
feat(rt): add full duplex request body support for okhttp engine

### DIFF
--- a/.changes/63e845b0-937d-4952-b416-b9ab6d9de17f.json
+++ b/.changes/63e845b0-937d-4952-b416-b9ab6d9de17f.json
@@ -1,0 +1,5 @@
+{
+    "id": "63e845b0-937d-4952-b416-b9ab6d9de17f",
+    "type": "feature",
+    "description": "Add support for full duplex HTTP exchanges"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.ignoreDisabledTargets=true
 
 
 # FIXME - see https://youtrack.jetbrains.com/issue/KTIJ-21583/HMPP-1-6-20-breaks-autocomplete-in-multiplatform-composite-build
-kotlin.mpp.hierarchicalStructureSupport=false
+#kotlin.mpp.hierarchicalStructureSupport=false
 
 # SDK
 sdkVersion=0.12.6-SNAPSHOT
@@ -21,7 +21,7 @@ ktorVersion=2.0.2
 atomicFuVersion=0.18.3
 kotlinxSerializationVersion=1.3.3
 jsoupVersion=1.14.3
-okHttpVersion=5.0.0-alpha.9
+okHttpVersion=5.0.0-alpha.10
 
 # codegen
 smithyVersion=1.23.0

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -32,7 +32,10 @@ internal val HttpRequest.uri: Uri
 internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.kotlin.crt.http.HttpRequest {
     val body = this.body
     val bodyStream = when (body) {
-        is HttpBody.Streaming -> ReadChannelBodyStream(body.readFrom(), callContext)
+        is HttpBody.Streaming -> {
+            check(!body.isDuplex) { "CrtHttpEngine does not yet support full duplex streams" }
+            ReadChannelBodyStream(body.readFrom(), callContext)
+        }
         is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
         else -> null
     }

--- a/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-ktor/common/src/aws/smithy/kotlin/runtime/http/engine/ktor/KtorRequestAdapter.kt
@@ -66,6 +66,7 @@ internal class KtorRequestAdapter(
 
     @OptIn(ExperimentalStdlibApi::class)
     private fun proxyRequestStream(body: HttpBody.Streaming, contentType: ContentType?): OutgoingContent {
+        check(!body.isDuplex) { "KtorEngine does not support full duplex streams" }
         val source = body.readFrom()
         fillRequestJob.invokeOnCompletion { cause ->
             source.cancel(cause)

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
@@ -21,7 +21,7 @@ internal class ByteChannelRequestBody(
     private val callContext: CoroutineContext,
 ) : RequestBody(), CoroutineScope {
 
-    private val producerJob = Job(callContext.job)
+    private val producerJob = Job(callContext[Job])
     override val coroutineContext: CoroutineContext = callContext + producerJob + callContext.derivedName("send-request-body") + Dispatchers.IO
     override fun contentType(): MediaType? = null
     override fun contentLength(): Long = body.contentLength ?: -1

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
@@ -6,8 +6,7 @@
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.http.HttpBody
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okio.BufferedSink
@@ -20,39 +19,68 @@ import kotlin.coroutines.CoroutineContext
 internal class ByteChannelRequestBody(
     private val body: HttpBody.Streaming,
     private val callContext: CoroutineContext,
-) : RequestBody() {
+) : RequestBody(), CoroutineScope {
+
+    private val producerJob = Job(callContext.job)
+    override val coroutineContext: CoroutineContext = callContext + producerJob + callContext.derivedName("send-request-body") + Dispatchers.IO
     override fun contentType(): MediaType? = null
     override fun contentLength(): Long = body.contentLength ?: -1
     override fun isOneShot(): Boolean = !body.isReplayable
-
-    // TODO - enable for event streams. Requires different processing of request body
-    override fun isDuplex(): Boolean = false
+    override fun isDuplex(): Boolean = body.isDuplex
 
     @OptIn(ExperimentalStdlibApi::class)
     override fun writeTo(sink: BufferedSink) {
-        // remove the current dispatcher (if it exists) and use the internal
-        // runBlocking dispatcher that blocks the current thread
-        val sendContext = callContext.minusKey(CoroutineDispatcher) + callContext.derivedName("send-request-body")
+        if (isDuplex()) {
+            // launch coroutine that writes to sink in the background
+            launch {
+                sink.use { transferBody(it) }
+            }
+        } else {
+            // remove the current dispatcher (if it exists) and use the internal
+            // runBlocking dispatcher that blocks the *current* thread
+            val blockingContext = coroutineContext.minusKey(CoroutineDispatcher)
 
-        // Non-duplex (aka "normal") requests MUST write all of their request body
-        // before this function returns. Requests are given a background thread to
-        // do this work in, and it is safe and expected to block.
-        // see: https://square.github.io/okhttp/4.x/okhttp/okhttp3/-request-body/is-duplex/
-        runBlocking(sendContext) {
-            val chan = body.readFrom()
-            val buffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
-            while (!chan.isClosedForRead) {
-                // fill the buffer by reading chunks from the underlying source
-                while (chan.readAvailable(buffer) != -1 && buffer.remaining() > 0) {
-                }
-
-                buffer.flip()
-                while (buffer.remaining() > 0) {
-                    sink.write(buffer)
-                }
-
-                buffer.clear()
+            // Non-duplex (aka "normal") requests MUST write all of their request body
+            // before this function returns. Requests are given a background thread to
+            // do this work in, and it is safe and expected to block.
+            // see: https://square.github.io/okhttp/4.x/okhttp/okhttp3/-request-body/is-duplex/
+            runBlocking(blockingContext) {
+                transferBody(sink)
             }
         }
+    }
+    private suspend fun transferBody(sink: BufferedSink) = withJob(producerJob) {
+        val chan = body.readFrom()
+        val buffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
+        while (!chan.isClosedForRead) {
+            // ensure request context hasn't been cancelled
+            callContext.ensureActive()
+
+            // fill the buffer by reading chunks from the underlying source
+            while (chan.readAvailable(buffer) != -1 && buffer.remaining() > 0) {}
+
+            buffer.flip()
+            while (buffer.remaining() > 0) {
+                sink.write(buffer)
+            }
+
+            buffer.clear()
+        }
+    }
+}
+
+/**
+ * Completes the given job when the block returns calling either `complete()` when the block runs
+ * successfully or `completeExceptionally()` on exception.
+ * @return the result of calling [block]
+ */
+private inline fun <T> withJob(job: CompletableJob, block: () -> T): T {
+    try {
+        return block()
+    } catch (ex: Exception) {
+        job.completeExceptionally(ex)
+        throw ex
+    } finally {
+        job.complete()
     }
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
@@ -56,6 +56,14 @@ public sealed class HttpBody {
         public open val isReplayable: Boolean = false
 
         /**
+         * Flag indicating that this request body should be handled as a duplex stream by the underlying engine.
+         *
+         * Most request bodies are sent completely before the response is received. In full duplex mode the request
+         * and response bodies may be interleaved. Only HTTP/2 calls support duplex streaming.
+         */
+        public open val isDuplex: Boolean = false
+
+        /**
          * Reset the stream such that the next call to [readFrom] provides a fresh channel.
          * @throws UnsupportedOperationException if the stream can only be consumed once. Consumers can check
          * [isReplayable] before calling


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/543

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Expose a flag to mark an HTTP request body as full duplex. This signals the underlying engine that the exchange is expected to be fully asynchronous with request and response bodies interleaved. This was chosen because at least two of our engines (CRT and okhttp) require different handling of the request body when streaming this way. This capability is only needed by event stream operations right now and should not be `true` for any other request body
* This PR only adds support for the okhttp engine and will fail at runtime if you try to use a full duplex request for any other engine. I believe the CRT has added support and exposed knobs for this but we have more work to got figure out what that looks like, thread it through `aws-crt-kotlin` and then expose it here. 
    *  NOTE: This is a conscious choice to only support our default engine right now. There are less than 10 event stream operations across the entirety of the AWS service fabric and we can fill in support for other engines when there is demand for it.

## Testing
I've tested this on the transcribe-streaming operation and can see the request and response bodies interleaved:

````
emitting audio event
emitting audio event
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.085,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.085,speaker=null,stable=null,startTime=1.085,type=punctuation,vocabularyFilterMatch=false)],transcript=Hello.)],channelId=null,endTime=1.085,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.0775,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=from,endTime=1.2875,speaker=null,stable=null,startTime=1.0775,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=it,endTime=1.4175,speaker=null,stable=null,startTime=1.2875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.4175,speaker=null,stable=null,startTime=1.4175,type=punctuation,vocabularyFilterMatch=false)],transcript=Hello from it.)],channelId=null,endTime=1.585,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
emitting audio event
emitting audio event
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.0775,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=from,endTime=1.2975,speaker=null,stable=null,startTime=1.0775,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=a,endTime=1.3875,speaker=null,stable=null,startTime=1.2975,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=1.4775,speaker=null,stable=null,startTime=1.3875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=S,endTime=1.9875,speaker=null,stable=null,startTime=1.5875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.9875,speaker=null,stable=null,startTime=1.9875,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=2.085,speaker=null,stable=null,startTime=1.9875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=2.085,speaker=null,stable=null,startTime=2.085,type=punctuation,vocabularyFilterMatch=false)],transcript=Hello from a D S. D.)],channelId=null,endTime=2.085,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.0775,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=from,endTime=1.2975,speaker=null,stable=null,startTime=1.0775,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=a,endTime=1.3875,speaker=null,stable=null,startTime=1.2975,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=1.4775,speaker=null,stable=null,startTime=1.3875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=S,endTime=1.9875,speaker=null,stable=null,startTime=1.5875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.9875,speaker=null,stable=null,startTime=1.9875,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=2.1375,speaker=null,stable=null,startTime=1.9875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=2.1375,speaker=null,stable=null,startTime=2.1375,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=K,endTime=2.4875,speaker=null,stable=null,startTime=2.1375,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=for,endTime=2.585,speaker=null,stable=null,startTime=2.4875,type=pronunciation,vocabularyFilterMatch=false)],transcript=Hello from a D S. D. K for)],channelId=null,endTime=2.585,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
emitting audio event
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.0775,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=from,endTime=1.2975,speaker=null,stable=null,startTime=1.0775,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=a,endTime=1.3875,speaker=null,stable=null,startTime=1.2975,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=1.4775,speaker=null,stable=null,startTime=1.3875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=S,endTime=1.9875,speaker=null,stable=null,startTime=1.5875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.9875,speaker=null,stable=null,startTime=1.9875,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=2.1375,speaker=null,stable=null,startTime=1.9875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=K,endTime=2.4875,speaker=null,stable=null,startTime=2.1375,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=for,endTime=2.7075,speaker=null,stable=null,startTime=2.4875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=college,endTime=3.085,speaker=null,stable=null,startTime=2.7075,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=3.085,speaker=null,stable=null,startTime=3.085,type=punctuation,vocabularyFilterMatch=false)],transcript=Hello from a D S. D K for college.)],channelId=null,endTime=3.085,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
Partial: Result(alternatives=[Alternative(entities=null,items=[Item(confidence=null,content=Hello,endTime=1.0775,speaker=null,stable=null,startTime=0.57,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=from,endTime=1.2975,speaker=null,stable=null,startTime=1.0775,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=a,endTime=1.3875,speaker=null,stable=null,startTime=1.2975,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=1.4775,speaker=null,stable=null,startTime=1.3875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=S,endTime=1.9875,speaker=null,stable=null,startTime=1.5875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=1.9875,speaker=null,stable=null,startTime=1.9875,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=D,endTime=2.1375,speaker=null,stable=null,startTime=1.9875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=2.1375,speaker=null,stable=null,startTime=2.1375,type=punctuation,vocabularyFilterMatch=false), Item(confidence=null,content=K,endTime=2.4875,speaker=null,stable=null,startTime=2.1375,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=for,endTime=2.7075,speaker=null,stable=null,startTime=2.4875,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=Colin,endTime=3.445,speaker=null,stable=null,startTime=2.7075,type=pronunciation,vocabularyFilterMatch=false), Item(confidence=null,content=.,endTime=3.445,speaker=null,stable=null,startTime=3.445,type=punctuation,vocabularyFilterMatch=false)],transcript=Hello from a D S. D. K for Colin.)],channelId=null,endTime=3.445,isPartial=true,languageCode=null,languageIdentification=null,resultId=c5d185a7-22cb-46eb-8590-164ab751ecb9,startTime=0.57)
Full transcript available
Full transcript:
Hello from a D S. D. K for Colin.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
