### PR TITLE
feat(codegen): change property type of RetryStrategy to allow mutability

### DIFF
--- a/.changes/0d2cc7ea-39dc-11ed-a261-0242ac120002.json
+++ b/.changes/0d2cc7ea-39dc-11ed-a261-0242ac120002.json
@@ -1,0 +1,6 @@
+{
+  "id": "0d2cc7ea-39dc-11ed-a261-0242ac120002",
+  "type": "feature",
+  "description": "Enables configurability of the retry strategy through environment variables, system properties, and AWS profiles.",
+  "issues": ["awslabs/aws-sdk-kotlin#486"]
+}

--- a/.changes/0d2cc7ea-39dc-11ed-a261-0242ac120002.json
+++ b/.changes/0d2cc7ea-39dc-11ed-a261-0242ac120002.json
@@ -1,6 +1,6 @@
 {
   "id": "0d2cc7ea-39dc-11ed-a261-0242ac120002",
   "type": "feature",
-  "description": "Enables configurability of the retry strategy through environment variables, system properties, and AWS profiles.",
+  "description": "Enable configurability of the retry strategy through environment variables, system properties, and AWS profiles.",
   "issues": ["awslabs/aws-sdk-kotlin#486"]
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
@@ -264,7 +264,7 @@ object KotlinClientRuntimeConfigProperty {
                 strategy.
             """.trimIndent()
 
-            propertyType = ClientConfigPropertyType.ConstantValue("StandardRetryStrategy()")
+            propertyType = ClientConfigPropertyType.RequiredWithDefault("StandardRetryStrategy()")
 
             additionalImports = listOf(RuntimeTypes.Core.Retries.StandardRetryStrategy)
         }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -43,7 +43,7 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
     public val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
-    public val retryStrategy: RetryStrategy = StandardRetryStrategy()
+    public val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
 """
         contents.shouldContainWithDiff(expectedProps)
@@ -66,6 +66,11 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
          * that represent idempotent tokens when not explicitly set by the caller using this generator.
          */
         public var idempotencyTokenProvider: IdempotencyTokenProvider? = null
+        /**
+         * The [RetryStrategy] implementation to use for service calls. All API calls will be wrapped by the
+         * strategy.
+         */
+        public var retryStrategy: RetryStrategy? = null
         /**
          * Configure events that will be logged. By default clients will not output
          * raw requests or responses. Use this setting to opt-in to additional debug logging.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue 
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/486

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is being submitted alongside another in [aws-kotlin-sdk](https://github.com/awslabs/aws-sdk-kotlin/pull/702). A mutable RetryStrategy is required for user configurability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
