### PR TITLE
chore(codegen): allow using maven local for to test Smithy changes

### DIFF
--- a/.changes/a59196ef-583c-45b2-9f7f-3d8329902be0.json
+++ b/.changes/a59196ef-583c-45b2-9f7f-3d8329902be0.json
@@ -1,0 +1,5 @@
+{
+    "id": "a59196ef-583c-45b2-9f7f-3d8329902be0",
+    "type": "misc",
+    "description": "Allow using maven local for to test Smithy changes"
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,7 @@
 
 pluginManagement {
     repositories {
+        mavenLocal()
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
         google()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Add the local maven to the list of repositories that allows to test changes to Smithy libraries, without this the build fails with something like:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':tests:benchmarks:serde-benchmarks'.
> Could not resolve all files for configuration ':tests:benchmarks:serde-benchmarks:classpath'.
   > Could not find software.amazon.smithy:smithy-cli:1.27.0-SNAPSHOT.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/smithy-cli-1.27.0-SNAPSHOT.pom
       - https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/maven-metadata.xml
       - https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/smithy-cli-1.27.0-SNAPSHOT.pom
       - https://dl.google.com/dl/android/maven2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/maven-metadata.xml
       - https://dl.google.com/dl/android/maven2/software/amazon/smithy/smithy-cli/1.27.0-SNAPSHOT/smithy-cli-1.27.0-SNAPSHOT.pom
     Required by:
         project :tests:benchmarks:serde-benchmarks
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
