### PR TITLE
chore: update CODEOWNERS to SDE group instead of admins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @awslabs/aws-sdk-kotlin-admins
+*    @awslabs/aws-sdk-kotlin-sde


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Update the code owners of this repository to [**aws-sdk-kotlin-sde**](https://github.com/orgs/awslabs/teams/aws-sdk-kotlin-sde/members) instead of [**aws-sdk-kotlin-admins**](https://github.com/orgs/awslabs/teams/aws-sdk-kotlin-admins/members).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
