### PR TITLE
fix(rt): okhttp engine crashing on Android when coroutine is cancelled while uploading request body

### DIFF
--- a/.changes/841987e7-c68c-4ff6-8426-f7bf51373d79.json
+++ b/.changes/841987e7-c68c-4ff6-8426-f7bf51373d79.json
@@ -1,0 +1,8 @@
+{
+    "id": "841987e7-c68c-4ff6-8426-f7bf51373d79",
+    "type": "bugfix",
+    "description": "Fix OkHttp engine crashing on Android when coroutine is cancelled while uploading request body",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#733"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/ByteChannelRequestBody.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.*
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okio.BufferedSink
+import java.io.IOException
 import java.nio.ByteBuffer
 import kotlin.coroutines.CoroutineContext
 
@@ -76,7 +77,9 @@ private inline fun <T> withJob(job: CompletableJob, block: () -> T): T {
         return block()
     } catch (ex: Exception) {
         job.completeExceptionally(ex)
-        throw ex
+        // wrap all exceptions thrown from inside `okhttp3.RequestBody#writeTo(..)` as an IOException
+        // see https://github.com/awslabs/aws-sdk-kotlin/issues/733
+        throw IOException(ex)
     } finally {
         job.complete()
     }

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/UploadTest.kt
@@ -176,6 +176,7 @@ class UploadTest : AbstractEngineTest() {
      * plug in a custom executor/thread factory to make the actual assertions (in a JVM test sourceSet).
      * Although that would only work so long as okhttp continues to use `execute` rather than `submit` internally.
      */
+    @OptIn(DelicateCoroutinesApi::class)
     @Test
     fun testUploadCancellation() = testEngines {
         test { env, client ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes https://github.com/awslabs/aws-sdk-kotlin/issues/733

## Description of changes
Wrap all exceptions from our implementation of `okhttp3.RequestBody#writeTo(...)` as an `IOException`.

See https://github.com/awslabs/aws-sdk-kotlin/issues/733#issuecomment-1290925795 for more detailed description.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
