### PR TITLE
fix(rt): second fix for okhttp engine crashing on Android when coroutine is cancelled uploading request body

### DIFF
--- a/.changes/3146b641-ffcb-4043-9fdf-1f8b3b324113.json
+++ b/.changes/3146b641-ffcb-4043-9fdf-1f8b3b324113.json
@@ -1,0 +1,8 @@
+{
+    "id": "3146b641-ffcb-4043-9fdf-1f8b3b324113",
+    "type": "bugfix",
+    "description": "Fix OkHttp engine crashing on Android when coroutine is cancelled while uploading request body",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#733"
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/733

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
The previous fix applied in https://github.com/awslabs/smithy-kotlin/pull/723 was not insufficient. This change wraps the entire `writeTo` method in a `try/catch` block and surfaces everything as `IOException` from there. This change was tested locally by Amplify to verify the behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
