### PR TITLE
fix(rt): handle exceptions in background okhttp response body coroutine

### DIFF
--- a/.changes/156447f6-0f80-4fde-a38d-6b92260432b8.json
+++ b/.changes/156447f6-0f80-4fde-a38d-6b92260432b8.json
@@ -1,0 +1,8 @@
+{
+    "id": "156447f6-0f80-4fde-a38d-6b92260432b8",
+    "type": "bugfix",
+    "description": "Fix Android crash when OkHttp response body coroutine throws an exception",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#753"
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes https://github.com/awslabs/aws-sdk-kotlin/issues/753

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Wrap response body handling with `runCatching` to prevent the exception from reaching the default [CoroutineExceptionHandler](https://kotlinlang.org/docs/exception-handling.html#coroutineexceptionhandler) (which on JVM will print a stacktrace but on Android it will crash the app). Exception is propagated through the channel which was the original intent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
