### PR TITLE
fix: upgrade smithy and correct formurl serialization of empty lists

### DIFF
--- a/.changes/8b692602-06c4-4c97-b554-a08cac97e1ea.json
+++ b/.changes/8b692602-06c4-4c97-b554-a08cac97e1ea.json
@@ -1,0 +1,5 @@
+{
+    "id": "8b692602-06c4-4c97-b554-a08cac97e1ea",
+    "type": "bugfix",
+    "description": "Correct formurl serialization of empty lists"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ jsoupVersion=1.14.3
 okHttpVersion=5.0.0-alpha.10
 
 # codegen
-smithyVersion=1.25.2
+smithyVersion=1.26.1
 smithyGradleVersion=0.6.0
 
 # testing/utility

--- a/runtime/serde/serde-form-url/common/test/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializerTest.kt
+++ b/runtime/serde/serde-form-url/common/test/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializerTest.kt
@@ -600,4 +600,40 @@ class FormUrlSerializerTest {
         val actual = serializer.toByteArray().decodeToString()
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun itSerializesEmptyList() {
+        val input = ListInput(
+            listOf(),
+            null,
+        )
+
+        val expected = """
+            PrimitiveList=
+        """.trimIndent().replace("\n", "")
+
+        val serializer = FormUrlSerializer()
+        input.serialize(serializer)
+        val actual = serializer.toByteArray().decodeToString()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun itSerializesEmptyListInMap() {
+        val input = MapInput(
+            mapOfLists = mapOf(
+                "foo" to listOf(),
+            ),
+        )
+
+        val expected = """
+            MapOfLists.entry.1.key=foo
+            &MapOfLists.entry.1.value=
+        """.trimIndent().replace("\n", "")
+
+        val serializer = FormUrlSerializer()
+        input.serialize(serializer)
+        val actual = serializer.toByteArray().decodeToString()
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
## Description of changes
Correct `FormUrl` serialization for empty lists.

An empty list should be serialized as
`<ListSerialName>=`
rather than being omitted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
