### PR TITLE
Fix crt stream leak via tracking transfer position

### DIFF
--- a/.changes/0c737e4d-adb6-45f4-95d3-7123f3455171.json
+++ b/.changes/0c737e4d-adb6-45f4-95d3-7123f3455171.json
@@ -1,0 +1,5 @@
+{
+    "id": "0c737e4d-adb6-45f4-95d3-7123f3455171",
+    "type": "bugfix",
+    "description": "Fix occasional stream leak due to race condition in CRT engine"
+}

--- a/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
+++ b/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
@@ -132,7 +132,7 @@ private suspend fun signableBodyStream(body: HttpBody): HttpRequestBodyStream? =
     body is HttpBody.Streaming && body.isReplayable ->
         // FIXME: this is not particularly efficient since we have to launch a coroutine to fill it.
         // see https://github.com/awslabs/smithy-kotlin/issues/436
-        ReadChannelBodyStream(body.readFrom(), coroutineContext)
+        ReadChannelBodyStream(body, coroutineContext)
     body is HttpBody.Streaming && !body.isReplayable ->
         // can only consume the stream once
         null

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
@@ -38,7 +38,7 @@ private suspend fun signableBodyStream(body: HttpBody): HttpRequestBodyStream? =
     is HttpBody.Streaming -> if (body.isReplayable) {
         // FIXME: this is not particularly efficient since we have to launch a coroutine to fill it.
         // see https://github.com/awslabs/smithy-kotlin/issues/436
-        ReadChannelBodyStream(body.readFrom(), coroutineContext)
+        ReadChannelBodyStream(body, coroutineContext)
     } else {
         // can only consume the stream once
         null

--- a/runtime/crt-util/jvm/src/aws/smithy/kotlin/runtime/crt/RequestUtilsJVM.kt
+++ b/runtime/crt-util/jvm/src/aws/smithy/kotlin/runtime/crt/RequestUtilsJVM.kt
@@ -9,6 +9,5 @@ import aws.sdk.kotlin.crt.io.MutableBuffer
 import aws.smithy.kotlin.runtime.io.SdkByteBuffer
 import aws.smithy.kotlin.runtime.io.readAvailable
 
-internal actual fun transferRequestBody(outgoing: SdkByteBuffer, dest: MutableBuffer) {
+internal actual fun transferRequestBody(outgoing: SdkByteBuffer, dest: MutableBuffer): Int =
     outgoing.readAvailable(dest.buffer)
-}

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferJVM.kt
@@ -37,12 +37,14 @@ public fun SdkByteBuffer.readFully(dst: ByteBuffer) {
 /**
  * Read as much from this buffer as possible to [dst] buffer moving its position
  */
-public fun SdkByteBuffer.readAvailable(dst: ByteBuffer) {
+public fun SdkByteBuffer.readAvailable(dst: ByteBuffer): Int {
     val wc = minOf(readRemaining.toInt(), dst.remaining())
-    if (wc == 0) return
-    val dstCopy = dst.duplicate().apply {
-        limit(position() + wc)
+    if (wc > 0) {
+        val dstCopy = dst.duplicate().apply {
+            limit(position() + wc)
+        }
+        readFully(dstCopy)
+        dst.position(dst.position() + wc)
     }
-    readFully(dstCopy)
-    dst.position(dst.position() + wc)
+    return wc
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -32,10 +32,7 @@ internal val HttpRequest.uri: Uri
 internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.kotlin.crt.http.HttpRequest {
     val body = this.body
     val bodyStream = when (body) {
-        is HttpBody.Streaming -> {
-            check(!body.isDuplex) { "CrtHttpEngine does not yet support full duplex streams" }
-            ReadChannelBodyStream(body.readFrom(), callContext)
-        }
+        is HttpBody.Streaming -> ReadChannelBodyStream(body, callContext)
         is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
         else -> null
     }

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -7,9 +7,7 @@ package aws.smithy.kotlin.runtime.http.test
 
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.hashing.sha256
-import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.HttpStatusCode
+import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.headers
@@ -17,13 +15,10 @@ import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
 import aws.smithy.kotlin.runtime.http.test.util.test
 import aws.smithy.kotlin.runtime.http.test.util.testSetup
-import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.util.encodeToHex
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -74,6 +69,39 @@ class UploadTest : AbstractEngineTest() {
                     ch.writeFully(slice, 0, end)
                     delay(1000)
                     ch.writeFully(data, offset = end)
+                    ch.close()
+                }
+                val call = client.call(req)
+                call.complete()
+                assertEquals(HttpStatusCode.OK, call.response.status)
+                assertEquals(sha, call.response.headers["content-sha256"])
+            }
+        }
+    }
+
+    @Test
+    fun testUploadWithClosingDelay() = testEngines {
+        test { env, client ->
+            val data = ByteArray(16) { it.toByte() }
+            val sha = data.sha256().encodeToHex()
+            val ch = SdkByteChannel(autoFlush = true)
+            val content = object : HttpBody.Streaming() {
+                override val contentLength: Long = data.size.toLong()
+                override fun readFrom(): SdkByteReadChannel = ch
+            }
+
+            val req = HttpRequest {
+                method = HttpMethod.POST
+                testSetup(env)
+                url.path = "/upload/content"
+                body = content
+            }
+
+            coroutineScope {
+                launch {
+                    ch.writeFully(data)
+                    delay(1000)
+                    // CRT will have stopped polling by now
                     ch.close()
                 }
                 val call = client.call(req)


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Fix the CRT streaming delay bug by tracking the current transfer position.

Mutually exclusive with #700 and #703.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
