### PR TITLE
feat(rt): add `nextRefresh` field to Credentials for static stability support

### DIFF
--- a/.changes/329b6bc4-1242-4cc2-89af-600e0013eaf7.json
+++ b/.changes/329b6bc4-1242-4cc2-89af-600e0013eaf7.json
@@ -1,0 +1,6 @@
+{
+  "id": "329b6bc4-1242-4cc2-89af-600e0013eaf7",
+  "type": "feature",
+  "description": "Add nextRefresh field to credentials to be used for static stability",
+  "issues": ["awslabs/aws-sdk-kotlin#707"]
+}

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
@@ -17,4 +17,5 @@ public data class Credentials(
     val sessionToken: String? = null,
     val expiration: Instant? = null,
     val providerName: String? = null,
+    val nextRefresh: Instant? = null,
 )

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
@@ -17,5 +17,4 @@ public data class Credentials(
     val sessionToken: String? = null,
     val expiration: Instant? = null,
     val providerName: String? = null,
-    val nextRefresh: Instant? = null,
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `nextRefresh` field to Credentials for static stability support

## Issue \#
[awslabs/aws-sdk-kotlin#707](https://github.com/awslabs/aws-sdk-kotlin/issues/707)

## Description of changes
See the [pair PR in aws-sdk-kotlin](https://github.com/awslabs/aws-sdk-kotlin/pull/719) for more description of the change. To stop continuously refreshing expired credentials, this new field will be used as an override. If `nextRefresh` is set, the CachedCredentialsProvider will not refresh the credentials until that time has passed. It will default to null, so it won't change SDK behavior unless set explicitly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
