### PR TITLE
feat(rt): add `MIN`/`MAX` values to `Instant`

### DIFF
--- a/.changes/3c662a11-98c2-48cc-8cf5-ca0b293db1f9.json
+++ b/.changes/3c662a11-98c2-48cc-8cf5-ca0b293db1f9.json
@@ -1,0 +1,5 @@
+{
+  "id": "3c662a11-98c2-48cc-8cf5-ca0b293db1f9",
+  "type": "feature",
+  "description": "add `MIN` and `MAX` accessors for the Instant type"
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -68,6 +68,17 @@ public expect class Instant : Comparable<Instant> {
          * Create an [Instant] from the current system time
          */
         public fun now(): Instant
+
+        /**
+         * Create an [Instant] with the minimum possible value
+         */
+        public val MIN_VALUE: Instant
+
+        /**
+         * Create an [Instant] with the maximum possible value
+         */
+        public val MAX_VALUE: Instant
+
     }
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -78,7 +78,6 @@ public expect class Instant : Comparable<Instant> {
          * Create an [Instant] with the maximum possible value
          */
         public val MAX_VALUE: Instant
-
     }
 }
 

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -129,12 +129,12 @@ public actual class Instant(internal val value: jtInstant) : Comparable<Instant>
         /**
          * Create an [Instant] with the minimum possible value
          */
-        public val MIN: Instant = Instant(jtInstant.MIN)
+        public actual val MIN_VALUE: Instant = Instant(jtInstant.MIN)
 
         /**
          * Create an [Instant] with the maximum possible value
          */
-        public val MAX: Instant = Instant(jtInstant.MAX)
+        public actual val MAX_VALUE: Instant = Instant(jtInstant.MAX)
     }
 }
 

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -125,6 +125,16 @@ public actual class Instant(internal val value: jtInstant) : Comparable<Instant>
          * Create an [Instant] from the current system time
          */
         public actual fun now(): Instant = Instant(jtInstant.now())
+
+        /**
+         * Create an [Instant] with the minimum possible value
+         */
+        public val MIN: Instant = Instant(jtInstant.MIN)
+
+        /**
+         * Create an [Instant] with the maximum possible value
+         */
+        public val MAX: Instant = Instant(jtInstant.MAX)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `Instant.MIN` and `Instant.MAX` which represent the minimum and maximum possible values of an Instant.

## Issue \#
N/A

## Description of changes
This is going to be used by a twin PR in aws-sdk-kotlin to set the expiration time of Credentials when no expiration data is received. When no expiration data is received, we should treat the Credentials as non-expiring. `Instant.MAX` will be used to ensure these Credentials are not refreshed at any point in their use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.