### PR TITLE
Fix crt stream leak via watchdog

### DIFF
--- a/.changes/0c737e4d-adb6-45f4-95d3-7123f3455171.json
+++ b/.changes/0c737e4d-adb6-45f4-95d3-7123f3455171.json
@@ -1,0 +1,5 @@
+{
+    "id": "0c737e4d-adb6-45f4-95d3-7123f3455171",
+    "type": "bugfix",
+    "description": "Fix occasional stream leak due to race condition in CRT engine"
+}

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
@@ -49,7 +49,7 @@ public class ReadChannelBodyStream(
             while (producerJob.isActive) {
                 if (bodyChan.isClosedForRead) {
                     producerJob.complete()
-                    return@launch;
+                    return@launch
                 }
                 delay(POLLING_DELAY)
             }

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
@@ -15,6 +15,9 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+
+private val POLLING_DELAY = 100.milliseconds
 
 /**
  * write as much of [outgoing] to [dest] as possible
@@ -40,6 +43,16 @@ public class ReadChannelBodyStream(
     init {
         producerJob.invokeOnCompletion { cause ->
             bodyChan.cancel(cause)
+        }
+
+        launch(coroutineContext + CoroutineName("body-channel-watchdog")) {
+            while (producerJob.isActive) {
+                if (bodyChan.isClosedForRead) {
+                    producerJob.complete()
+                    return@launch;
+                }
+                delay(POLLING_DELAY)
+            }
         }
     }
 

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -7,9 +7,7 @@ package aws.smithy.kotlin.runtime.http.test
 
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.hashing.sha256
-import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.headers
@@ -17,13 +15,10 @@ import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
 import aws.smithy.kotlin.runtime.http.test.util.test
 import aws.smithy.kotlin.runtime.http.test.util.testSetup
-import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.util.encodeToHex
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -83,6 +78,39 @@ class UploadTest : AbstractEngineTest() {
             }
         }
     }
+
+@Test
+fun testUploadWithClosingDelay() = testEngines {
+    test { env, client ->
+        val data = ByteArray(16) { it.toByte() }
+        val sha = data.sha256().encodeToHex()
+        val ch = SdkByteChannel(autoFlush = true)
+        val content = object : HttpBody.Streaming() {
+            override val contentLength: Long = data.size.toLong()
+            override fun readFrom(): SdkByteReadChannel = ch
+        }
+
+        val req = HttpRequest {
+            method = HttpMethod.POST
+            testSetup(env)
+            url.path = "/upload/content"
+            body = content
+        }
+
+        coroutineScope {
+            launch {
+                ch.writeFully(data)
+                delay(1000)
+                // CRT will have stopped polling by now
+                ch.close()
+            }
+            val call = client.call(req)
+            call.complete()
+            assertEquals(HttpStatusCode.OK, call.response.status)
+            assertEquals(sha, call.response.headers["content-sha256"])
+        }
+    }
+}
 
     @Test
     fun testUploadWithWrappedStream() = testEngines {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Fix the CRT streaming delay bug by adding a poller.

Mutually exclusive with #701 and #703.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
