### PR TITLE
test(rt): add missing tests around round tripping ISO8601 timestamps with UTC offsets

### DIFF
--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/time/InstantTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/time/InstantTest.kt
@@ -239,4 +239,22 @@ class InstantTest {
         assertEquals(Instant.fromEpochSeconds(1010, 2000), start + offset)
         assertEquals(Instant.fromEpochSeconds(990, 0), start - offset)
     }
+
+    @Test
+    fun testRoundTripUtcOffset() {
+        // sanity check we only ever emit UTC timestamps (e.g. round trip a response with UTC offset)
+        val tests = listOf(
+            "2020-11-05T19:22:37+00:20" to "2020-11-05T19:02:37Z",
+            "2020-11-05T19:22:37-00:20" to "2020-11-05T19:42:37Z",
+            "2020-11-05T19:22:37+12:45" to "2020-11-05T06:37:37Z",
+            "2020-11-05T19:22:37-12:45" to "2020-11-06T08:07:37Z",
+            "2020-11-05T19:22:37.345-12:45" to "2020-11-06T08:07:37.345Z",
+        )
+
+        tests.forEachIndexed { idx, test ->
+            val parsed = Instant.fromIso8601(test.first)
+            val actual = parsed.format(TimestampFormat.ISO_8601)
+            assertEquals(test.second, actual, "test[$idx]: failed to format offset timestamp in UTC")
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/725

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds missing test coverage around round tripping timestamps with UTC offsets to ensure we only emit timestamps in UTC.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
