### PR TITLE
fix(rt): disable throwing CancellationException in OkHttp's transferBody method

### DIFF
--- a/.changes/a73c323b-980c-408e-9f67-6ed2d9c0ade7.json
+++ b/.changes/a73c323b-980c-408e-9f67-6ed2d9c0ade7.json
@@ -1,0 +1,6 @@
+{
+  "id": "a73c323b-980c-408e-9f67-6ed2d9c0ade7",
+  "type": "bugfix",
+  "description": "Disable throwing CancellationException in OkHttp engine's transferBody method",
+  "issues": ["awslabs/aws-sdk-kotlin#704"]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
@@ -52,9 +52,7 @@ internal class ByteChannelRequestBody(
     private suspend fun transferBody(sink: BufferedSink) = withJob(producerJob) {
         val chan = body.readFrom()
         val buffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
-        while (!chan.isClosedForRead) {
-            // ensure request context hasn't been cancelled
-            callContext.ensureActive()
+        while (!chan.isClosedForRead && callContext.isActive) {
 
             // fill the buffer by reading chunks from the underlying source
             while (chan.readAvailable(buffer) != -1 && buffer.remaining() > 0) {}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
@@ -53,7 +53,6 @@ internal class ByteChannelRequestBody(
         val chan = body.readFrom()
         val buffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
         while (!chan.isClosedForRead && callContext.isActive) {
-
             // fill the buffer by reading chunks from the underlying source
             while (chan.readAvailable(buffer) != -1 && buffer.remaining() > 0) {}
 


### PR DESCRIPTION
Disable throwing CancellationException in OkHttp's transferBody method by replacing `.ensureActive()` call with `.isActive` in the conditional loop check. 

## Issue
https://github.com/awslabs/aws-sdk-kotlin/issues/704

## Description of changes
In the issue above, we were seeing a CancellationException being intermittently thrown when cancelling a coroutine which was performing some HTTP request. This is because when we check if the coroutine is active, we use `ensureActive()` which is [guaranteed to throw a CancellationException](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/ensure-active.html) which is currently not handled. 

There are at least two options to solve this:

1) Wrap the `writeTo` method in a try-catch. Catch the CancellationException and prevent it from bubbling further up the call stack
2) Prevent throwing CancellationException in the first place

The second option seemed more straightforward and addresses the root cause, so that's what is implemented here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
