### PR TITLE
feat(codegen): add `order` parameter to ClientConfigProperty to be used for ordering configuration dependencies

### DIFF
--- a/.changes/490f40f2-97e1-47f9-b53c-d0740e394814.json
+++ b/.changes/490f40f2-97e1-47f9-b53c-d0740e394814.json
@@ -1,0 +1,6 @@
+{
+  "id": "490f40f2-97e1-47f9-b53c-d0740e394814",
+  "type": "feature",
+  "description": "Add order parameter to ClientConfigProperty to be used for ordering configuration dependencies",
+  "issues": ["awslabs/aws-sdk-kotlin/#711"]
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
@@ -68,7 +68,7 @@ class ClientConfigGenerator(
 
         addPropertyImports()
 
-        props.sortBy { it.propertyName }
+        props.sortWith(compareBy({ it.order }, { it.propertyName }))
         val baseClasses = props
             .mapNotNull { it.baseClass?.name }
             .toSet()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
@@ -70,6 +70,11 @@ class ClientConfigProperty private constructor(builder: Builder) {
     val additionalImports: List<Symbol> = builder.additionalImports
 
     /**
+     * The priority order of rendering the property. Used to manage dependencies between configuration properties.
+     */
+    val order: Int = builder.order
+
+    /**
      * Flag indicating if this property stems from some base class and needs an override modifier when rendered
      */
     internal val requiresOverride: Boolean
@@ -143,6 +148,8 @@ class ClientConfigProperty private constructor(builder: Builder) {
         var propertyType: ClientConfigPropertyType = ClientConfigPropertyType.SymbolDefault
 
         var additionalImports: List<Symbol> = emptyList()
+
+        var order: Int = 0
 
         fun build(): ClientConfigProperty = ClientConfigProperty(this)
     }
@@ -237,6 +244,7 @@ object KotlinClientRuntimeConfigProperty {
             NOTE: The caller is responsible for managing the lifetime of the engine when set. The SDK
             client will not close it when the client is closed.
             """.trimIndent()
+            order = -1
         }
 
         IdempotencyTokenProvider = ClientConfigProperty {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
@@ -244,7 +244,7 @@ object KotlinClientRuntimeConfigProperty {
             NOTE: The caller is responsible for managing the lifetime of the engine when set. The SDK
             client will not close it when the client is closed.
             """.trimIndent()
-            order = -1
+            order = -100
         }
 
         IdempotencyTokenProvider = ClientConfigProperty {

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -40,8 +40,8 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
         contents.shouldContainWithDiff(expectedCtor)
 
         val expectedProps = """
-    public val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
+    public val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
     public val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
@@ -51,16 +51,16 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
         val expectedBuilder = """
     public class Builder {
         /**
-         * Set the [aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver] used to resolve service endpoints. Operation requests will be
-         * made against the endpoint returned by the resolver.
-         */
-        public var endpointResolver: EndpointResolver? = null
-        /**
          * Override the default HTTP client engine used to make SDK requests (e.g. configure proxy behavior, timeouts, concurrency, etc).
          * NOTE: The caller is responsible for managing the lifetime of the engine when set. The SDK
          * client will not close it when the client is closed.
          */
         public var httpClientEngine: HttpClientEngine? = null
+        /**
+         * Set the [aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver] used to resolve service endpoints. Operation requests will be
+         * made against the endpoint returned by the resolver.
+         */
+        public var endpointResolver: EndpointResolver? = null
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
          * that represent idempotent tokens when not explicitly set by the caller using this generator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an `order` Integer parameter to ClientConfigProperty which is used to order configuration dependencies.

## Issue \#
[awslabs/aws-sdk-kotlin/711](https://github.com/awslabs/aws-sdk-kotlin/issues/711)

## Description of changes
This was added in order to support passing of certain client configuration properties into other client configuration properties. For example, client configurations can specify an HttpEngine to be used for all requests, which must be passed into the DefaultChainCredentialsProvider which is also a client configuration. This introduces a dependency between client configuration properties which I addressed with the `order` parameter.

When rendering the client configuration properties, we will sort them by `order` (new behavior) and then alphabetically by property name (as it's done today).  This will ensure all client configuration property dependencies are satisfied before we try to access them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.