### PR TITLE
feat: endpoints2: endpoint provider middleware and final integration

### DIFF
--- a/docs/design/endpoints.md
+++ b/docs/design/endpoints.md
@@ -481,10 +481,7 @@ internal class GetResourceResolveEndpointMiddleware(
         }
         
         op.execution.mutate.intercept { req, next -> ...
-            setRequestEndpoint(req, endpoint)
-
-            // further action can be taken here as part of renderPostResolution...
-
+            setResolvedEndpoint(req, endpoint)
             next.call(req)
         }
     }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointProvider.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointProvider.kt
@@ -5,19 +5,14 @@
 
 package aws.smithy.kotlin.runtime.http.endpoints
 
-import aws.smithy.kotlin.runtime.util.InternalApi
-
 /**
  * Resolves endpoints for a given service client.
- *
- * This is a static version of the otherwise-generated endpoint resolver interface and is intended for use by internal
- * clients within the runtime.
  */
-@InternalApi
-public fun interface EndpointResolver {
+public fun interface EndpointProvider<T> {
     /**
      * Resolve the endpoint to make requests to
+     * @param params The input context for the resolver function
      * @return an [Endpoint] that can be used to connect to the service
      */
-    public suspend fun resolve(): Endpoint
+    public suspend fun resolveEndpoint(params: T): Endpoint
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointResolver.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/endpoints/EndpointResolver.kt
@@ -5,9 +5,15 @@
 
 package aws.smithy.kotlin.runtime.http.endpoints
 
+import aws.smithy.kotlin.runtime.util.InternalApi
+
 /**
- * Resolves endpoints for a given service client
+ * Resolves endpoints for a given service client.
+ *
+ * This is a static version of the otherwise-generated endpoint resolver interface and is intended for use by internal
+ * clients within the runtime.
  */
+@InternalApi
 public fun interface EndpointResolver {
     /**
      * Resolve the endpoint to make requests to

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -4,7 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.middleware
 
-import aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver
+import aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider
 import aws.smithy.kotlin.runtime.http.endpoints.setResolvedEndpoint
 import aws.smithy.kotlin.runtime.http.operation.ModifyRequestMiddleware
 import aws.smithy.kotlin.runtime.http.operation.SdkHttpRequest
@@ -18,12 +18,13 @@ import aws.smithy.kotlin.runtime.util.InternalApi
  * within the runtime.
  */
 @InternalApi
-public class ResolveEndpoint(
-    private val resolver: EndpointResolver,
+public class ResolveEndpoint<T>(
+    private val provider: EndpointProvider<T>,
+    private val params: T,
 ) : ModifyRequestMiddleware {
 
     override suspend fun modifyRequest(req: SdkHttpRequest): SdkHttpRequest {
-        val endpoint = resolver.resolve()
+        val endpoint = provider.resolveEndpoint(params)
         setResolvedEndpoint(req, endpoint)
         val logger = req.context.getLogger("ResolveEndpoint")
         logger.debug { "resolved endpoint: $endpoint" }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpoint.kt
@@ -2,17 +2,20 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package aws.smithy.kotlin.runtime.http.middleware
 
-import aws.smithy.kotlin.runtime.http.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver
-import aws.smithy.kotlin.runtime.http.operation.*
+import aws.smithy.kotlin.runtime.http.endpoints.setResolvedEndpoint
+import aws.smithy.kotlin.runtime.http.operation.ModifyRequestMiddleware
+import aws.smithy.kotlin.runtime.http.operation.SdkHttpRequest
+import aws.smithy.kotlin.runtime.http.operation.getLogger
 import aws.smithy.kotlin.runtime.util.InternalApi
-import aws.smithy.kotlin.runtime.util.net.Host
 
 /**
- *  Http middleware for resolving the service endpoint.
+ * Http middleware for resolving the service endpoint.
+ *
+ * This is a static version of the otherwise-generated endpoint middleware and is intended for use by internal clients
+ * within the runtime.
  */
 @InternalApi
 public class ResolveEndpoint(
@@ -21,39 +24,9 @@ public class ResolveEndpoint(
 
     override suspend fun modifyRequest(req: SdkHttpRequest): SdkHttpRequest {
         val endpoint = resolver.resolve()
-        setRequestEndpoint(req, endpoint)
+        setResolvedEndpoint(req, endpoint)
         val logger = req.context.getLogger("ResolveEndpoint")
         logger.debug { "resolved endpoint: $endpoint" }
         return req
     }
-}
-
-/**
- * Populate the request URL parameters from a resolved endpoint
- */
-@InternalApi
-public fun setRequestEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
-    val hostPrefix = req.context.getOrNull(HttpOperationContext.HostPrefix)
-    val hostname = if (hostPrefix != null && !endpoint.isHostnameImmutable) {
-        "$hostPrefix${endpoint.uri.host}"
-    } else {
-        endpoint.uri.host.toString()
-    }
-
-    req.subject.url.scheme = endpoint.uri.scheme
-    req.subject.url.host = Host.parse(hostname)
-    req.subject.url.port = endpoint.uri.port
-    req.subject.headers["Host"] = hostname
-    if (endpoint.uri.path.isNotBlank()) {
-        val opPath = req.subject.url.path
-        val endpointPath = endpoint.uri.path.removeSuffix("/")
-        req.subject.url.path = if (opPath.isNotBlank()) {
-            "$endpointPath/${opPath.removePrefix("/")}"
-        } else {
-            // keep endpoint path as is
-            endpoint.uri.path
-        }
-    }
-
-    req.subject.url.parameters.appendAll(endpoint.uri.parameters)
 }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -103,22 +103,6 @@ class ResolveEndpointTest {
     }
 
     @Test
-    fun testSkipHostPrefixForImmutableHostnames() = runTest {
-        val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
-        val endpoint = Endpoint(uri = Url.parse("http://api.test.com"), isHostnameImmutable = true)
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
-        op.context[HttpOperationContext.HostPrefix] = "prefix."
-
-        op.roundTrip(client, Unit)
-        val actual = op.context[HttpOperationContext.HttpCallList].first().request
-
-        assertEquals(Host.Domain("api.test.com"), actual.url.host)
-        assertEquals(Protocol.HTTP, actual.url.scheme)
-        assertEquals("/operation", actual.url.path)
-    }
-
-    @Test
     fun testEndpointPathPrefixWithNonEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix/"))

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -44,8 +44,8 @@ class ResolveEndpointTest {
     fun testHostIsSet() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder(), Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -59,8 +59,8 @@ class ResolveEndpointTest {
     fun testHostWithPort() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder(), Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com:8080"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -74,8 +74,8 @@ class ResolveEndpointTest {
     fun testHostWithBasePath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com:8080/foo/bar"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -90,8 +90,8 @@ class ResolveEndpointTest {
     fun testHostPrefix() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
         op.context[HttpOperationContext.HostPrefix] = "prefix."
 
         op.roundTrip(client, Unit)
@@ -106,8 +106,8 @@ class ResolveEndpointTest {
     fun testEndpointPathPrefixWithNonEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix/"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -121,8 +121,8 @@ class ResolveEndpointTest {
     fun testEndpointPathPrefixWithEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -136,8 +136,8 @@ class ResolveEndpointTest {
     fun testQueryParameters() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com?foo=bar&baz=qux"))
-        val resolver = EndpointProvider<Nothing?> { endpoint }
-        op.install(ResolveEndpoint(resolver, null))
+        val resolver = EndpointProvider<Unit> { endpoint }
+        op.install(ResolveEndpoint(resolver, Unit))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.Protocol
 import aws.smithy.kotlin.runtime.http.Url
 import aws.smithy.kotlin.runtime.http.endpoints.Endpoint
-import aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver
+import aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
@@ -44,8 +44,8 @@ class ResolveEndpointTest {
     fun testHostIsSet() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder(), Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -59,8 +59,8 @@ class ResolveEndpointTest {
     fun testHostWithPort() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder(), Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com:8080"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -74,8 +74,8 @@ class ResolveEndpointTest {
     fun testHostWithBasePath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("https://api.test.com:8080/foo/bar"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -90,8 +90,8 @@ class ResolveEndpointTest {
     fun testHostPrefix() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
         op.context[HttpOperationContext.HostPrefix] = "prefix."
 
         op.roundTrip(client, Unit)
@@ -106,8 +106,8 @@ class ResolveEndpointTest {
     fun testEndpointPathPrefixWithNonEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix/"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -121,8 +121,8 @@ class ResolveEndpointTest {
     fun testEndpointPathPrefixWithEmptyPath() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com/path/prefix"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request
@@ -136,8 +136,8 @@ class ResolveEndpointTest {
     fun testQueryParameters() = runTest {
         val op = newTestOperation<Unit, Unit>(HttpRequestBuilder().apply { url.path = "/operation" }, Unit)
         val endpoint = Endpoint(uri = Url.parse("http://api.test.com?foo=bar&baz=qux"))
-        val resolver = EndpointResolver { endpoint }
-        op.install(ResolveEndpoint(resolver))
+        val resolver = EndpointProvider<Nothing?> { endpoint }
+        op.install(ResolveEndpoint(resolver, null))
 
         op.roundTrip(client, Unit)
         val actual = op.context[HttpOperationContext.HttpCallList].first().request

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -69,12 +69,14 @@ object RuntimeTypes {
             val context = runtimeSymbol("context", KotlinDependency.HTTP, "operation")
             val roundTrip = runtimeSymbol("roundTrip", KotlinDependency.HTTP, "operation")
             val execute = runtimeSymbol("execute", KotlinDependency.HTTP, "operation")
+            val InlineMiddleware = runtimeSymbol("InlineMiddleware", KotlinDependency.HTTP, "operation")
         }
 
         object Endpoints {
             val EndpointResolver = runtimeSymbol("EndpointResolver", KotlinDependency.HTTP, "endpoints")
             val Endpoint = runtimeSymbol("Endpoint", KotlinDependency.HTTP, "endpoints")
             val EndpointProviderException = runtimeSymbol("EndpointProviderException", KotlinDependency.HTTP, "endpoints")
+            val setResolvedEndpoint = runtimeSymbol("setResolvedEndpoint", KotlinDependency.HTTP, "endpoints")
 
             object Functions {
                 val substring = runtimeSymbol("substring", KotlinDependency.HTTP, "endpoints.functions")
@@ -224,6 +226,7 @@ object RuntimeTypes {
                 val PresigningLocation = runtimeSymbol("PresigningLocation", KotlinDependency.AWS_SIGNING_COMMON)
                 val ServicePresignConfig = runtimeSymbol("ServicePresignConfig", KotlinDependency.AWS_SIGNING_COMMON)
                 val SigningEndpointProvider = runtimeSymbol("SigningEndpointProvider", KotlinDependency.AWS_SIGNING_COMMON)
+                val SigningContextualizedEndpoint = runtimeSymbol("SigningContextualizedEndpoint", KotlinDependency.AWS_SIGNING_COMMON)
             }
 
             object AwsSigningStandard {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -73,7 +73,7 @@ object RuntimeTypes {
         }
 
         object Endpoints {
-            val EndpointResolver = runtimeSymbol("EndpointResolver", KotlinDependency.HTTP, "endpoints")
+            val EndpointProvider = runtimeSymbol("EndpointProvider", KotlinDependency.HTTP, "endpoints")
             val Endpoint = runtimeSymbol("Endpoint", KotlinDependency.HTTP, "endpoints")
             val EndpointProviderException = runtimeSymbol("EndpointProviderException", KotlinDependency.HTTP, "endpoints")
             val setResolvedEndpoint = runtimeSymbol("setResolvedEndpoint", KotlinDependency.HTTP, "endpoints")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
@@ -31,9 +31,7 @@ fun ParameterType.toSymbol(): Symbol =
         ParameterType.STRING -> KotlinTypes.String
         ParameterType.BOOLEAN -> KotlinTypes.Boolean
     }
-        .toBuilder()
-        .boxed()
-        .build()
+        .asNullable()
 
 /**
  * Get the writable literal for a rules engine value.
@@ -41,6 +39,6 @@ fun ParameterType.toSymbol(): Symbol =
 fun Value.toLiteral(): String =
     when (this) {
         is Value.String -> expectString().doubleQuote()
-        is Value.Bool -> if (expectBool()) "true" else "false"
+        is Value.Bool -> expectBool().toString()
         else -> throw IllegalArgumentException("unrecognized parameter value type")
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/RulesEngineExt.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.model
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
+import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
+import software.amazon.smithy.kotlin.codegen.utils.toCamelCase
+import software.amazon.smithy.rulesengine.language.eval.Value
+import software.amazon.smithy.rulesengine.language.syntax.Identifier
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
+import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
+
+/**
+ * Derive the kotlin variable name for an identifier.
+ */
+fun Identifier.defaultName(): String = asString().toCamelCase()
+
+/**
+ * Derive the kotlin variable name for an endpoint parameter.
+ */
+fun Parameter.defaultName(): String = name.defaultName()
+
+/**
+ * Get the symbol for an endpoint parameter type. All endpoint parameter members are nullable.
+ */
+fun ParameterType.toSymbol(): Symbol =
+    when (this) {
+        ParameterType.STRING -> KotlinTypes.String
+        ParameterType.BOOLEAN -> KotlinTypes.Boolean
+    }
+        .toBuilder()
+        .boxed()
+        .build()
+
+/**
+ * Get the writable literal for a rules engine value.
+ */
+fun Value.toLiteral(): String =
+    when (this) {
+        is Value.String -> expectString().doubleQuote()
+        is Value.Bool -> if (expectBool()) "true" else "false"
+        else -> throw IllegalArgumentException("unrecognized parameter value type")
+    }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.model
 
+import kotlin.streams.toList
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.core.defaultName

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -5,8 +5,10 @@
 
 package software.amazon.smithy.kotlin.codegen.model
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.core.defaultName
+import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationInput
 import software.amazon.smithy.kotlin.codegen.model.traits.OperationOutput
 import software.amazon.smithy.kotlin.codegen.utils.getOrNull
@@ -238,3 +240,12 @@ fun UnionShape.filterEventStreamErrors(model: Model): Collection<MemberShape> {
  * Test if a shape is optional.
  */
 fun Shape.isOptional(): Boolean = members().none { it.isRequired }
+
+/**
+ * Derive the input and output symbols for an operation.
+ */
+fun OperationIndex.getOperationInputOutputSymbols(op: OperationShape, symbolProvider: SymbolProvider): Pair<Symbol, Symbol> =
+    Pair(
+        getInput(op).map { symbolProvider.toSymbol(it) }.getOrNull() ?: KotlinTypes.Unit,
+        getOutput(op).map { symbolProvider.toSymbol(it) }.getOrNull() ?: KotlinTypes.Unit,
+    )

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -17,7 +17,10 @@ import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.*
-import kotlin.streams.toList
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
+import software.amazon.smithy.rulesengine.traits.EndpointTestCase
+import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
 
 /**
  * Get all shapes of a particular type from the model.
@@ -249,3 +252,17 @@ fun OperationIndex.getOperationInputOutputSymbols(op: OperationShape, symbolProv
         getInput(op).map { symbolProvider.toSymbol(it) }.getOrNull() ?: KotlinTypes.Unit,
         getOutput(op).map { symbolProvider.toSymbol(it) }.getOrNull() ?: KotlinTypes.Unit,
     )
+
+/**
+ * Extract a service's endpoint rules if present.
+ */
+fun ServiceShape.getEndpointRules(): EndpointRuleSet? =
+    getTrait<EndpointRuleSetTrait>()?.let {
+        EndpointRuleSet.fromNode(it.ruleSet)
+    }
+
+/**
+ * Extract endpoint test cases from a service if present.
+ */
+fun ServiceShape.getEndpointTests(): List<EndpointTestCase> =
+    getTrait<EndpointTestsTrait>()?.testCases ?: emptyList()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.kotlin.codegen.model
 
-import kotlin.streams.toList
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.core.defaultName
@@ -22,6 +21,7 @@ import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rulesengine.traits.EndpointTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
+import kotlin.streams.toList
 
 /**
  * Get all shapes of a particular type from the model.

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
@@ -132,3 +132,8 @@ fun Symbol.Builder.addReference(symbol: Symbol, option: SymbolReference.ContextO
  */
 val Symbol.shape: Shape?
     get() = getProperty(SymbolProperty.SHAPE_KEY, Shape::class.java).getOrNull()
+
+/**
+ * Get the nullable version of a symbol
+ */
+fun Symbol.asNullable(): Symbol = toBuilder().boxed().build()

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigProperty.kt
@@ -228,7 +228,6 @@ object KotlinClientRuntimeConfigProperty {
     val IdempotencyTokenProvider: ClientConfigProperty
     val RetryStrategy: ClientConfigProperty
     val SdkLogMode: ClientConfigProperty
-    val EndpointResolver: ClientConfigProperty
 
     init {
         val httpClientConfigSymbol = buildSymbol {
@@ -300,15 +299,6 @@ object KotlinClientRuntimeConfigProperty {
             performance considerations when dumping the request/response body. This is primarily a tool for
             debug purposes.
             """.trimIndent()
-        }
-
-        EndpointResolver = ClientConfigProperty {
-            symbol = RuntimeTypes.Http.Endpoints.EndpointResolver
-            documentation = """
-            Set the [${symbol!!.fullName}] used to resolve service endpoints. Operation requests will be 
-            made against the endpoint returned by the resolver.
-            """.trimIndent()
-            propertyType = ClientConfigPropertyType.Required()
         }
     }
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
+import software.amazon.smithy.kotlin.codegen.model.defaultName
 import software.amazon.smithy.model.SourceLocation
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.language.syntax.Identifier
@@ -120,7 +121,7 @@ class DefaultEndpointProviderGenerator(
         // explicitly wrap blocks with assignments to restrict scope therein
         writer.wrapBlockIf(assignments.isNotEmpty(), "run {", "}") {
             assignments.forEach {
-                writer.writeInline("val #L = ", it.result.get().toKotlin())
+                writer.writeInline("val #L = ", it.result.get().defaultName())
                 renderExpression(it.fn)
                 writer.write("")
             }
@@ -214,7 +215,7 @@ class ExpressionGenerator(
         if (isParamRef(reference)) {
             writer.writeInline("params.")
         }
-        writer.writeInline(reference.name.toKotlin())
+        writer.writeInline(reference.name.defaultName())
     }
 
     override fun visitGetAttr(getAttr: GetAttr) {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -38,6 +38,8 @@ class EndpointParametersGenerator(
                 name = CLASS_NAME
                 namespace = "${settings.pkg.name}.endpoints"
             }
+
+        fun getParamKotlinName(param: Parameter): String = param.name.toKotlin()
     }
 
     private val params: List<KotlinEndpointParameter> = rules.parameters.toList()
@@ -181,7 +183,7 @@ private fun KotlinEndpointParameter.renderDeclaration(writer: KotlinWriter, init
     writer.write("")
 }
 
-internal fun Identifier.toKotlin(): String = asString().toCamelCase()
+fun Identifier.toKotlin(): String = asString().toCamelCase()
 
 private fun ParameterType.toSymbol(): Symbol =
     when (this) {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -8,7 +8,6 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
-import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 
 /**
@@ -32,12 +31,10 @@ class EndpointProviderGenerator(
 
     fun render() {
         renderDocumentation()
-        writer.withBlock("public fun interface #L {", "}", CLASS_NAME) {
-            write("public suspend fun resolveEndpoint(params: #T): #T", paramsSymbol, RuntimeTypes.Http.Endpoints.Endpoint)
-        }
+        writer.write("public typealias EndpointProvider = #T<#T>", RuntimeTypes.Http.Endpoints.EndpointProvider, paramsSymbol)
     }
 
-    fun renderDocumentation() {
+    private fun renderDocumentation() {
         writer.dokka {
             write("Resolves to an endpoint for a given service operation.")
         }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.rendering.endpoints
+
+import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.core.*
+import software.amazon.smithy.kotlin.codegen.model.*
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.kotlin.codegen.utils.getOrNull
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.OperationIndex
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
+import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
+import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait
+
+/**
+ * Generates resolver middleware for a specific endpoint provider signature.
+ * The binding of parameter values is generated separately in [EndpointParameterBindingGenerator], and that generated
+ * implementation is plugged in here.
+ */
+class ResolveEndpointMiddlewareGenerator(
+    private val ctx: ProtocolGenerator.GenerationContext,
+    private val writer: KotlinWriter,
+) {
+    companion object {
+        const val CLASS_NAME = "ResolveEndpointMiddleware"
+
+        fun getSymbol(settings: KotlinSettings): Symbol =
+            buildSymbol {
+                name = CLASS_NAME
+                namespace = "${settings.pkg.name}.endpoints.internal"
+            }
+    }
+
+    fun render() {
+        writer.openBlock("public class #L<I, O>(", CLASS_NAME)
+        renderConstructorParams()
+        writer.closeAndOpenBlock(") : #T<I, O> {", RuntimeTypes.Http.Operation.InlineMiddleware)
+        renderClassMembers()
+        writer.write("")
+        renderInstall()
+        writer.closeBlock("}")
+    }
+
+    private fun renderConstructorParams() {
+        writer.write("private val endpointProvider: #T,", EndpointProviderGenerator.getSymbol(ctx.settings))
+        writer.write("private val buildParams: #T.Builder.(input: I) -> Unit,", EndpointParametersGenerator.getSymbol(ctx.settings))
+    }
+
+    private fun renderClassMembers() {
+        writer.write("private lateinit var endpoint: #T", RuntimeTypes.Http.Endpoints.Endpoint)
+    }
+
+    private fun renderInstall() {
+        writer.withBlock("public override fun install(op: #T<I, O>) {", "}", RuntimeTypes.Http.Operation.SdkHttpOperation) {
+            renderInitialize()
+            write("")
+            renderMutate()
+        }
+    }
+
+    private fun renderInitialize() {
+        writer.withBlock("op.execution.initialize.intercept { req, next ->", "}") {
+            write("val params = #T { buildParams(req.subject) }", EndpointParametersGenerator.getSymbol(ctx.settings))
+            write("endpoint = endpointProvider.resolveEndpoint(params)")
+            write("next.call(req)")
+        }
+    }
+
+    private fun renderMutate() {
+        writer.withBlock("op.execution.mutate.intercept { req, next ->", "}") {
+            write("#T(req, endpoint)", RuntimeTypes.Http.Endpoints.setResolvedEndpoint)
+            write("next.call(req)")
+        }
+    }
+}
+
+/**
+ * Renders an endpoint parameter builder lambda that binds values for a specific operation.
+ */
+class EndpointParameterBindingGenerator(
+    private val model: Model,
+    private val service: ServiceShape,
+    private val writer: KotlinWriter,
+    private val op: OperationShape,
+    private val rules: EndpointRuleSet,
+    private val inputPrefix: String,
+) {
+    private val opIndex = OperationIndex.of(model)
+    private val staticContextParams = op.getTrait<StaticContextParamsTrait>()
+
+    // maps endpoint parameter name -> input member shape
+    private val inputContextParams = buildMap<String, MemberShape> {
+        opIndex.getInput(op).getOrNull()?.members()?.forEach { member ->
+            member.getTrait<ContextParamTrait>()?.let { trait ->
+                put(trait.name, member)
+            }
+        }
+    }
+    private val clientContextParams = service.getTrait<ClientContextParamsTrait>()
+
+    fun render() {
+        rules.parameters.toList().forEach(::renderBinding)
+    }
+
+    /**
+     * Render the assignment of an endpoint param value within a builder. The SEP dictates a specific source order to
+     * use when determining how to bind:
+     * 1. staticContextParams (from operation shape)
+     * 2. contextParam (from member of operation input shape)
+     * 3. clientContextParams (from service shape)
+     * 4. builtin binding
+     * 5. builtin default
+     *
+     * Sources 4 and 5 are SDK-specific, builtin bindings are plugged in and rendered beforehand such that any bindings
+     * from source 1 or 2 can supersede them.
+     */
+    private fun renderBinding(param: Parameter) {
+        val paramName = param.name.asString()
+        val paramKotlinName = param.name.toKotlin()
+
+        staticContextParams?.parameters?.get(paramName)?.let {
+            writer.writeInline("#L = ", paramKotlinName)
+            when (param.type) {
+                ParameterType.STRING -> writer.write("#S", it.value.expectStringNode().value)
+                ParameterType.BOOLEAN -> writer.write("#L", it.value.expectBooleanNode().value)
+                else -> throw CodegenException("unexpected static context param type ${param.type}")
+            }
+            return
+        }
+
+        inputContextParams[paramName]?.let {
+            writer.write("#L = #L#L", paramKotlinName, inputPrefix, it.defaultName())
+            return
+        }
+
+        clientContextParams?.parameters?.get(paramName)?.let {
+            writer.write("#1L = config.#1L", paramKotlinName)
+        }
+    }
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -293,7 +293,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         val pathBindings = requestBindings.filter { it.location == HttpBinding.Location.LABEL }
 
         if (pathBindings.isNotEmpty()) {
-            writer.openBlock("val pathSegments = listOf(", ")") {
+            writer.openBlock("val pathSegments = listOf<String>(", ")") {
                 httpTrait.uri.segments.forEach { segment ->
                     if (segment.isLabel || segment.isGreedyLabel) {
                         // spec dictates member name and label name MUST be the same

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolTestGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolTestGenerator.kt
@@ -62,6 +62,7 @@ class HttpProtocolTestGenerator(
                     writer.addImport("${ctx.settings.pkg.name}.model", "*")
 
                     requestTestBuilder
+                        .ctx(ctx)
                         .writer(writer)
                         .model(ctx.model)
                         .symbolProvider(ctx.symbolProvider)
@@ -87,6 +88,7 @@ class HttpProtocolTestGenerator(
 
                     writer.addImport("${ctx.settings.pkg.name}.model", "*")
                     responseTestBuilder
+                        .ctx(ctx)
                         .writer(writer)
                         .model(ctx.model)
                         .symbolProvider(ctx.symbolProvider)
@@ -117,6 +119,7 @@ class HttpProtocolTestGenerator(
                         writer.addImport("${ctx.settings.pkg.name}.model", "*")
                         errorTestBuilder
                             .error(error)
+                            .ctx(ctx)
                             .writer(writer)
                             .model(ctx.model)
                             .symbolProvider(ctx.symbolProvider)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestGenerator.kt
@@ -22,13 +22,13 @@ import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase
 abstract class HttpProtocolUnitTestGenerator<T : HttpMessageTestCase>
 protected constructor(builder: Builder<T>) {
 
-    protected val ctx: ProtocolGenerator.GenerationContext = builder.ctx!!
-    protected val symbolProvider: SymbolProvider = builder.symbolProvider!!
-    protected val model: Model = builder.model!!
-    protected val testCases: List<T> = builder.testCases!!
-    protected val operation: OperationShape = builder.operation!!
-    protected val writer: KotlinWriter = builder.writer!!
-    protected val serviceShape: ServiceShape = builder.service!!
+    protected val ctx: ProtocolGenerator.GenerationContext = requireNotNull(builder.ctx) { "protocol generator ctx is required" }
+    protected val symbolProvider: SymbolProvider = requireNotNull(builder.symbolProvider) { "symbol provider is required" }
+    protected val model: Model = requireNotNull(builder.model) { "model is required" }
+    protected val testCases: List<T> = requireNotNull(builder.testCases) { "list of test cases is required" }
+    protected val operation: OperationShape = requireNotNull(builder.operation) { "operation shape is required" }
+    protected val writer: KotlinWriter = requireNotNull(builder.writer) { "writer is required" }
+    protected val serviceShape: ServiceShape = requireNotNull(builder.service) { "service shape is required" }
 
     protected val idempotentFieldsInModel: Boolean by lazy {
         operation.input.isPresent &&

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestGenerator.kt
@@ -22,6 +22,7 @@ import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase
 abstract class HttpProtocolUnitTestGenerator<T : HttpMessageTestCase>
 protected constructor(builder: Builder<T>) {
 
+    protected val ctx: ProtocolGenerator.GenerationContext = builder.ctx!!
     protected val symbolProvider: SymbolProvider = builder.symbolProvider!!
     protected val model: Model = builder.model!!
     protected val testCases: List<T> = builder.testCases!!
@@ -74,6 +75,7 @@ protected constructor(builder: Builder<T>) {
     protected abstract fun renderTestBody(test: T)
 
     abstract class Builder<T : HttpMessageTestCase> {
+        var ctx: ProtocolGenerator.GenerationContext? = null
         var symbolProvider: SymbolProvider? = null
         var model: Model? = null
         var testCases: List<T>? = null
@@ -81,6 +83,7 @@ protected constructor(builder: Builder<T>) {
         var writer: KotlinWriter? = null
         var service: ServiceShape? = null
 
+        fun ctx(ctx: ProtocolGenerator.GenerationContext): Builder<T> = apply { this.ctx = ctx }
         fun symbolProvider(provider: SymbolProvider): Builder<T> = apply { this.symbolProvider = provider }
         fun model(model: Model): Builder<T> = apply { this.model = model }
         fun testCases(testCases: List<T>): Builder<T> = apply { this.testCases = testCases }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolGenerator.kt
@@ -11,10 +11,7 @@ import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.namespace
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.DefaultEndpointProviderGenerator
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.DefaultEndpointProviderTestGenerator
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointParametersGenerator
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointProviderGenerator
+import software.amazon.smithy.kotlin.codegen.rendering.endpoints.*
 import software.amazon.smithy.kotlin.codegen.rendering.serde.StructuredDataParserGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.serde.StructuredDataSerializerGenerator
 import software.amazon.smithy.model.Model

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
@@ -7,13 +7,10 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.withBlock
-import software.amazon.smithy.kotlin.codegen.model.expectTrait
-import software.amazon.smithy.kotlin.codegen.model.hasTrait
+import software.amazon.smithy.kotlin.codegen.model.getEndpointRules
 import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointParameterBindingGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.endpoints.ResolveEndpointMiddlewareGenerator
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.rulesengine.language.EndpointRuleSet
-import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 
 /**
  * Default endpoint resolver middleware
@@ -22,10 +19,11 @@ class ResolveEndpointMiddleware : ProtocolMiddleware {
     override val name: String = "ResolveEndpoint"
 
     override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
-        val rules = EndpointRuleSet.fromNode(ctx.service.expectTrait<EndpointRuleSetTrait>().ruleSet)
         val middlewareSymbol = ResolveEndpointMiddlewareGenerator.getSymbol(ctx.settings)
-        writer.withBlock("op.install(#T(config.endpointProvider)) {", "}", middlewareSymbol) {
-            EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "input.").render()
+        writer.withBlock("op.install(#T(config.endpointProvider) {", "})", middlewareSymbol) {
+            ctx.service.getEndpointRules()?.let { rules ->
+                EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "input.").render()
+            }
         }
     }
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
@@ -6,8 +6,14 @@
 package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
-import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
+import software.amazon.smithy.kotlin.codegen.core.withBlock
+import software.amazon.smithy.kotlin.codegen.model.expectTrait
+import software.amazon.smithy.kotlin.codegen.model.hasTrait
+import software.amazon.smithy.kotlin.codegen.rendering.endpoints.EndpointParameterBindingGenerator
+import software.amazon.smithy.kotlin.codegen.rendering.endpoints.ResolveEndpointMiddlewareGenerator
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 
 /**
  * Default endpoint resolver middleware
@@ -16,7 +22,10 @@ class ResolveEndpointMiddleware : ProtocolMiddleware {
     override val name: String = "ResolveEndpoint"
 
     override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
-        writer.addImport(RuntimeTypes.Http.Middlware.ResolveEndpoint)
-        writer.write("op.install(#T(config.endpointResolver))", RuntimeTypes.Http.Middlware.ResolveEndpoint)
+        val rules = EndpointRuleSet.fromNode(ctx.service.expectTrait<EndpointRuleSetTrait>().ruleSet)
+        val middlewareSymbol = ResolveEndpointMiddlewareGenerator.getSymbol(ctx.settings)
+        writer.withBlock("op.install(#T(config.endpointProvider)) {", "}", middlewareSymbol) {
+            EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "input.").render()
+        }
     }
 }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -41,6 +41,7 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
 
         val expectedProps = """
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
+    public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
     public val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
@@ -55,6 +56,10 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
          * client will not close it when the client is closed.
          */
         public var httpClientEngine: HttpClientEngine? = null
+        /**
+         * The endpoint provider used to determine where to make service requests.
+         */
+        public var endpointProvider: EndpointProvider? = null
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
          * that represent idempotent tokens when not explicitly set by the caller using this generator.

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -41,7 +41,6 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
 
         val expectedProps = """
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
-    public val endpointResolver: EndpointResolver = requireNotNull(builder.endpointResolver) { "endpointResolver is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
     public val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
@@ -56,11 +55,6 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
          * client will not close it when the client is closed.
          */
         public var httpClientEngine: HttpClientEngine? = null
-        /**
-         * Set the [aws.smithy.kotlin.runtime.http.endpoints.EndpointResolver] used to resolve service endpoints. Operation requests will be
-         * made against the endpoint returned by the resolver.
-         */
-        public var endpointResolver: EndpointResolver? = null
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
          * that represent idempotent tokens when not explicitly set by the caller using this generator.
@@ -90,7 +84,6 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
         contents.shouldContainWithDiff(expectedBuilder)
 
         val expectedImports = listOf(
-            "import ${RuntimeTypes.Http.Endpoints.EndpointResolver.fullName}",
             "import ${RuntimeTypes.Http.Engine.HttpClientEngine.fullName}",
             "import ${KotlinDependency.HTTP.namespace}.config.HttpClientConfig",
             "import ${KotlinDependency.CORE.namespace}.config.IdempotencyTokenConfig",

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionGeneratorTest.kt
@@ -13,8 +13,6 @@ import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.expectShape
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.DefaultEndpointProviderGenerator
-import software.amazon.smithy.kotlin.codegen.rendering.endpoints.DefaultEndpointProviderTestGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ApplicationProtocol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.rendering.serde.StructuredDataParserGenerator
@@ -239,25 +237,6 @@ class ExceptionGeneratorTest {
                 }
 
                 override fun structuredDataSerializer(ctx: ProtocolGenerator.GenerationContext): StructuredDataSerializerGenerator {
-                    error("not needed for test")
-                }
-
-                override fun defaultEndpointProviderGenerator(
-                    writer: KotlinWriter,
-                    rules: EndpointRuleSet,
-                    interfaceSymbol: Symbol,
-                    paramsSymbol: Symbol,
-                ): DefaultEndpointProviderGenerator {
-                    error("not needed for test")
-                }
-
-                override fun defaultEndpointProviderTestGenerator(
-                    writer: KotlinWriter,
-                    rules: EndpointRuleSet,
-                    tests: List<EndpointTestCase>,
-                    defaultProviderSymbol: Symbol,
-                    paramsSymbol: Symbol,
-                ): DefaultEndpointProviderTestGenerator {
                     error("not needed for test")
                 }
 

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
@@ -166,7 +166,7 @@ class EndpointParametersGeneratorTest {
     fun testCompanionObject() {
         val expected = """
             public companion object {
-                public operator fun invoke(block: Builder.() -> Unit): EndpointParameters = Builder().apply(block).build()
+                public inline operator fun invoke(block: Builder.() -> Unit): EndpointParameters = Builder().apply(block).build()
             }
         """.formatForTest()
         generatedClass.shouldContainOnlyOnceWithDiff(expected)
@@ -272,7 +272,7 @@ class EndpointParametersGeneratorTest {
     @Test
     fun testBuilder() {
         val expected = """
-            public class Builder internal constructor() {
+            public class Builder {
                 public var booleanField: Boolean? = null
          
                 public var defaultedBooleanField: Boolean? = true
@@ -302,7 +302,7 @@ class EndpointParametersGeneratorTest {
          
                 public var stringField: String? = null
          
-                internal fun build(): EndpointParameters = EndpointParameters(this)
+                public fun build(): EndpointParameters = EndpointParameters(this)
             }
         """.formatForTest()
         generatedClass.shouldContainOnlyOnceWithDiff(expected)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -54,7 +54,7 @@ internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
         builder.method = HttpMethod.POST
 
         builder.url {
-            val pathSegments = listOf(
+            val pathSegments = listOf<String>(
                 "smoketest",
                 "$label1".encodeLabel(),
                 "foo",
@@ -263,7 +263,7 @@ internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRe
         builder.method = HttpMethod.POST
 
         builder.url {
-            val pathSegments = listOf(
+            val pathSegments = listOf<String>(
                 "input",
                 "timestamp",
                 "$tsLabel".encodeLabel(),
@@ -340,7 +340,7 @@ internal class ConstantQueryStringOperationSerializer: HttpSerialize<ConstantQue
         builder.method = HttpMethod.GET
 
         builder.url {
-            val pathSegments = listOf(
+            val pathSegments = listOf<String>(
                 "ConstantQueryString",
                 "$label1".encodeLabel(),
             )

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 
     compileOnly(project(":smithy-kotlin-codegen"))
     implementation(project(":runtime:runtime-core"))
+    implementation(project(":runtime:protocol:http"))
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
 }

--- a/tests/codegen/paginator-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
@@ -1,0 +1,6 @@
+package com.test.endpoints
+
+/**
+ * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
+ */
+typealias EndpointProvider = aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider<Unit>

--- a/tests/codegen/waiter-tests/build.gradle.kts
+++ b/tests/codegen/waiter-tests/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
     compileOnly(project(":smithy-kotlin-codegen"))
     implementation(project(":runtime:runtime-core"))
+    implementation(project(":runtime:protocol:http"))
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
 }

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
@@ -1,0 +1,6 @@
+package com.test.endpoints
+
+/**
+ * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
+ */
+typealias EndpointProvider = aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider<Unit>


### PR DESCRIPTION
## Description of changes
Implement middleware and endpoint parameter binding generators to call endpoint providers per-operation at runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
