### PR TITLE
feat(rt): implement `aws-chunked` content encoding

### DIFF
--- a/.changes/dd18ebc5-bcba-4b38-ba21-75aa4c6a7e24.json
+++ b/.changes/dd18ebc5-bcba-4b38-ba21-75aa4c6a7e24.json
@@ -1,0 +1,8 @@
+{
+    "id": "dd18ebc5-bcba-4b38-ba21-75aa4c6a7e24",
+    "type": "feature",
+    "description": "Add aws-chunked content encoding",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#747"
+    ]
+}

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -7,6 +7,8 @@ description = "Common types for AWS signing"
 extra["displayName"] = "Smithy :: Kotlin :: AWS Signing Common"
 extra["moduleName"] = "aws.smithy.kotlin.runtime.auth.signing.awssigning"
 
+val coroutinesVersion: String by project
+
 kotlin {
     sourceSets {
         commonMain {
@@ -14,6 +16,14 @@ kotlin {
                 api(project(":runtime:auth:aws-credentials"))
                 api(project(":runtime:protocol:http"))
                 implementation(project(":runtime:logging"))
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+                implementation(project(":runtime:auth:aws-signing-tests"))
+                implementation(project(":runtime:auth:aws-signing-default"))
             }
         }
 

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -7,8 +7,6 @@ description = "Common types for AWS signing"
 extra["displayName"] = "Smithy :: Kotlin :: AWS Signing Common"
 extra["moduleName"] = "aws.smithy.kotlin.runtime.auth.signing.awssigning"
 
-val coroutinesVersion: String by project
-
 kotlin {
     sourceSets {
         commonMain {
@@ -16,14 +14,6 @@ kotlin {
                 api(project(":runtime:auth:aws-credentials"))
                 api(project(":runtime:protocol:http"))
                 implementation(project(":runtime:logging"))
-            }
-        }
-
-        commonTest {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
-                implementation(project(":runtime:auth:aws-signing-tests"))
-                implementation(project(":runtime:auth:aws-signing-default"))
             }
         }
 

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -18,13 +18,6 @@ kotlin {
                 implementation(project(":runtime:logging"))
             }
         }
-        commonTest {
-            dependencies {
-                implementation(project(":runtime:auth:aws-signing-default"))
-                implementation(project(":runtime:auth:aws-signing-tests"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
-            }
-        }
 
         commonTest {
             dependencies {

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -18,6 +18,13 @@ kotlin {
                 implementation(project(":runtime:logging"))
             }
         }
+        commonTest {
+            dependencies {
+                implementation(project(":runtime:auth:aws-signing-default"))
+                implementation(project(":runtime:auth:aws-signing-tests"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+            }
+        }
 
         commonTest {
             dependencies {

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
@@ -13,7 +13,7 @@ internal abstract class AbstractAwsChunked(
     private val signer: AwsSigner,
     private val signingConfig: AwsSigningConfig,
     private var previousSignature: ByteArray,
-    private var trailingHeaders: Headers = Headers.Empty
+    private var trailingHeaders: Headers = Headers.Empty,
 ) : SdkByteReadChannel by chan {
     companion object {
         const val CHUNK_SIZE_BYTES: Int = 65536
@@ -154,7 +154,7 @@ internal abstract class AbstractAwsChunked(
                 }
             }
 
-            return chunk + "\r\n".encodeToByteArray()  // final CRLF to signal end of chunked transaction
+            return chunk + "\r\n".encodeToByteArray() // final CRLF to signal end of chunked transaction
         }
 
         val chunkBody = chan.readRemaining(CHUNK_SIZE_BYTES)
@@ -207,7 +207,8 @@ internal abstract class AbstractAwsChunked(
      */
     suspend fun getTrailingHeadersChunk(trailingHeaders: Headers): ByteArray {
         var trailerBody = trailingHeaders.entries().map {
-            entry -> buildString {
+                entry ->
+            buildString {
                 append(entry.key)
                 append(":")
                 append(entry.value.joinToString(","))

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
@@ -139,7 +139,7 @@ internal abstract class AbstractAwsChunked(
             append(";")
             append("chunk-signature=")
             appendLine(chunkSignature)
-        }.toByteArray()
+        }.encodeToByteArray()
 
         chunkOffset = 0
         return chunkHeader + chunkBody

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
@@ -13,7 +13,7 @@ internal abstract class AbstractAwsChunked(
     private val signer: AwsSigner,
     private val signingConfig: AwsSigningConfig,
     private var previousSignature: ByteArray,
-    private var trailingHeaders: Headers = Headers.Empty,
+    private var trailingHeaders: Headers = Headers.Empty
 ) : SdkByteReadChannel by chan {
     companion object {
         const val CHUNK_SIZE_BYTES: Int = 65536
@@ -154,7 +154,7 @@ internal abstract class AbstractAwsChunked(
                 }
             }
 
-            return chunk + "\r\n".encodeToByteArray() // final CRLF to signal end of chunked transaction
+            return chunk + "\r\n".encodeToByteArray()  // final CRLF to signal end of chunked transaction
         }
 
         val chunkBody = chan.readRemaining(CHUNK_SIZE_BYTES)
@@ -207,8 +207,7 @@ internal abstract class AbstractAwsChunked(
      */
     suspend fun getTrailingHeadersChunk(trailingHeaders: Headers): ByteArray {
         var trailerBody = trailingHeaders.entries().map {
-                entry ->
-            buildString {
+            entry -> buildString {
                 append(entry.key)
                 append(":")
                 append(entry.value.joinToString(","))

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AbstractAwsChunked.kt
@@ -1,0 +1,148 @@
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+
+internal abstract class AbstractAwsChunked(
+    private val chan: SdkByteReadChannel,
+    private val signer: AwsSigner,
+    private val signingConfig: AwsSigningConfig,
+    private var previousSignature: ByteArray
+): SdkByteReadChannel by chan {
+    companion object {
+        const val CHUNK_SIZE_BYTES: Int = 65536
+    }
+
+    var chunk: ByteArray? = null
+    var chunkOffset: Int = 0
+
+    /**
+     * Returns all the bytes remaining in the underlying data source, up to [limit].
+     * @return a [ByteArray] containing at most [limit] bytes. it may contain fewer if there are less than [limit] bytes
+     * remaining in the data source.
+     */
+    override suspend fun readRemaining(limit: Int): ByteArray {
+        if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
+
+        var bytesWritten = 0
+        var bytes = byteArrayOf()
+        while (bytesWritten != limit) {
+            val numBytesToWrite: Int = minOf(limit - bytesWritten, chunk!!.size - chunkOffset)
+
+            bytes += chunk!!.slice(chunkOffset .. chunkOffset + numBytesToWrite)
+
+            bytesWritten += numBytesToWrite
+            chunkOffset += numBytesToWrite
+
+            // read a new chunk. this handles the case where we consumed the whole chunk but still have not sent `limit` bytes
+            if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
+        }
+
+        return bytes
+    }
+
+    /**
+     * Writes [length] bytes to [sink], starting [offset] bytes from the beginning. If [length] bytes are not available in
+     * the source data, the call will fail with an [IllegalArgumentException].
+     *
+     * @param sink the destination [ByteArray] to write to
+     * @param offset the number of bytes in [sink] to skip before beginning to write
+     * @param length the number of bytes to write to [sink]
+     * @throws IllegalArgumentException when illegal [offset] and [length] arguments are passed
+     * @throws RuntimeException when the source data is exhausted before [length] bytes are written to [sink]
+     */
+    override suspend fun readFully(sink: ByteArray, offset: Int, length: Int) {
+        require(!chan.isClosedForRead) { "Invalid read: channel is closed for reading" }
+        require(offset >= 0) { "Invalid read: offset must be positive:  $offset" }
+        require(offset + length <= sink.size) { "Invalid read: offset + length should be less than the destination size: $offset + $length < ${sink.size}" }
+
+        // make sure the chunk is valid
+        if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
+
+        var bytesWritten = 0
+        while (bytesWritten != length) {
+            val numBytesToWrite: Int = minOf(length, chunk!!.size - chunkOffset)
+
+            val bytes = chunk!!.slice(chunkOffset  .. chunkOffset + numBytesToWrite).toByteArray()
+
+            bytes.copyInto(sink, offset + bytesWritten)
+
+            bytesWritten += numBytesToWrite
+            chunkOffset += numBytesToWrite
+
+            if (chunk == null || chunkOffset >= chunk!!.size) {
+                chunk = getNextChunk()
+
+                // we may get nothing after reading next chunk -- this means the underlying source has closed, and we should fail
+                if(chunk == null || chunk!!.isEmpty()) {
+                    throw RuntimeException("Invalid read: unable to fully read $length bytes. missing $length - $bytesWritten bytes.")
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes [length] bytes to [sink], starting [offset] bytes from the beginning.
+     * Returns when [length] bytes or the number of available bytes have been written, whichever is lower.
+     * @param sink the bytearray to write the data to
+     * @param offset the number of bytes to skip from the beginning of the chunk
+     * @param length the maximum number of bytes to write to [sink]. the actual number of bytes written may be fewer if
+     * there are less immediately available.
+     * @throws IllegalArgumentException when illegal [offset] and [length] arguments are passed
+     * @return an [Int] representing the number of bytes written
+     */
+    override suspend fun readAvailable(sink: ByteArray, offset: Int, length: Int): Int {
+        // input validation
+        require(!chan.isClosedForRead) { "Invalid read: channel is closed for reading" }
+        require(offset >= 0) { "Invalid read: offset must be positive:  $offset" }
+        require(offset + length <= sink.size) { "Invalid read: offset + length should be less than the destination size: $offset + $length < ${sink.size}" }
+
+        // make sure the current chunk is valid -- suspend and read a new chunk if not valid
+        if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
+
+        var bytesWritten = 0
+        while (bytesWritten != length) {
+            val numBytesToWrite = minOf(length, chunk!!.size - chunkOffset)
+
+            val bytes = chunk!!.slice(chunkOffset .. chunkOffset + numBytesToWrite).toByteArray()
+
+            bytes.copyInto(sink, offset + bytesWritten)
+
+            bytesWritten += numBytesToWrite
+            chunkOffset += numBytesToWrite
+
+            // if we've exhausted the current chunk, exit without suspending for a new one
+            if (chunk == null || chunkOffset >= chunk!!.size) { break }
+        }
+
+        return bytesWritten
+    }
+
+    /**
+     * Read the next chunk of data and add hex-formatted chunk size and chunk signature to the front
+     * This function assumes that the previous chunk has been fully consumed and there is no remaining data, because the
+     * previous chunk will be overwritten with new data.
+     * @return an aws-chunked encoded ByteArray with the hex-formatted chunk size, chunk signature, and chunk data
+     * (in that order), ready to send on the wire
+     */
+    suspend fun getNextChunk(): ByteArray? {
+        val chunkBody = chan.readRemaining(CHUNK_SIZE_BYTES)
+
+        if (chunkBody.isEmpty()) { return null }
+
+        val chunkSignature = signer.signChunk(chunkBody, previousSignature, signingConfig).signature
+        previousSignature = chunkSignature
+
+        // the chunk header consists of the size of the chunk encoded in hexadecimal, followed by the chunk signature,
+        // separated with a semicolon
+        val chunkHeader = buildString {
+            append(chunkBody.size.toString(16))
+            append(";")
+            append("chunk-signature=")
+            appendLine(chunkSignature)
+        }.toByteArray()
+
+        chunkOffset = 0
+        return chunkHeader + chunkBody
+    }
+
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -24,5 +24,5 @@ internal expect class AwsChunked internal constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-    trailingHeaders: Headers = Headers.Empty
+    trailingHeaders: Headers = Headers.Empty,
 ) : AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -24,5 +24,5 @@ internal expect class AwsChunked internal constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-    trailingHeaders: Headers = Headers.Empty,
+    trailingHeaders: Headers = Headers.Empty
 ) : AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
@@ -5,10 +10,14 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 /**
  * AwsChunked Encoding
  * not thread-safe! do not use multiple executors to read from the same AwsChunked object
+ * @param chan the underlying [SdkByteReadChannel] which will have its data encoded in aws-chunked format
+ * @param signer the signer to use to sign chunks and (optionally) chunk trailer
+ * @param signingConfig the config to use for signing
+ * @previousSignature the previous signature to use for signing. in most cases, this should be the seed signature
  */
 internal expect class AwsChunked internal constructor(
     chan: SdkByteReadChannel,
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-): AbstractAwsChunked
+) : AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -1,0 +1,14 @@
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+
+/**
+ * AwsChunked Encoding
+ * not thread-safe! do not use multiple executors to read from the same AwsChunked object
+ */
+internal expect class AwsChunked constructor(
+    chan: SdkByteReadChannel,
+    signer: AwsSigner,
+    signingConfig: AwsSigningConfig,
+    previousSignature: ByteArray
+): AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -5,19 +5,24 @@
 
 package aws.smithy.kotlin.runtime.auth.awssigning
 
+import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 
 /**
- * AwsChunked Encoding
- * Operations on this class can not be invoked concurrently.
+ * aws-chunked content encoding. Operations on this class can not be invoked concurrently.
+ * This class wraps an SdkByteReadChannel. When reads are performed on this class, it will read the wrapped data
+ * and return it in aws-chunked content encoding.
+ * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html">SigV4 Streaming</a>
  * @param chan the underlying [SdkByteReadChannel] which will have its data encoded in aws-chunked format
  * @param signer the signer to use to sign chunks and (optionally) chunk trailer
  * @param signingConfig the config to use for signing
- * @previousSignature the previous signature to use for signing. in most cases, this should be the seed signature
+ * @param previousSignature the previous signature to use for signing. in most cases, this should be the seed signature
+ * @param trailingHeaders the optional trailing headers to include in the final chunk
  */
 internal expect class AwsChunked internal constructor(
     chan: SdkByteReadChannel,
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
+    trailingHeaders: Headers = Headers.Empty
 ) : AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -9,7 +9,7 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 
 /**
  * AwsChunked Encoding
- * not thread-safe! do not use multiple executors to read from the same AwsChunked object
+ * Operations on this class can not be invoked concurrently.
  * @param chan the underlying [SdkByteReadChannel] which will have its data encoded in aws-chunked format
  * @param signer the signer to use to sign chunks and (optionally) chunk trailer
  * @param signingConfig the config to use for signing

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunked.kt
@@ -6,9 +6,9 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
  * AwsChunked Encoding
  * not thread-safe! do not use multiple executors to read from the same AwsChunked object
  */
-internal expect class AwsChunked constructor(
+internal expect class AwsChunked internal constructor(
     chan: SdkByteReadChannel,
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
-    previousSignature: ByteArray
+    previousSignature: ByteArray,
 ): AbstractAwsChunked

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigner.kt
@@ -31,4 +31,17 @@ public interface AwsSigner {
         prevSignature: ByteArray,
         config: AwsSigningConfig,
     ): AwsSigningResult<Unit>
+
+    /**
+     * Signs a chunked payload's trailer according to the supplied signing configuration
+     * @param trailingHeaders The canonicalized trailing headers
+     * @param finalChunkSignature The signature of the final payload chunk
+     * @param config The signing configuration
+     * @return The signing result, which should be appended as a trailing header itself, named `x-amz-trailer-signature`
+     */
+    public suspend fun signChunkTrailer(
+        trailingHeaders: ByteArray,
+        finalChunkSignature: ByteArray,
+        config: AwsSigningConfig,
+    ): AwsSigningResult<Unit>
 }

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
@@ -164,7 +164,7 @@ class AwsChunkedTest {
         var previousSignature: ByteArray = byteArrayOf()
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
-        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + 1 + 1 + "chunk-signature=".length + 64 + 6
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + 1 + 1 + "chunk-signature=".length + 64 + 4
 
         val bytes = awsChunked.readRemaining(numBytesToRead) // read all the underlying data plus any chunk signature overhead
         val bytesAsString = bytes.decodeToString()
@@ -204,7 +204,7 @@ class AwsChunkedTest {
         val numBytesToRead = dataLengthBytes +
             (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
             (4 + 1 + "chunk-signature=".length + 64 + 4) + // last chunk
-            (1 + 1 + "chunk-signature=".length + 64 + 6) // terminating chunk (zero length)
+            (1 + 1 + "chunk-signature=".length + 64 + 4) // terminating chunk (zero length)
 
         val bytes = awsChunked.readRemaining(numBytesToRead) // read all the underlying data plus any chunk signature overhead
         val bytesAsString = bytes.decodeToString()
@@ -337,7 +337,7 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
         // read all the chunk data plus all bytes from header
-        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 6
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4
 
         val sink = ByteArray(numBytesToRead)
         awsChunked.readFully(sink, 0, numBytesToRead)
@@ -411,7 +411,7 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
         // read all the chunk data plus all bytes from header
-        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 6
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4
 
         val offset = 128
         val sink = ByteArray(numBytesToRead + offset) { 0 }
@@ -448,7 +448,7 @@ class AwsChunkedTest {
         assertTrue(chan.isClosedForRead) // no chunk data available
 
         // read the chunk of zero length
-        val numBytesToRead = 1 + 1 + "chunk-signature=".length + 64 + 6
+        val numBytesToRead = 1 + 1 + "chunk-signature=".length + 64 + 4
         val sink = ByteArray(numBytesToRead)
         awsChunked.readFully(sink, 0, numBytesToRead)
 
@@ -487,7 +487,7 @@ class AwsChunkedTest {
         var previousSignature: ByteArray = byteArrayOf()
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
-        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + 1 + 1 + "chunk-signature=".length + 64 + 6
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + 1 + 1 + "chunk-signature=".length + 64 + 4
         val sink = ByteArray(numBytesToRead)
         awsChunked.readFully(sink, 0, numBytesToRead) // read all the underlying data plus any chunk signature overhead
         val bytesAsString = sink.decodeToString()
@@ -529,7 +529,7 @@ class AwsChunkedTest {
         val numBytesToRead = dataLengthBytes +
             (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
             ((CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4) + // last chunk
-            (1 + 1 + "chunk-signature=".length + 64 + 6) // terminating chunk
+            (1 + 1 + "chunk-signature=".length + 64 + 4) // terminating chunk
 
         val sink = ByteArray(numBytesToRead)
         awsChunked.readFully(sink, 0, numBytesToRead) // read all the underlying data plus any chunk signature overhead
@@ -658,7 +658,7 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
         // read all the chunk data plus all bytes from header
-        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + (1 + 1 + "chunk-signature=".length + 64 + 6)
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 + (1 + 1 + "chunk-signature=".length + 64 + 4)
 
         val sink = ByteArray(numBytesToRead)
         // need to make 2 successive calls because there are two chunks -- readAvailable will only fetch the first one to avoid potential suspensions
@@ -750,14 +750,14 @@ class AwsChunkedTest {
         var previousSignature: ByteArray = byteArrayOf()
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
-        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + (1 + 1 + "chunk-signature=".length + 64 + 6)
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks + (1 + 1 + "chunk-signature=".length + 64 + 4)
         val sink = ByteArray(numBytesToRead)
 
         var bytesRead = 0
         for (chunk in 0 until numChunks) { // read the chunks in a loop
             bytesRead += awsChunked.readAvailable(sink, bytesRead, CHUNK_SIZE_BYTES + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4))
         }
-        bytesRead += awsChunked.readAvailable(sink, bytesRead, (1 + 1 + "chunk-signature=".length + 64 + 6))
+        bytesRead += awsChunked.readAvailable(sink, bytesRead, (1 + 1 + "chunk-signature=".length + 64 + 4))
         assertEquals(numBytesToRead, bytesRead)
 
         val bytesAsString = sink.decodeToString()
@@ -801,7 +801,7 @@ class AwsChunkedTest {
         val numBytesToRead = dataLengthBytes +
             (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
             ((CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4) + // last chunk
-            (1 + 1 + "chunk-signature=".length + 64 + 6) // terminal chunk
+            (1 + 1 + "chunk-signature=".length + 64 + 4) // terminal chunk
 
         val sink = ByteArray(numBytesToRead)
 
@@ -813,7 +813,7 @@ class AwsChunkedTest {
         bytesRead += awsChunked.readAvailable(sink, bytesRead, CHUNK_SIZE_BYTES / 2 + (CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4)
 
         // read the terminal chunk
-        bytesRead += awsChunked.readAvailable(sink, bytesRead, 1 + 1 + "chunk-signature=".length + 64 + 6)
+        bytesRead += awsChunked.readAvailable(sink, bytesRead, 1 + 1 + "chunk-signature=".length + 64 + 4)
 
         val bytesAsString = sink.decodeToString()
 

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
@@ -1,0 +1,591 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.*
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AwsChunkedTest {
+
+    private val CHUNK_SIGNATURE_REGEX = Regex("chunk-signature=[a-zA-Z0-9]{64}") // alphanumeric, length of 64
+    private val CHUNK_SIZE_BYTES = AbstractAwsChunked.CHUNK_SIZE_BYTES
+
+    private val testSigner = DefaultAwsSigner
+    private val testSigningConfig = AwsSigningConfig {
+        region = "foo"
+        service = "bar"
+        signingDate = Instant.fromIso8601("20220427T012345Z")
+        credentialsProvider = testCredentialsProvider
+    }
+
+    @Test
+    fun testReadRemainingExactBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val bytes = awsChunked.readRemaining(CHUNK_SIZE_BYTES + 1024) // read all the underlying data plus any chunk signature overhead
+        val bytesAsString = bytes.decodeToString()
+
+        assertEquals(dataLengthBytes.toString(16), bytesAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = bytesAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+        assertTrue { awsChunked.isClosedForRead } // we've consumed all of the bytes
+    }
+
+    @Test
+    fun testReadRemainingFewerBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = CHUNK_SIZE_BYTES / 2 // read ~half of the chunk data
+        val bytes = awsChunked.readRemaining(numBytesToRead)
+        val bytesAsString = bytes.decodeToString()
+
+        // header should still come at the front
+        assertEquals(dataLengthBytes.toString(16), bytesAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = bytesAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+
+        assertFalse { awsChunked.isClosedForRead }
+        assertEquals(bytes.size, numBytesToRead)
+    }
+
+    @Test
+    fun testReadRemainingExcessiveBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = 131072 // read double of the available chunk data
+        val bytes = awsChunked.readRemaining(numBytesToRead)
+        val bytesAsString = bytes.decodeToString()
+
+        // validate chunk header
+        assertEquals(dataLengthBytes.toString(16), bytesAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = bytesAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+
+        // validate chunk body
+        val bytesAfterHeaderAsString = bytesAsString.split("\r\n")[1]
+        assertEquals(bytesAfterHeaderAsString, data.decodeToString())
+
+        // the SdkByteReadChannel should be fully exhausted
+        assertTrue { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadRemainingMultipleFullChunks() = runTest {
+        val numChunks = 5
+        val dataLengthBytes = CHUNK_SIZE_BYTES * numChunks
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks
+
+        val bytes = awsChunked.readRemaining(numBytesToRead) // read all the underlying data plus any chunk signature overhead
+        val bytesAsString = bytes.decodeToString()
+
+        assertEquals(bytes.size, numBytesToRead)
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+    }
+
+    @Test
+    fun testReadRemainingMultipleChunksLastChunkNotFull() = runTest {
+        val numChunks = 6
+        val dataLengthBytes = CHUNK_SIZE_BYTES * (numChunks - 1) + CHUNK_SIZE_BYTES / 2 // 5 full chunks, 1 half-full chunk
+
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes +
+            (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
+            (4 + 1 + "chunk-signature=".length + 64 + 4) // last chunk
+
+        val bytes = awsChunked.readRemaining(numBytesToRead) // read all the underlying data plus any chunk signature overhead
+        val bytesAsString = bytes.decodeToString()
+
+        assertEquals(bytes.size, numBytesToRead)
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks - 1) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+
+        // validate the last chunk
+        val expectedChunkSignature = testSigner.signChunk(
+            data.slice(CHUNK_SIZE_BYTES * (numChunks - 1) until data.size).toByteArray(),
+            previousSignature,
+            testSigningConfig,
+        ).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures.last())
+    }
+
+    @Test
+    fun testReadFullyNegativeOffset() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val sink = ByteArray(dataLengthBytes)
+
+        assertFailsWith<IllegalArgumentException> {
+            awsChunked.readFully(sink, -500, dataLengthBytes)
+        }
+    }
+
+    @Test
+    fun testReadFullyOffsetTooLarge() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val sink = ByteArray(dataLengthBytes)
+
+        assertFailsWith<IllegalArgumentException> {
+            awsChunked.readFully(sink, 0, sink.size * 2) // try to read double the size available in the sink
+        }
+    }
+
+    @Test
+    fun testReadFullyExactBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read all the chunk data plus all bytes from header
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+
+        val sink = ByteArray(numBytesToRead)
+        awsChunked.readFully(sink, 0, numBytesToRead)
+
+        val sinkAsString = sink.decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+        assertTrue { awsChunked.isClosedForRead } // we've consumed all of the bytes
+    }
+
+    @Test
+    fun testReadFullyFewerBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes / 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+
+        val sink = ByteArray(numBytesToRead)
+        awsChunked.readFully(sink, 0, numBytesToRead)
+
+        val sinkAsString = sink.decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+        assertFalse { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadFullyExcessiveBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val numBytesToRead = dataLengthBytes * 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+        val sink = ByteArray(numBytesToRead)
+
+        assertFailsWith<RuntimeException> {
+            awsChunked.readFully(sink, 0, numBytesToRead)
+        }
+    }
+
+    @Test
+    fun testReadFullyWithNonZeroOffset() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read all the chunk data plus all bytes from header
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+
+        val sink = ByteArray(numBytesToRead) { 0 }
+        val offset = 128
+        awsChunked.readFully(sink, offset, numBytesToRead - offset)
+
+        for (index in 0..127) { // make sure the default value has not been overridden for the first `offset` bytes
+            assertEquals(0, sink.get(index))
+        }
+
+        val sinkAsString = sink.slice(128 until sink.size).toByteArray().decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+
+        assertFalse { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadFullyOnAlreadyClosedChannel() = runTest {
+        val dataLengthBytes = 0
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+        val sink = ByteArray(numBytesToRead)
+
+        assertTrue(chan.isClosedForRead)
+        assertFailsWith<RuntimeException> {
+            awsChunked.readFully(sink, 0, numBytesToRead)
+        }
+    }
+
+    @Test
+    fun testReadFullyZeroBytesOnAlreadyClosedChannel() = runTest {
+        val dataLengthBytes = 0
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val sink = ByteArray(0)
+
+        assertTrue(chan.isClosedForRead)
+        awsChunked.readFully(sink, 0, 0)
+    }
+
+    @Test
+    fun testReadFullyMultipleFullChunks() = runTest {
+        val numChunks = 5
+        val dataLengthBytes = CHUNK_SIZE_BYTES * numChunks
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks
+        val sink = ByteArray(numBytesToRead)
+        awsChunked.readFully(sink, 0, numBytesToRead) // read all the underlying data plus any chunk signature overhead
+        val bytesAsString = sink.decodeToString()
+
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+    }
+
+    @Test
+    fun testReadFullyMultipleChunksLastChunkNotFull() = runTest {
+        val numChunks = 6
+        val dataLengthBytes = CHUNK_SIZE_BYTES * (numChunks - 1) + CHUNK_SIZE_BYTES / 2 // 5 full chunks, 1 half-full chunk
+
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes +
+            (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
+            ((CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4) // last chunk
+
+        val sink = ByteArray(numBytesToRead)
+        awsChunked.readFully(sink, 0, numBytesToRead) // read all the underlying data plus any chunk signature overhead
+        val bytesAsString = sink.decodeToString()
+
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks - 1) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+
+        // validate the last chunk
+        val expectedChunkSignature = testSigner.signChunk(
+            data.slice(CHUNK_SIZE_BYTES * (numChunks - 1) until data.size).toByteArray(),
+            previousSignature,
+            testSigningConfig,
+        ).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures.last())
+    }
+
+    @Test
+    fun testReadAvailableNegativeOffset() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val sink = ByteArray(dataLengthBytes)
+
+        assertFailsWith<IllegalArgumentException> {
+            awsChunked.readAvailable(sink, -500, dataLengthBytes)
+        }
+    }
+
+    @Test
+    fun testReadAvailableOffsetTooLarge() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val sink = ByteArray(dataLengthBytes)
+
+        assertFailsWith<IllegalArgumentException> {
+            awsChunked.readAvailable(sink, 0, sink.size * 2) // try to read double the size available in the sink
+        }
+    }
+
+    @Test
+    fun testReadAvailableExactBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read all the chunk data plus all bytes from header
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+
+        val sink = ByteArray(numBytesToRead)
+        val bytesRead = awsChunked.readAvailable(sink, 0, numBytesToRead)
+
+        val sinkAsString = sink.decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+
+        assertEquals(bytesRead, numBytesToRead)
+        assertTrue { awsChunked.isClosedForRead } // we've consumed all of the bytes
+    }
+
+    @Test
+    fun testReadAvailableExcessiveBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+        val numBytesToRead = dataLengthBytes * 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+        val sink = ByteArray(numBytesToRead)
+
+        val bytesRead = awsChunked.readAvailable(sink, 0, numBytesToRead)
+
+        val sinkAsString = sink.decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+
+        assertNotEquals(bytesRead, numBytesToRead) // because we requested more bytes than were available
+        assertTrue { awsChunked.isClosedForRead } // we've consumed all of the bytes
+    }
+
+    @Test
+    fun testReadAvailableFewerBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature.decodeToString()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes / 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4
+
+        val sink = ByteArray(numBytesToRead)
+        awsChunked.readAvailable(sink, 0, numBytesToRead)
+
+        val sinkAsString = sink.decodeToString()
+        assertEquals(dataLengthBytes.toString(16), sinkAsString.split(";")[0]) // hex-encoded length
+        val chunkSignature = sinkAsString.split("chunk-signature=")[1].split("\r\n")[0] // chunk signature
+        assertEquals(expectedChunkSignature, chunkSignature)
+        assertFalse { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadAvailableMultipleFullChunks() = runTest {
+        val numChunks = 5
+        val dataLengthBytes = CHUNK_SIZE_BYTES * numChunks
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * numChunks
+        val sink = ByteArray(numBytesToRead)
+
+        var bytesRead = 0
+        for (chunk in 0 until numChunks) { // read the chunks in a loop
+            bytesRead += awsChunked.readAvailable(sink, bytesRead, CHUNK_SIZE_BYTES + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4))
+        }
+
+        val bytesAsString = sink.decodeToString()
+
+        assertEquals(numBytesToRead, bytesRead)
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+    }
+
+    @Test
+    fun testReadAvailableMultipleChunksLastChunkNotFull() = runTest {
+        val numChunks = 6
+        val dataLengthBytes = CHUNK_SIZE_BYTES * (numChunks - 1) + CHUNK_SIZE_BYTES / 2 // 5 full chunks, 1 half-full chunk
+
+        val data = ByteArray(dataLengthBytes) { Random.Default.nextBytes(1)[0] }
+        val chan = SdkByteReadChannel(data)
+        var previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        val numBytesToRead = dataLengthBytes +
+            (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4) * (numChunks - 1) +
+            ((CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4) // last chunk
+
+        val sink = ByteArray(numBytesToRead)
+
+        var bytesRead = 0
+        for (chunk in 0 until numChunks - 1) {
+            bytesRead += awsChunked.readAvailable(sink, bytesRead, CHUNK_SIZE_BYTES + (dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4)) // read all the underlying data plus any chunk signature overhead
+        }
+        // read the last chunk, which is smaller in size
+        bytesRead += awsChunked.readAvailable(sink, bytesRead, CHUNK_SIZE_BYTES / 2 + (CHUNK_SIZE_BYTES / 2).toString(16).length + 1 + "chunk-signature=".length + 64 + 4)
+
+        val bytesAsString = sink.decodeToString()
+
+        assertEquals(numBytesToRead, bytesRead)
+        assertTrue { awsChunked.isClosedForRead }
+
+        val chunkSignatures = CHUNK_SIGNATURE_REGEX.findAll(bytesAsString).map { result -> result.value.split("=")[1] }.toList()
+        assertEquals(chunkSignatures.size, numChunks)
+
+        // validate each chunk signature
+        for (chunk in 0 until numChunks - 1) {
+            val expectedChunkSignature = testSigner.signChunk(
+                data.slice(CHUNK_SIZE_BYTES * chunk until (CHUNK_SIZE_BYTES * (chunk + 1))).toByteArray(),
+                previousSignature,
+                testSigningConfig,
+            ).signature
+            previousSignature = expectedChunkSignature
+
+            assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[chunk])
+        }
+
+        // validate the last chunk
+        val expectedChunkSignature = testSigner.signChunk(
+            data.slice(CHUNK_SIZE_BYTES * (numChunks - 1) until data.size).toByteArray(),
+            previousSignature,
+            testSigningConfig,
+        ).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures.last())
+    }
+}

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
@@ -36,7 +36,8 @@ class AwsChunkedTest {
      * chunk-signature=<64 alphanumeric characters>
      */
     private fun getChunkSignatures(bytes: String): List<String> = CHUNK_SIGNATURE_REGEX.findAll(bytes).map {
-        result -> result.value.split("=")[1]
+            result ->
+        result.value.split("=")[1]
     }.toList()
 
     /**
@@ -45,7 +46,8 @@ class AwsChunkedTest {
      * String(Hex(ChunkSize));chunk-signature=<chunk_signature>
      */
     private fun getChunkSizes(bytes: String): List<Int> = CHUNK_SIZE_REGEX.findAll(bytes).map {
-        result -> result.value.split(";")[0].toInt(16)
+            result ->
+        result.value.split(";")[0].toInt(16)
     }.toList()
 
     /**
@@ -58,20 +60,19 @@ class AwsChunkedTest {
         }.toList().firstOrNull()
     }
 
-
-
     /**
      * Calculates the `aws-chunked` encoded trailing header length
      * Used to calculate how many bytes should be read for all the trailing headers to be consumed
      */
     private fun getTrailingHeadersLength(trailingHeaders: Headers) = trailingHeaders.entries().map {
-        entry -> buildString {
+            entry ->
+        buildString {
             append(entry.key)
             append(":")
             append(entry.value.joinToString(","))
             append("\r\n")
-            }.length
-        } .reduce { acc, len -> acc + len } +
+        }.length
+    }.reduce { acc, len -> acc + len } +
         "x-amz-trailer-signature:".length + 64 + "\r\n".length
 
     @Test
@@ -83,8 +84,10 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
         // read the exact chunk length
-        val bytes = awsChunked.readRemaining(CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
-                "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4 + 2)
+        val bytes = awsChunked.readRemaining(
+            CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
+                "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4 + 2,
+        )
         val bytesAsString = bytes.decodeToString()
 
         val chunkSignatures = getChunkSignatures(bytesAsString)
@@ -595,7 +598,6 @@ class AwsChunkedTest {
         awsChunked.readFully(sink, 0, numBytesToRead)
         val bytesAsString = sink.decodeToString()
 
-
         val chunkSignatures = getChunkSignatures(bytesAsString)
         assertEquals(chunkSignatures.size, 2) // chunk of data plus an empty chunk
         var expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
@@ -871,8 +873,8 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature, trailingHeaders)
 
         val numBytesToRead = CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
-                ("chunk-signature=".length + 64 + 4) +
-                (1 + 1 + "chunk-signature=".length + 64 + 2) + trailingHeadersLength + 2
+            ("chunk-signature=".length + 64 + 4) +
+            (1 + 1 + "chunk-signature=".length + 64 + 2) + trailingHeadersLength + 2
 
         val sink = ByteArray(numBytesToRead)
 

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedTest.kt
@@ -36,8 +36,7 @@ class AwsChunkedTest {
      * chunk-signature=<64 alphanumeric characters>
      */
     private fun getChunkSignatures(bytes: String): List<String> = CHUNK_SIGNATURE_REGEX.findAll(bytes).map {
-            result ->
-        result.value.split("=")[1]
+        result -> result.value.split("=")[1]
     }.toList()
 
     /**
@@ -46,8 +45,7 @@ class AwsChunkedTest {
      * String(Hex(ChunkSize));chunk-signature=<chunk_signature>
      */
     private fun getChunkSizes(bytes: String): List<Int> = CHUNK_SIZE_REGEX.findAll(bytes).map {
-            result ->
-        result.value.split(";")[0].toInt(16)
+        result -> result.value.split(";")[0].toInt(16)
     }.toList()
 
     /**
@@ -60,19 +58,20 @@ class AwsChunkedTest {
         }.toList().firstOrNull()
     }
 
+
+
     /**
      * Calculates the `aws-chunked` encoded trailing header length
      * Used to calculate how many bytes should be read for all the trailing headers to be consumed
      */
     private fun getTrailingHeadersLength(trailingHeaders: Headers) = trailingHeaders.entries().map {
-            entry ->
-        buildString {
+        entry -> buildString {
             append(entry.key)
             append(":")
             append(entry.value.joinToString(","))
             append("\r\n")
-        }.length
-    }.reduce { acc, len -> acc + len } +
+            }.length
+        } .reduce { acc, len -> acc + len } +
         "x-amz-trailer-signature:".length + 64 + "\r\n".length
 
     @Test
@@ -84,10 +83,8 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
 
         // read the exact chunk length
-        val bytes = awsChunked.readRemaining(
-            CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
-                "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4 + 2,
-        )
+        val bytes = awsChunked.readRemaining(CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
+                "chunk-signature=".length + 64 + 4 + 1 + 1 + "chunk-signature=".length + 64 + 4 + 2)
         val bytesAsString = bytes.decodeToString()
 
         val chunkSignatures = getChunkSignatures(bytesAsString)
@@ -598,6 +595,7 @@ class AwsChunkedTest {
         awsChunked.readFully(sink, 0, numBytesToRead)
         val bytesAsString = sink.decodeToString()
 
+
         val chunkSignatures = getChunkSignatures(bytesAsString)
         assertEquals(chunkSignatures.size, 2) // chunk of data plus an empty chunk
         var expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
@@ -873,8 +871,8 @@ class AwsChunkedTest {
         val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature, trailingHeaders)
 
         val numBytesToRead = CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
-            ("chunk-signature=".length + 64 + 4) +
-            (1 + 1 + "chunk-signature=".length + 64 + 2) + trailingHeadersLength + 2
+                ("chunk-signature=".length + 64 + 4) +
+                (1 + 1 + "chunk-signature=".length + 64 + 2) + trailingHeadersLength + 2
 
         val sink = ByteArray(numBytesToRead)
 

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.auth.awssigning
 
+import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import java.nio.ByteBuffer
 
@@ -13,6 +14,7 @@ internal actual class AwsChunked actual constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
+    trailingHeaders: Headers
 ) : AbstractAwsChunked(chan, signer, signingConfig, previousSignature) {
 
     override suspend fun readAvailable(sink: ByteBuffer): Int {

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -14,7 +14,7 @@ internal actual class AwsChunked actual constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-    trailingHeaders: Headers,
+    trailingHeaders: Headers
 ) : AbstractAwsChunked(chan, signer, signingConfig, previousSignature, trailingHeaders) {
 
     override suspend fun readAvailable(sink: ByteBuffer): Int {

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -1,0 +1,36 @@
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import java.nio.ByteBuffer
+
+internal actual class AwsChunked constructor(
+    chan: SdkByteReadChannel,
+    signer: AwsSigner,
+    signingConfig: AwsSigningConfig,
+    previousSignature: ByteArray
+): AbstractAwsChunked(chan, signer, signingConfig, previousSignature) {
+
+    override suspend fun readAvailable(sink: ByteBuffer): Int {
+        if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
+
+        var bytesWritten = 0
+        while (chunkOffset < chunk!!.size) {
+            val numBytesToWrite = chunk!!.size - chunkOffset
+
+            val bytes = chunk!!.slice(chunkOffset .. chunkOffset + numBytesToWrite).toByteArray()
+
+            sink.put(bytes)
+
+            bytesWritten += numBytesToWrite
+            chunkOffset += numBytesToWrite
+
+            sink.position(bytesWritten)
+
+            // if we've exhausted the current chunk, exit without suspending for a new one
+            if (chunk == null || chunkOffset >= chunk!!.size) { break }
+        }
+
+        sink.flip()
+        return bytesWritten
+    }
+}

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
@@ -8,7 +13,7 @@ internal actual class AwsChunked actual constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-): AbstractAwsChunked(chan, signer, signingConfig, previousSignature) {
+) : AbstractAwsChunked(chan, signer, signingConfig, previousSignature) {
 
     override suspend fun readAvailable(sink: ByteBuffer): Int {
         if (chunk == null || chunkOffset >= chunk!!.size) { chunk = getNextChunk() }
@@ -17,7 +22,7 @@ internal actual class AwsChunked actual constructor(
         while (chunkOffset < chunk!!.size) {
             val numBytesToWrite = chunk!!.size - chunkOffset
 
-            val bytes = chunk!!.slice(chunkOffset .. chunkOffset + numBytesToWrite).toByteArray()
+            val bytes = chunk!!.slice(chunkOffset until chunkOffset + numBytesToWrite).toByteArray()
 
             sink.put(bytes)
 

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -14,7 +14,7 @@ internal actual class AwsChunked actual constructor(
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
     previousSignature: ByteArray,
-    trailingHeaders: Headers
+    trailingHeaders: Headers,
 ) : AbstractAwsChunked(chan, signer, signingConfig, previousSignature, trailingHeaders) {
 
     override suspend fun readAvailable(sink: ByteBuffer): Int {

--- a/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
+++ b/runtime/auth/aws-signing-common/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVM.kt
@@ -3,11 +3,11 @@ package aws.smithy.kotlin.runtime.auth.awssigning
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import java.nio.ByteBuffer
 
-internal actual class AwsChunked constructor(
+internal actual class AwsChunked actual constructor(
     chan: SdkByteReadChannel,
     signer: AwsSigner,
     signingConfig: AwsSigningConfig,
-    previousSignature: ByteArray
+    previousSignature: ByteArray,
 ): AbstractAwsChunked(chan, signer, signingConfig, previousSignature) {
 
     override suspend fun readAvailable(sink: ByteBuffer): Int {

--- a/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
+++ b/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
@@ -1,0 +1,273 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.*
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import aws.smithy.kotlin.runtime.auth.awssigning.*
+import aws.smithy.kotlin.runtime.http.Headers
+
+
+import java.nio.ByteBuffer
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AwsChunkedJVMTest {
+
+    private val CHUNK_SIGNATURE_REGEX = Regex("chunk-signature=[a-zA-Z0-9]{64}") // alphanumeric, length of 64
+    private val CHUNK_SIZE_REGEX = Regex("[0-9a-f]+;chunk-signature=") // hexadecimal, any length, immediately followed by the chunk signature
+
+    private val CHUNK_SIZE_BYTES = AbstractAwsChunked.CHUNK_SIZE_BYTES
+
+    private val testSigner = DefaultAwsSigner
+    private val testSigningConfig = AwsSigningConfig {
+        region = "foo"
+        service = "bar"
+        signingDate = Instant.fromIso8601("20220427T012345Z")
+        credentialsProvider = testCredentialsProvider
+    }
+
+    /**
+     * Given a string representation of aws-chunked encoded bytes, return a list of the chunk signatures as strings.
+     * Chunk signatures are defined by the following grammar:
+     * chunk-signature=<64 alphanumeric characters>
+     */
+    private fun getChunkSignatures(bytes: String): List<String> = CHUNK_SIGNATURE_REGEX.findAll(bytes).map {
+            result -> result.value.split("=")[1]
+    }.toList()
+
+    /**
+     * Given a string representation of aws-chunked encoded bytes, returns a list of the chunk sizes as integers.
+     * Chunk sizes are defined by the following grammar:
+     * String(Hex(ChunkSize));chunk-signature=<chunk_signature>
+     */
+    private fun getChunkSizes(bytes: String): List<Int> = CHUNK_SIZE_REGEX.findAll(bytes).map {
+            result -> result.value.split(";")[0].toInt(16)
+    }.toList()
+
+    /**
+     * Given a string representation of aws-chunked encoded bytes, return the value of the x-amz-chunk-trailer trailing header.
+     */
+    private fun getChunkTrailerSignature(bytes: String): String? {
+        val re = Regex("x-amz-trailer-signature:[a-zA-Z0-9]{64}")
+        return re.findAll(bytes).map { result ->
+            result.value.split(":")[1]
+        }.toList().firstOrNull()
+    }
+
+    /**
+     * Calculates the `aws-chunked` encoded trailing header length
+     * Used to calculate how many bytes should be read for all the trailing headers to be consumed
+     */
+    private fun getTrailingHeadersLength(trailingHeaders: Headers) = trailingHeaders.entries().map {
+            entry -> buildString {
+        append(entry.key)
+        append(":")
+        append(entry.value.joinToString(","))
+        append("\r\n")
+    }.length
+    } .reduce { acc, len -> acc + len } +
+            "x-amz-trailer-signature:".length + 64 + "\r\n".length
+
+
+    @Test
+    fun testReadAvailableExactBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read all the chunk data plus all bytes from header
+        val numBytesToRead = dataLengthBytes + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
+            (1 + 1 + "chunk-signature=".length + 64 + 4)
+
+        var sink = ByteArray(numBytesToRead)
+        val BUFFER_SIZE = 1024
+        val buffer = ByteBuffer.allocate(BUFFER_SIZE)
+
+        var bytesRead = 0
+        while (bytesRead != numBytesToRead) {
+            bytesRead += awsChunked.readAvailable(buffer)
+
+            while (buffer.remaining() > 0) {
+                sink += buffer.get()
+            }
+
+            buffer.clear()
+        }
+
+        assertEquals(numBytesToRead, bytesRead)
+
+        val sinkAsString = sink.decodeToString()
+
+        val chunkSignatures = getChunkSignatures(sinkAsString)
+        assertEquals(2, chunkSignatures.size)
+        val chunkSizes = getChunkSizes(sinkAsString)
+        assertEquals(2, chunkSizes.size)
+
+        var expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[0])
+        assertEquals(CHUNK_SIZE_BYTES, chunkSizes[0])
+
+        expectedChunkSignature = testSigner.signChunk(byteArrayOf(), expectedChunkSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[1])
+        assertEquals(0, chunkSizes[1])
+
+        assertTrue { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadAvailableExcessiveBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read excess of chunk data
+        val numBytesToRead = dataLengthBytes * 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
+                (1 + 1 + "chunk-signature=".length + 64 + 4)
+
+        var sink = ByteArray(numBytesToRead)
+        val BUFFER_SIZE = 1024
+        val buffer = ByteBuffer.allocate(BUFFER_SIZE)
+
+
+        while (awsChunked.readAvailable(buffer) != -1) {
+            while (buffer.remaining() > 0) {
+                sink += buffer.get()
+            }
+            buffer.clear()
+        }
+
+        val sinkAsString = sink.decodeToString()
+
+        val chunkSignatures = getChunkSignatures(sinkAsString)
+        assertEquals(2, chunkSignatures.size)
+        val chunkSizes = getChunkSizes(sinkAsString)
+        assertEquals(2, chunkSizes.size)
+
+        var expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[0])
+        assertEquals(CHUNK_SIZE_BYTES, chunkSizes[0])
+
+        expectedChunkSignature = testSigner.signChunk(byteArrayOf(), expectedChunkSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[1])
+        assertEquals(0, chunkSizes[1])
+
+        assertTrue { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadAvailableFewerBytes() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+
+        val previousSignature: ByteArray = byteArrayOf()
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature)
+
+        // read excess of chunk data
+        val numBytesToRead = dataLengthBytes / 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
+                (1 + 1 + "chunk-signature=".length + 64 + 4)
+
+        var sink = byteArrayOf()
+        val BUFFER_SIZE = 1024
+        val buffer = ByteBuffer.allocate(BUFFER_SIZE)
+
+        var bytesRead = 0
+        while (bytesRead <= numBytesToRead) {
+            val currBytesRead = awsChunked.readAvailable(buffer)
+            if (currBytesRead == -1) { break }
+            bytesRead += currBytesRead
+
+            while (buffer.remaining() > 0) {
+                sink += buffer.get()
+            }
+            buffer.clear()
+        }
+
+        val sinkAsString = sink.decodeToString()
+        println(sinkAsString)
+
+        val chunkSignatures = getChunkSignatures(sinkAsString)
+        assertEquals(1, chunkSignatures.size)
+        val chunkSizes = getChunkSizes(sinkAsString)
+        assertEquals(1, chunkSizes.size)
+
+        val expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[0])
+        assertEquals(CHUNK_SIZE_BYTES, chunkSizes[0])
+
+        assertFalse { awsChunked.isClosedForRead }
+    }
+
+    @Test
+    fun testReadAvailableWithTrailingHeaders() = runTest {
+        val dataLengthBytes = CHUNK_SIZE_BYTES
+        val data = ByteArray(dataLengthBytes) { 0x7A.toByte() }
+        val chan = SdkByteReadChannel(data)
+        val previousSignature: ByteArray = byteArrayOf()
+        val trailingHeaders = Headers {
+            append("x-amz-checksum-crc32", "AAAAAA==")
+            append("x-amz-arbitrary-header-with-value", "THIS IS A TEST!")
+        }
+        val trailingHeadersLength = getTrailingHeadersLength(trailingHeaders)
+
+        val awsChunked = AwsChunked(chan, testSigner, testSigningConfig, previousSignature, trailingHeaders)
+
+        // read all the chunk data plus all bytes from header
+        val numBytesToRead = CHUNK_SIZE_BYTES + CHUNK_SIZE_BYTES.toString(16).length + 1 +
+            ("chunk-signature=".length + 64 + 4) +
+            (1 + 1 + "chunk-signature=".length + 64 + 2) + trailingHeadersLength + 2
+
+        var sink = ByteArray(numBytesToRead)
+        val BUFFER_SIZE = 1024
+        val buffer = ByteBuffer.allocate(BUFFER_SIZE)
+
+        var bytesRead = 0
+        while (bytesRead != numBytesToRead) {
+            bytesRead += awsChunked.readAvailable(buffer)
+
+            while (buffer.remaining() > 0) {
+                sink += buffer.get()
+            }
+
+            buffer.clear()
+        }
+
+        assertEquals(numBytesToRead, bytesRead)
+
+        val sinkAsString = sink.decodeToString()
+        println(sinkAsString)
+
+        val chunkSignatures = getChunkSignatures(sinkAsString)
+        assertEquals(2, chunkSignatures.size)
+        val chunkSizes = getChunkSizes(sinkAsString)
+        assertEquals(2, chunkSizes.size)
+
+        var expectedChunkSignature = testSigner.signChunk(data, previousSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[0])
+        assertEquals(CHUNK_SIZE_BYTES, chunkSizes[0])
+
+        expectedChunkSignature = testSigner.signChunk(byteArrayOf(), expectedChunkSignature, testSigningConfig).signature
+        assertEquals(expectedChunkSignature.decodeToString(), chunkSignatures[1])
+        assertEquals(0, chunkSizes[1])
+
+        val trailingHeaderBytes = sink.slice(sink.size - trailingHeadersLength - 2 until sink.size - "x-amz-trailer-signature:".length - 64 - 4).toByteArray()
+        val expectedTrailerSignature = testSigner.signChunkTrailer(trailingHeaderBytes, expectedChunkSignature, testSigningConfig).signature
+        val trailerSignature = getChunkTrailerSignature(sinkAsString)
+        assertEquals(expectedTrailerSignature.decodeToString(), trailerSignature)
+
+        assertTrue { awsChunked.isClosedForRead }
+    }
+}

--- a/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
+++ b/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
@@ -6,16 +6,13 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.*
+import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.*
-import aws.smithy.kotlin.runtime.auth.awssigning.*
-import aws.smithy.kotlin.runtime.http.Headers
-
-
 import java.nio.ByteBuffer
+import kotlin.test.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AwsChunkedJVMTest {
@@ -39,7 +36,8 @@ class AwsChunkedJVMTest {
      * chunk-signature=<64 alphanumeric characters>
      */
     private fun getChunkSignatures(bytes: String): List<String> = CHUNK_SIGNATURE_REGEX.findAll(bytes).map {
-            result -> result.value.split("=")[1]
+            result ->
+        result.value.split("=")[1]
     }.toList()
 
     /**
@@ -48,7 +46,8 @@ class AwsChunkedJVMTest {
      * String(Hex(ChunkSize));chunk-signature=<chunk_signature>
      */
     private fun getChunkSizes(bytes: String): List<Int> = CHUNK_SIZE_REGEX.findAll(bytes).map {
-            result -> result.value.split(";")[0].toInt(16)
+            result ->
+        result.value.split(";")[0].toInt(16)
     }.toList()
 
     /**
@@ -66,15 +65,15 @@ class AwsChunkedJVMTest {
      * Used to calculate how many bytes should be read for all the trailing headers to be consumed
      */
     private fun getTrailingHeadersLength(trailingHeaders: Headers) = trailingHeaders.entries().map {
-            entry -> buildString {
-        append(entry.key)
-        append(":")
-        append(entry.value.joinToString(","))
-        append("\r\n")
-    }.length
-    } .reduce { acc, len -> acc + len } +
-            "x-amz-trailer-signature:".length + 64 + "\r\n".length
-
+            entry ->
+        buildString {
+            append(entry.key)
+            append(":")
+            append(entry.value.joinToString(","))
+            append("\r\n")
+        }.length
+    }.reduce { acc, len -> acc + len } +
+        "x-amz-trailer-signature:".length + 64 + "\r\n".length
 
     @Test
     fun testReadAvailableExactBytes() = runTest {
@@ -135,12 +134,11 @@ class AwsChunkedJVMTest {
 
         // read excess of chunk data
         val numBytesToRead = dataLengthBytes * 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
-                (1 + 1 + "chunk-signature=".length + 64 + 4)
+            (1 + 1 + "chunk-signature=".length + 64 + 4)
 
         var sink = ByteArray(numBytesToRead)
         val BUFFER_SIZE = 1024
         val buffer = ByteBuffer.allocate(BUFFER_SIZE)
-
 
         while (awsChunked.readAvailable(buffer) != -1) {
             while (buffer.remaining() > 0) {
@@ -178,7 +176,7 @@ class AwsChunkedJVMTest {
 
         // read excess of chunk data
         val numBytesToRead = dataLengthBytes / 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
-                (1 + 1 + "chunk-signature=".length + 64 + 4)
+            (1 + 1 + "chunk-signature=".length + 64 + 4)
 
         var sink = byteArrayOf()
         val BUFFER_SIZE = 1024

--- a/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
+++ b/runtime/auth/aws-signing-common/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedJVMTest.kt
@@ -6,13 +6,16 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.*
-import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import java.nio.ByteBuffer
 import kotlin.test.*
+import aws.smithy.kotlin.runtime.auth.awssigning.*
+import aws.smithy.kotlin.runtime.http.Headers
+
+
+import java.nio.ByteBuffer
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AwsChunkedJVMTest {
@@ -36,8 +39,7 @@ class AwsChunkedJVMTest {
      * chunk-signature=<64 alphanumeric characters>
      */
     private fun getChunkSignatures(bytes: String): List<String> = CHUNK_SIGNATURE_REGEX.findAll(bytes).map {
-            result ->
-        result.value.split("=")[1]
+            result -> result.value.split("=")[1]
     }.toList()
 
     /**
@@ -46,8 +48,7 @@ class AwsChunkedJVMTest {
      * String(Hex(ChunkSize));chunk-signature=<chunk_signature>
      */
     private fun getChunkSizes(bytes: String): List<Int> = CHUNK_SIZE_REGEX.findAll(bytes).map {
-            result ->
-        result.value.split(";")[0].toInt(16)
+            result -> result.value.split(";")[0].toInt(16)
     }.toList()
 
     /**
@@ -65,15 +66,15 @@ class AwsChunkedJVMTest {
      * Used to calculate how many bytes should be read for all the trailing headers to be consumed
      */
     private fun getTrailingHeadersLength(trailingHeaders: Headers) = trailingHeaders.entries().map {
-            entry ->
-        buildString {
-            append(entry.key)
-            append(":")
-            append(entry.value.joinToString(","))
-            append("\r\n")
-        }.length
-    }.reduce { acc, len -> acc + len } +
-        "x-amz-trailer-signature:".length + 64 + "\r\n".length
+            entry -> buildString {
+        append(entry.key)
+        append(":")
+        append(entry.value.joinToString(","))
+        append("\r\n")
+    }.length
+    } .reduce { acc, len -> acc + len } +
+            "x-amz-trailer-signature:".length + 64 + "\r\n".length
+
 
     @Test
     fun testReadAvailableExactBytes() = runTest {
@@ -134,11 +135,12 @@ class AwsChunkedJVMTest {
 
         // read excess of chunk data
         val numBytesToRead = dataLengthBytes * 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
-            (1 + 1 + "chunk-signature=".length + 64 + 4)
+                (1 + 1 + "chunk-signature=".length + 64 + 4)
 
         var sink = ByteArray(numBytesToRead)
         val BUFFER_SIZE = 1024
         val buffer = ByteBuffer.allocate(BUFFER_SIZE)
+
 
         while (awsChunked.readAvailable(buffer) != -1) {
             while (buffer.remaining() > 0) {
@@ -176,7 +178,7 @@ class AwsChunkedJVMTest {
 
         // read excess of chunk data
         val numBytesToRead = dataLengthBytes / 2 + dataLengthBytes.toString(16).length + 1 + "chunk-signature=".length + 64 + 4 +
-            (1 + 1 + "chunk-signature=".length + 64 + 4)
+                (1 + 1 + "chunk-signature=".length + 64 + 4)
 
         var sink = byteArrayOf()
         val BUFFER_SIZE = 1024

--- a/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
+++ b/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
@@ -47,6 +47,14 @@ public object CrtAwsSigner : AwsSigner {
         val crtResult = CrtSigner.signChunk(chunkBody, prevSignature, crtConfig)
         return AwsSigningResult(Unit, crtResult.signature)
     }
+
+    override suspend fun signChunkTrailer(
+        trailingHeaders: ByteArray,
+        finalChunkSignature: ByteArray,
+        config: AwsSigningConfig,
+    ): AwsSigningResult<Unit> {
+        TODO("Not yet implemented")
+    }
 }
 
 private fun AwsSignatureType.toCrtSignatureType() = when (this) {

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannel.kt
@@ -42,7 +42,7 @@ public expect interface SdkByteReadChannel : Closeable {
     public suspend fun readRemaining(limit: Int = Int.MAX_VALUE): ByteArray
 
     /**
-     * Reads all length bytes to [sink] buffer or fails if source has been closed. Suspends if not enough
+     * Reads all [length] bytes to [sink] buffer or fails if source has been closed. Suspends if not enough
      * bytes available.
      */
     public suspend fun readFully(sink: ByteArray, offset: Int = 0, length: Int = sink.size - offset)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implements the `aws-chunked` content encoding.

- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming-trailers.html

## Issue \#
https://github.com/awslabs/aws-sdk-kotlin/issues/747

## Description of changes
This change is required to achieve feature parity with other SDKs. It adds the `aws-chunked` content encoding, which can be used to upload data in chunks.

It works by wrapping an underlying `SdkByteReadChannel`. When reads are performed, the AwsChunked class will read from the underlying channel and transform the content to aws-chunked.

 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
