### PR TITLE
fix: correct check for channel closure when reading all bytes of an HttpBody

### DIFF
--- a/.changes/3952237f-4d07-4e81-ac73-73fb935bfd43.json
+++ b/.changes/3952237f-4d07-4e81-ac73-73fb935bfd43.json
@@ -1,0 +1,5 @@
+{
+    "id": "3952237f-4d07-4e81-ac73-73fb935bfd43",
+    "type": "bugfix",
+    "description": "Switch to a safer check to determine if all bytes have been read from an HTTP body"
+}

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannel.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannel.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.http.testutils
 
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannel.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannel.kt
@@ -1,0 +1,6 @@
+package aws.smithy.kotlin.runtime.http.testutils
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+
+expect class MockByteReadChannel(contents: String, isClosedForRead: Boolean = true, isClosedForWrite: Boolean = true) :
+    SdkByteReadChannel

--- a/runtime/protocol/http/jvm/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannelJVM.kt
+++ b/runtime/protocol/http/jvm/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannelJVM.kt
@@ -1,0 +1,19 @@
+package aws.smithy.kotlin.runtime.http.testutils
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import java.nio.ByteBuffer
+
+actual class MockByteReadChannel actual constructor(
+    val contents: String,
+    override val isClosedForRead: Boolean,
+    override val isClosedForWrite: Boolean,
+) : SdkByteReadChannel {
+    override val availableForRead: Int = 0
+    override suspend fun awaitContent() = error("Not implemented")
+    override fun cancel(cause: Throwable?) = error("Not implemented")
+    override fun close() = error("Not implemented")
+    override suspend fun readAvailable(sink: ByteArray, offset: Int, length: Int) = error("Not implemented")
+    override suspend fun readAvailable(sink: ByteBuffer): Int = error("Not implemented")
+    override suspend fun readFully(sink: ByteArray, offset: Int, length: Int) = error("Not implemented")
+    override suspend fun readRemaining(limit: Int) = contents.encodeToByteArray()
+}

--- a/runtime/protocol/http/jvm/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannelJVM.kt
+++ b/runtime/protocol/http/jvm/test/aws/smithy/kotlin/runtime/http/testutils/MockByteReadChannelJVM.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.http.testutils
 
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#681](https://github.com/awslabs/aws-sdk-kotlin/issues/681)

## Description of changes

This PR updates the check used to determine if an HTTP body has been fully read. Previously, we only checked `isClosedForRead` which is sometimes inaccurate based on timing. To be safer, we'll check both `isClosedForRead` and `isClosedForWrite`/`availableForRead` since either condition effectively indicates that the entire body has been read.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
