### PR TITLE
bugfix: correct nullability semantics around generation and usage of struct members

### DIFF
--- a/.changes/da10a905-d84c-45bf-bc34-520ab90d9285.json
+++ b/.changes/da10a905-d84c-45bf-bc34-520ab90d9285.json
@@ -1,0 +1,5 @@
+{
+    "id": "da10a905-d84c-45bf-bc34-520ab90d9285",
+    "type": "bugfix",
+    "description": "Fix inconsistent nullability semantics when generating struct members."
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.10
 
 # codegen
-smithyVersion=1.25.0
+smithyVersion=1.25.2
 smithyGradleVersion=0.6.0
 
 # testing/utility

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -170,7 +170,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         val targetShape =
             model.getShape(shape.target).orElseThrow { CodegenException("Shape not found: ${shape.target}") }
 
-        val targetSymbol = if (nullableIndex.isMemberNullable(shape, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1)) {
+        val targetSymbol = if (nullableIndex.isMemberNullable(shape, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1_NO_INPUT)) {
             toSymbol(targetShape).toBuilder().boxed().build()
         } else {
             toSymbol(targetShape)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -148,7 +148,7 @@ class StructureGenerator(
     // Return the appropriate hashCode fragment based on ShapeID of member target.
     private fun selectHashFunctionForShape(member: MemberShape): String {
         val targetShape = model.expectShape(member.target)
-        val isNullable = nullableIndex.isMemberNullable(member, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1_NO_INPUT)
+        val isNullable = memberNameSymbolIndex[member]!!.second.isBoxed
         return when (targetShape.type) {
             ShapeType.INTEGER ->
                 when (isNullable) {


### PR DESCRIPTION
## Description of changes

- Fix the nullability index check mode in the symbol provider (to prevent member signature breakage)
- Use a consistent symbol reference for future null checks, instead of re-checking with the index, when generating references to members


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
