### PR TITLE
fix: correctly calculate file lengths on byte streams from paths

### DIFF
--- a/.changes/2310b190-0074-4d42-89c4-8229b0197609.json
+++ b/.changes/2310b190-0074-4d42-89c4-8229b0197609.json
@@ -1,0 +1,8 @@
+{
+    "id": "2310b190-0074-4d42-89c4-8229b0197609",
+    "type": "bugfix",
+    "description": "Fix the calculation of file lengths on `ByteStream`s from `Path`s",
+    "issues": [
+        "awslabs/smithy-kotlin#678"
+    ]
+}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -45,13 +45,9 @@ public fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStre
     val f = toFile()
     require(f.exists()) { "cannot create ByteStream, file does not exist: $this" }
     require(f.isFile) { "cannot create a ByteStream from a directory: $this" }
+    require(endInclusive >= -1L) { "endInclusive must be -1 or greater" }
 
-    val calculatedEndInclusive = when {
-        endInclusive >= 0L -> endInclusive
-        endInclusive == -1L -> f.length() - 1
-        else -> throw IllegalArgumentException("endInclusive must be -1 or greater")
-    }
-
+    val calculatedEndInclusive = if (endInclusive == -1L) f.length() - 1L else endInclusive
     return f.asByteStream(start, calculatedEndInclusive)
 }
 

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -23,7 +23,7 @@ public fun ByteStream.Companion.fromFile(file: File): ByteStream = file.asByteSt
  */
 public fun File.asByteStream(start: Long = 0, endInclusive: Long = length() - 1): ByteStream {
     require(start >= 0) { "start index $start cannot be negative" }
-    require(endInclusive == -1L || endInclusive >= start) {
+    require(endInclusive >= start) {
         "end index $endInclusive must be greater than or equal to start index $start"
     }
 
@@ -45,7 +45,14 @@ public fun Path.asByteStream(start: Long = 0, endInclusive: Long = -1): ByteStre
     val f = toFile()
     require(f.exists()) { "cannot create ByteStream, file does not exist: $this" }
     require(f.isFile) { "cannot create a ByteStream from a directory: $this" }
-    return f.asByteStream(start, endInclusive)
+
+    val calculatedEndInclusive = when {
+        endInclusive >= 0L -> endInclusive
+        endInclusive == -1L -> f.length() - 1
+        else -> throw IllegalArgumentException("endInclusive must be -1 or greater")
+    }
+
+    return f.asByteStream(start, calculatedEndInclusive)
 }
 
 /**

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
@@ -122,4 +122,12 @@ class ByteStreamJVMTest {
 
         assertContentEquals(expected, part0 + part1 + part2)
     }
+
+    @Test
+    fun `path as byte stream has contentLength`() = runTest {
+        val path = RandomTempFile(1024).toPath()
+        val stream = path.asByteStream()
+
+        assertEquals(1024, stream.contentLength)
+    }
 }


### PR DESCRIPTION
## Issue \#

Closes #678 

## Description of changes

We were calculating `endInclusive` incorrectly downstream of `Path.asByteStream` when no explicit value was passed. This change explicitly calculates file length if none is provided and prohibits `endInclusive == -1` in `File.asByteStream`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
