### PR TITLE
fix: properly check if a member can be nullable

### DIFF
--- a/.changes/69672ec4-a822-465c-80ac-2656dd3ff334.json
+++ b/.changes/69672ec4-a822-465c-80ac-2656dd3ff334.json
@@ -1,0 +1,5 @@
+{
+    "id": "69672ec4-a822-465c-80ac-2656dd3ff334",
+    "type": "bugfix",
+    "description": "Properly check if a member can be nullable"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.10
 
 # codegen
-smithyVersion=1.23.0
+smithyVersion=1.25.0
 smithyGradleVersion=0.6.0
 
 # testing/utility


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
Change the way we compute the nullability of members. Before we were only looking at the box trait in the target type and ignoring the trait on the member itself. See for instance the test `can read box trait from member` which has the following model:
```
        namespace com.test
        structure MyStruct {
           @box
           foo: MyFoo
        }
        long MyFoo
```
The code was incorrectly assuming that the foo member was not nullable. This change accounts for this by using the `NullableIndex` which correctly computes whether or not the member or the target type are nullable. 

**NOTE** This is a draft pull request as it depends on the pending release of smithy 1.25.0 scheduled for tomorrow, but sending along to get a head start on the review of the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
