### PR TITLE
Fix timestamp format codegen

### DIFF
--- a/.changes/cccb2f1d-b607-4b8d-9f26-5ff172fffa1d.json
+++ b/.changes/cccb2f1d-b607-4b8d-9f26-5ff172fffa1d.json
@@ -1,0 +1,8 @@
+{
+    "id": "cccb2f1d-b607-4b8d-9f26-5ff172fffa1d",
+    "type": "bugfix",
+    "description": "Properly parse timestamps when format override is applied to target shapes",
+    "issues": [
+        "awslabs/smithy-kotlin#714"
+    ]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -541,10 +541,8 @@ open class DeserializeStructGenerator(
 
             target.type == ShapeType.TIMESTAMP -> {
                 writer.addImport(RuntimeTypes.Core.Instant)
-                val tsFormat = shape
-                    .getTrait(TimestampFormatTrait::class.java)
-                    .map { it.format }
-                    .orElse(defaultTimestampFormat)
+                val trait = shape.getTrait<TimestampFormatTrait>() ?: target.getTrait()
+                val tsFormat = trait?.format ?: defaultTimestampFormat
 
                 when (tsFormat) {
                     TimestampFormatTrait.Format.EPOCH_SECONDS -> "deserializeString().let { Instant.fromEpochSeconds(it) }"


### PR DESCRIPTION
## Issue \#

#714 

## Description of changes

Check both member shape and target shape for `timestampFormat` override. This is tested by new protocol tests proposed in [smithy#1440](https://github.com/awslabs/smithy/pull/1440).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
