### PR TITLE
refactor(rt): make ExecutionContext implement CoroutineScope

### DIFF
--- a/.changes/2706bf03-43a0-4f21-93a9-4d7be027d554.json
+++ b/.changes/2706bf03-43a0-4f21-93a9-4d7be027d554.json
@@ -1,0 +1,5 @@
+{
+    "id": "2706bf03-43a0-4f21-93a9-4d7be027d554",
+    "type": "misc",
+    "description": "Provide an explicit scope for request bound work"
+}

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
@@ -52,10 +52,9 @@ public data class HttpCall(
  * This must be called when finished with the response!
  */
 @InternalApi
-public fun HttpCall.complete() {
+public suspend fun HttpCall.complete() {
     val job = callContext[Job] as? CompletableJob ?: return
 
-    // FIXME - make suspend and join() the call context job
     try {
         // ensure the response is cancelled
         (response.body as? HttpBody.Streaming)?.readFrom()?.cancel(null)
@@ -63,4 +62,5 @@ public fun HttpCall.complete() {
     }
 
     job.complete()
+    job.join()
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
@@ -5,17 +5,20 @@
 package aws.smithy.kotlin.runtime.client
 
 import aws.smithy.kotlin.runtime.util.Attributes
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Per operation metadata a service client uses to drive the execution of a single request/response
  */
-public class ExecutionContext private constructor(builder: ExecutionContextBuilder) : Attributes by builder.attributes {
-    // TODO - propagate Job() and/or coroutine context?
-
+public class ExecutionContext private constructor(builder: ExecutionContextBuilder) : Attributes by builder.attributes, CoroutineScope {
     /**
      * Default construct an [ExecutionContext]. Note: this is not usually useful without configuring the call attributes
      */
     public constructor() : this(ExecutionContextBuilder())
+
+    override val coroutineContext: CoroutineContext = SupervisorJob()
 
     /**
      * Attributes associated with this particular execution/call

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/ExecutionContext.kt
@@ -6,7 +6,7 @@ package aws.smithy.kotlin.runtime.client
 
 import aws.smithy.kotlin.runtime.util.Attributes
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -18,7 +18,7 @@ public class ExecutionContext private constructor(builder: ExecutionContextBuild
      */
     public constructor() : this(ExecutionContextBuilder())
 
-    override val coroutineContext: CoroutineContext = SupervisorJob()
+    override val coroutineContext: CoroutineContext = Job()
 
     /**
      * Attributes associated with this particular execution/call


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/543

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Most background work is related to HTTP engine but there are cases where clients need a way to launch background work related to request processing (e.g. event streams). This change makes ExecutionContext
implement CoroutineScope for background work to be launched into. This scope is cancelled and joined when an `SdkHttpOperation` is done executing. 

The `HttpCall` context has also been updated and is joined explicitly now. This should expose coroutine leaks much faster if they ever happen again since the operation will fail to complete with a response and we'll hear about it from customers much quicker (not to mention it will be more obvious what is happening). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
