### PR TITLE
fix: remove erroneous @InternalApi marker on CRT HTTP engine config class

### DIFF
--- a/.changes/5529014d-3b3e-49de-b32f-3d65d0662555.json
+++ b/.changes/5529014d-3b3e-49de-b32f-3d65d0662555.json
@@ -1,0 +1,5 @@
+{
+    "id": "5529014d-3b3e-49de-b32f-3d65d0662555",
+    "type": "bugfix",
+    "description": "Remove erroneous `@InternalApi` marker on CRT HTTP engine configuration class"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngineConfig.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngineConfig.kt
@@ -8,9 +8,11 @@ package aws.smithy.kotlin.runtime.http.engine.crt
 import aws.sdk.kotlin.crt.io.ClientBootstrap
 import aws.sdk.kotlin.crt.io.TlsContext
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
-import aws.smithy.kotlin.runtime.util.InternalApi
 
-@InternalApi
+/**
+ * Describes configuration options for the CRT HTTP engine. Use [Default] for the standard configuration or use
+ * [Builder] to build a custom configuration.
+ */
 public class CrtHttpEngineConfig private constructor(builder: Builder) : HttpClientEngineConfig(builder) {
     public companion object {
         /**


### PR DESCRIPTION
## Issue \#

Found while reproducing [aws-sdk-kotlin#758](https://github.com/awslabs/aws-sdk-kotlin/issues/758)

## Description of changes

The `CrtHttpEngineConfig` class has the `@InternalApi` marker applied to it, meaning users have no way to reference or build a CRT engine configuration without opting in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
