### PR TITLE
fix: enable intra-repo links in API ref docs

### DIFF
--- a/.changes/2ae86281-8a85-4470-bb85-618d857cb21b.json
+++ b/.changes/2ae86281-8a85-4470-bb85-618d857cb21b.json
@@ -1,0 +1,8 @@
+{
+    "id": "2ae86281-8a85-4470-bb85-618d857cb21b",
+    "type": "bugfix",
+    "description": "Enable intra-repo links in API ref docs",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#715"
+    ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,12 @@ if (project.prop("kotlinWarningsAsErrors")?.toString()?.toBoolean() == true) {
 tasks.dokkaHtmlMultiModule.configure {
     moduleName.set("Smithy Kotlin")
 
+    // Output subprojects' docs to <docs-base>/project-name/* instead of <docs-base>/path/to/project-name/*
+    // This is especially important for inter-repo linking (e.g., via externalDocumentationLink) because the
+    // package-list doesn't contain enough project path information to indicate where modules' documentation are
+    // located.
+    fileLayout.set { parent, child -> parent.outputDirectory.get().resolve(child.project.name) }
+
     includes.from(
         // NOTE: these get concatenated
         rootProject.file("docs/dokka-presets/README.md"),

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
+# FIXME - workaround for https://github.com/Kotlin/dokka/issues/2679
+kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 # FIXME - see https://youtrack.jetbrains.com/issue/KTIJ-21583/HMPP-1-6-20-breaks-autocomplete-in-multiplatform-composite-build
 #kotlin.mpp.hierarchicalStructureSupport=false
@@ -46,4 +48,4 @@ kotlinLoggingVersion=2.1.21
 slf4jVersion=1.7.36
 
 # crt
-crtKotlinVersion=0.6.4
+crtKotlinVersion=0.6.5-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,7 @@ kotlin.incremental.js=true
 kotlin.incremental.multiplatform=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
-
-# FIXME - workaround for https://github.com/Kotlin/dokka/issues/2679
 kotlin.mpp.enableCompatibilityMetadataVariant=true
-
-# FIXME - see https://youtrack.jetbrains.com/issue/KTIJ-21583/HMPP-1-6-20-breaks-autocomplete-in-multiplatform-composite-build
-#kotlin.mpp.hierarchicalStructureSupport=false
 
 # SDK
 sdkVersion=0.12.9-SNAPSHOT


### PR DESCRIPTION
## Issue \#

[aws-sdk-kotlin#715](https://github.com/awslabs/aws-sdk-kotlin/issues/715)

## Description of changes

* Temporarily works around [dokka#2679](https://github.com/Kotlin/dokka/issues/2679) by enabling non-hierarchical project compatibility mode
* Bumps **aws-crt-kotlin** version to pick up similar fix in dependent project
* Configures flatter submodule directory tree in generated documentation

**Companion PRs**: [aws-crt-kotlin#59](https://github.com/awslabs/aws-crt-kotlin/pull/59) & [aws-sdk-kotlin#716](https://github.com/awslabs/aws-sdk-kotlin/pull/716)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
