### PR TITLE
refactor(rt)!: allow SdkSource variant for ByteStream and HttpBody

### DIFF
--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
@@ -146,7 +146,7 @@ public class AwsSigningMiddleware(private val config: Config) : ModifyRequestMid
                 contextHashSpecification != null -> contextHashSpecification
                 config.isUnsignedPayload -> HashSpecification.UnsignedPayload
                 body is HttpBody.Empty -> HashSpecification.EmptyBody
-                body is HttpBody.Streaming && !body.isReplayable -> {
+                body.isOneShot -> {
                     logger.warn { "unable to compute hash for unbounded stream; defaulting to unsigned payload" }
                     HashSpecification.UnsignedPayload
                 }
@@ -162,15 +162,8 @@ public class AwsSigningMiddleware(private val config: Config) : ModifyRequestMid
         req.context[AwsSigningAttributes.RequestSignature] = signingResult.signature
 
         req.subject.update(signedRequest)
-        req.subject.body.resetStream()
 
         return req
-    }
-}
-
-private fun HttpBody.resetStream() {
-    if (this is HttpBody.Streaming && this.isReplayable) {
-        this.reset()
     }
 }
 

--- a/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
+++ b/runtime/auth/aws-signing-crt/common/src/aws/smithy/kotlin/runtime/auth/awssigning/crt/CrtAwsSigner.kt
@@ -4,19 +4,14 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning.crt
 
-import aws.sdk.kotlin.crt.http.HttpRequestBodyStream
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awssigning.*
-import aws.smithy.kotlin.runtime.crt.ReadChannelBodyStream
-import aws.smithy.kotlin.runtime.crt.SdkSourceBodyStream
+import aws.smithy.kotlin.runtime.crt.toSignableCrtRequest
+import aws.smithy.kotlin.runtime.crt.update
 import aws.smithy.kotlin.runtime.http.Headers
-import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
-import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.toBuilder
-import aws.smithy.kotlin.runtime.http.util.fullUriToQueryParameters
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
-import kotlin.coroutines.coroutineContext
 import aws.sdk.kotlin.crt.auth.credentials.Credentials as CrtCredentials
 import aws.sdk.kotlin.crt.auth.signing.AwsSignatureType as CrtSignatureType
 import aws.sdk.kotlin.crt.auth.signing.AwsSignedBodyHeaderType as CrtSignedBodyHeaderType
@@ -24,7 +19,6 @@ import aws.sdk.kotlin.crt.auth.signing.AwsSigner as CrtSigner
 import aws.sdk.kotlin.crt.auth.signing.AwsSigningAlgorithm as CrtSigningAlgorithm
 import aws.sdk.kotlin.crt.auth.signing.AwsSigningConfig as CrtSigningConfig
 import aws.sdk.kotlin.crt.http.Headers as CrtHeaders
-import aws.sdk.kotlin.crt.http.HttpRequest as CrtHttpRequest
 
 public object CrtAwsSigner : AwsSigner {
     override suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult<HttpRequest> {
@@ -98,44 +92,4 @@ private fun Headers.toCrtHeaders(): CrtHeaders {
     val headersBuilder = aws.sdk.kotlin.crt.http.HeadersBuilder()
     forEach(headersBuilder::appendAll)
     return headersBuilder.build()
-}
-
-/**
- * Convert an [HttpRequest] into a CRT HttpRequest for the purposes of signing
- */
-private suspend fun HttpRequest.toSignableCrtRequest() = CrtHttpRequest(
-    method = method.name,
-    encodedPath = url.encodedPath,
-    headers = headers.toCrtHeaders(),
-    body = signableBodyStream(body),
-)
-
-private fun HttpRequestBuilder.update(crtRequest: CrtHttpRequest) {
-    crtRequest.headers.entries().forEach { entry ->
-        headers.appendMissing(entry.key, entry.value)
-    }
-
-    if (crtRequest.encodedPath.isNotBlank()) {
-        crtRequest.encodedPath.fullUriToQueryParameters()?.let {
-            it.forEach { key, values ->
-                // The CRT request has a URL-encoded path which means simply appending missing could result in both the
-                // raw and percent-encoded value being present. Instead, just append new keys added by signing.
-                if (!url.parameters.contains(key)) {
-                    url.parameters.appendAll(key, values)
-                }
-            }
-        }
-    }
-}
-
-private suspend fun signableBodyStream(body: HttpBody): HttpRequestBodyStream? {
-    // can only consume the stream once
-    if (body.isOneShot) return null
-
-    return when (body) {
-        is HttpBody.Empty -> null
-        is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
-        is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), coroutineContext)
-        is HttpBody.SourceContent -> SdkSourceBodyStream(body.readFrom())
-    }
 }

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
@@ -38,11 +38,10 @@ public abstract class MiddlewareSigningTestBase : HasSigner {
                     headers.appendAll("x-amz-archive-description", listOf("test", "test"))
                     val requestBody = "{\"TableName\": \"foo\"}"
                     body = when (streaming) {
-                        true -> object : HttpBody.Streaming() {
+                        true -> object : HttpBody.ChannelContent() {
                             override val contentLength: Long = requestBody.length.toLong()
                             override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(requestBody.encodeToByteArray())
-                            override val isReplayable: Boolean = replayable
-                            override fun reset() { }
+                            override val isOneShot: Boolean = !replayable
                         }
                         false -> ByteArrayContent(requestBody.encodeToByteArray())
                     }

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
@@ -34,8 +34,7 @@ public suspend fun HttpRequestBuilder.toSignableCrtRequest(unsignedPayload: Bool
 }
 
 private suspend fun signableBodyStream(body: HttpBody): HttpRequestBodyStream? {
-    // can only consume the stream once
-    if (body.isOneShot) return null
+    if (body.isOneShot) return null // can only consume the stream once
 
     return when (body) {
         is HttpBody.Empty -> null

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/Http.kt
@@ -38,14 +38,10 @@ private suspend fun signableBodyStream(body: HttpBody): HttpRequestBodyStream? {
     if (body.isOneShot) return null
 
     return when (body) {
+        is HttpBody.Empty -> null
         is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
-        is HttpBody.ChannelContent -> {
-            // FIXME: this is not particularly efficient since we have to launch a coroutine to fill it.
-            // see https://github.com/awslabs/smithy-kotlin/issues/436
-            ReadChannelBodyStream(body.readFrom(), coroutineContext)
-        }
-        is HttpBody.SourceContent -> TODO()
-        else -> null
+        is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), coroutineContext)
+        is HttpBody.SourceContent -> SdkSourceBodyStream(body.readFrom())
     }
 }
 

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream.kt
@@ -39,8 +39,6 @@ public class ReadChannelBodyStream(
     private val currBuffer = atomic<SdkBuffer?>(null)
     private val bufferChan = Channel<SdkBuffer>(Channel.UNLIMITED)
 
-    private val totalBytesSent = atomic(0L)
-
     init {
         producerJob.invokeOnCompletion { cause ->
             bodyChan.cancel(cause)
@@ -112,10 +110,7 @@ public class ReadChannelBodyStream(
             outgoing = bufferChan.tryReceive().getOrNull() ?: return false
         }
 
-        val sizeBefore = outgoing.size
         transferRequestBody(outgoing, buffer)
-
-        totalBytesSent += sizeBefore - outgoing.size
 
         if (outgoing.size > 0L) {
             currBuffer.value = outgoing

--- a/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStream.kt
+++ b/runtime/crt-util/common/src/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStream.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.crt
+
+import aws.sdk.kotlin.crt.http.HttpRequestBodyStream
+import aws.sdk.kotlin.crt.io.MutableBuffer
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.buffer
+import aws.smithy.kotlin.runtime.util.InternalApi
+
+/**
+ * Implement's [HttpRequestBodyStream] which proxies an SDK source [SdkSource]
+ */
+@InternalApi
+public class SdkSourceBodyStream(
+    source: SdkSource,
+) : HttpRequestBodyStream {
+
+    private val source = source.buffer()
+
+    // lie - CRT tries to control this via normal seek operations (e.g. when they calculate a hash for signing
+    // they consume the aws_input_stream and then seek to the beginning). Instead we either support creating
+    // a new read channel or we don't. At this level we don't care, consumers of this type need to understand
+    // and handle these concerns.
+    override fun resetPosition(): Boolean = true
+
+    override fun sendRequestBody(buffer: MutableBuffer): Boolean {
+        if (!source.request(1)) return true
+
+        val sink = ByteArray(minOf(buffer.writeRemaining, source.buffer.size.toInt()))
+        val rc = source.read(sink)
+        if (rc == -1) return true
+
+        val wc = buffer.write(sink, 0, rc)
+        // sanity check
+        check(rc == wc) { "Expected to write $rc bytes but wrote $wc bytes" }
+
+        // if any data is still available from the underlying source then we aren't done
+        return !source.request(1)
+    }
+}

--- a/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStreamTest.kt
+++ b/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStreamTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.crt
+
+import aws.sdk.kotlin.crt.io.MutableBuffer
+import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SdkSourceBodyStreamTest {
+    private fun mutableBuffer(capacity: Int): Pair<MutableBuffer, ByteArray> {
+        val dest = ByteArray(capacity)
+        return MutableBuffer.of(dest) to dest
+    }
+
+    @Test
+    fun testReadFully() = runTest {
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        val source = data.source()
+        val stream = SdkSourceBodyStream(source)
+
+        val (sendBuffer, sent) = mutableBuffer(16)
+        val streamDone = stream.sendRequestBody(sendBuffer)
+        assertTrue(streamDone)
+        assertTrue {
+            sent.sliceArray(data.indices).contentEquals(data)
+        }
+    }
+
+    @Test
+    fun testPartialRead() = runTest {
+        val source = "123456".encodeToByteArray().source()
+        val stream = SdkSourceBodyStream(source)
+
+        val (sendBuffer1, sent1) = mutableBuffer(3)
+        var streamDone = stream.sendRequestBody(sendBuffer1)
+        assertFalse(streamDone)
+        assertEquals("123", sent1.decodeToString())
+        assertEquals(0, sendBuffer1.writeRemaining)
+
+        val (sendBuffer2, sent2) = mutableBuffer(3)
+        streamDone = stream.sendRequestBody(sendBuffer2)
+        assertTrue(streamDone)
+        assertEquals("456", sent2.decodeToString())
+    }
+
+    @Test
+    fun testLargeTransfer() = runTest {
+        val data = "foobar"
+        val n = 10_000
+        val source = object : SdkSource {
+            var count = n
+            override fun close() {}
+            override fun read(sink: SdkBuffer, limit: Long): Long {
+                if (count <= 0) return -1L
+                sink.writeUtf8(data)
+                count--
+                return data.length.toLong()
+            }
+        }
+
+        val stream = SdkSourceBodyStream(source)
+
+        var totalBytesRead = 0
+        val sendSize = 16
+        do {
+            val (sendBuffer, _) = mutableBuffer(sendSize)
+            val streamDone = stream.sendRequestBody(sendBuffer)
+            totalBytesRead += sendSize - sendBuffer.writeRemaining
+        } while (!streamDone)
+
+        val expected = data.length * n
+        assertEquals(expected, totalBytesRead)
+    }
+}

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSink.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSink.kt
@@ -18,6 +18,9 @@ import aws.smithy.kotlin.runtime.io.internal.toSdk
  *
  * Sinks are not thread safe by default. Do not share a sink between threads or coroutines without external
  * synchronization.
+ *
+ * This is a blocking interface! Use from coroutines should be done from an appropriate dispatcher
+ * (e.g. `Dispatchers.IO`).
  */
 public interface SdkSink : Closeable {
 

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
@@ -5,6 +5,9 @@
 
 package aws.smithy.kotlin.runtime.io
 
+import aws.smithy.kotlin.runtime.util.InternalApi
+import kotlinx.coroutines.CoroutineScope
+
 /**
  * A source for reading a stream of bytes (e.g. from file, network, or in-memory buffer). Sources may
  * be layered to transform data as it is read (e.g. to decompress, decrypt, or remove protocol framign).
@@ -32,3 +35,18 @@ public interface SdkSource : Closeable {
     @Throws(IOException::class)
     override fun close()
 }
+
+/**
+ * Consume the [SdkSource] and pull the entire contents into memory as a [ByteArray].
+ */
+@InternalApi
+public expect suspend fun SdkSource.readToByteArray(): ByteArray
+
+/**
+ * Convert the [SdkSource] to an [SdkByteReadChannel]. Content is read from the source and forwarded
+ * to the channel.
+ * @param coroutineScope the coroutine scope to use to launch a background reader channel responsible for propagating data
+ * between source and the returned channel
+ */
+@InternalApi
+public expect fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope? = null): SdkByteReadChannel

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 
 /**
  * A source for reading a stream of bytes (e.g. from file, network, or in-memory buffer). Sources may
- * be layered to transform data as it is read (e.g. to decompress, decrypt, or remove protocol framign).
+ * be layered to transform data as it is read (e.g. to decompress, decrypt, or remove protocol framing).
  *
  * Most application code should not operate on a source directly, but rather a [SdkBufferedSource] which is
  * more convenient. Use [SdkSource.buffer] to wrap any source with a buffer.
@@ -19,6 +19,9 @@ import kotlinx.coroutines.CoroutineScope
  *
  * Sources are not thread safe by default. Do not share a source between threads or coroutines without external
  * synchronization.
+ *
+ * This is a blocking interface! Use from coroutines should be done from an appropriate dispatcher
+ * (e.g. `Dispatchers.IO`).
  */
 public interface SdkSource : Closeable {
     /**

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
@@ -42,8 +42,4 @@ public class JobChannel(
         }
         return delegate.close(cause)
     }
-
-    override fun close() {
-        delegate.close()
-    }
 }

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io.internal
+
+import aws.smithy.kotlin.runtime.io.SdkByteChannel
+import aws.smithy.kotlin.runtime.util.InternalApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+
+/**
+ * Ties the lifetime of the channel and a Job together. Channel failures (closed with exception) will
+ * cause the underlying [Job] to fail with the channel exception.
+ *
+ * This is useful for launching coroutines with the soul purpose of reading/writing data to the channel where
+ * the coroutine should only continue if the channel hasn't failed.
+ */
+@InternalApi
+public class JobChannel(
+    private val delegate: SdkByteChannel = SdkByteChannel(true),
+) : SdkByteChannel by delegate {
+    internal var job: Job? = null
+
+    public fun attachJob(job: Job) {
+        if (isClosedForRead) {
+            job.cancel(CancellationException("channel was already closed", delegate.closedCause))
+            return
+        }
+        this.job = job
+    }
+
+    override fun cancel(cause: Throwable?): Boolean {
+        job?.cancel(CancellationException("channel was cancelled", cause))
+        return delegate.cancel(cause)
+    }
+
+    override fun close(cause: Throwable?): Boolean {
+        if (cause != null) {
+            job?.cancel(CancellationException("channel was closed with cause", cause))
+        }
+        return delegate.close(cause)
+    }
+
+    override fun close() {
+        delegate.close()
+    }
+}

--- a/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/SdkDispatcher.kt
+++ b/runtime/io/common/src/aws/smithy/kotlin/runtime/io/internal/SdkDispatcher.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io.internal
+
+import aws.smithy.kotlin.runtime.util.InternalApi
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Internal coroutine dispatchers used by the SDK
+ */
+@InternalApi
+public expect object SdkDispatchers {
+    /**
+     * The CoroutineDispatcher that is designed for offloading blocking IO tasks to a shared pool of threads.
+     * On JVM this is guaranteed to be `Dispatchers.IO`
+     */
+    public val IO: CoroutineDispatcher
+}

--- a/runtime/io/common/test/aws/smithy/kotlin/runtime/io/JobChannelTest.kt
+++ b/runtime/io/common/test/aws/smithy/kotlin/runtime/io/JobChannelTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io
+
+import aws.smithy.kotlin.runtime.io.internal.JobChannel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class JobChannelTest {
+    @Test
+    fun testClose() = runTest {
+        val ch = JobChannel()
+        val job = Job()
+        ch.attachJob(job)
+        assertTrue(job.isActive)
+        ch.close()
+        assertTrue(job.isActive)
+    }
+
+    @Test
+    fun testCloseWithCause() = runTest {
+        val ch = JobChannel()
+        val job = Job()
+        ch.attachJob(job)
+        assertTrue(job.isActive)
+        val cause = TestException()
+        ch.close(cause)
+        assertFalse(job.isActive)
+        assertTrue(job.isCancelled)
+    }
+
+    @Test
+    fun testCancel() = runTest {
+        val ch = JobChannel()
+        val job = Job()
+        ch.attachJob(job)
+        assertTrue(job.isActive)
+        val cause = TestException()
+        ch.cancel(cause)
+        assertFalse(job.isActive)
+        assertTrue(job.isCancelled)
+    }
+}

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io
+
+import aws.smithy.kotlin.runtime.io.internal.JobChannel
+import aws.smithy.kotlin.runtime.util.InternalApi
+import kotlinx.coroutines.*
+
+@InternalApi
+public actual suspend fun SdkSource.readToByteArray(): ByteArray = withContext(Dispatchers.IO) {
+    use { it.buffer().readByteArray() }
+}
+
+@InternalApi
+@OptIn(DelicateCoroutinesApi::class)
+public actual fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope?): SdkByteReadChannel {
+    val source = this
+    val ch = JobChannel()
+    val scope = coroutineScope ?: GlobalScope
+    val job = scope.launch(Dispatchers.IO + CoroutineName("sdk-source-reader")) {
+        val buffer = SdkBuffer()
+        val result = runCatching {
+            source.use {
+                while (true) {
+                    ensureActive()
+                    val rc = source.read(buffer, DEFAULT_BYTE_CHANNEL_MAX_BUFFER_SIZE.toLong())
+                    if (rc == -1L) break
+                    ch.write(buffer)
+                }
+            }
+        }
+
+        ch.close(result.exceptionOrNull())
+    }
+
+    ch.attachJob(job)
+
+    return ch
+}

--- a/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/internal/SdkDispatchersJVM.kt
+++ b/runtime/io/jvm/src/aws/smithy/kotlin/runtime/io/internal/SdkDispatchersJVM.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io.internal
+
+import aws.smithy.kotlin.runtime.util.InternalApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@InternalApi
+public actual object SdkDispatchers {
+    public actual val IO: CoroutineDispatcher = Dispatchers.IO
+}

--- a/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkSourceExtensionsTest.kt
+++ b/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/SdkSourceExtensionsTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.io
+
+import aws.smithy.kotlin.runtime.io.internal.JobChannel
+import aws.smithy.kotlin.runtime.testing.RandomTempFile
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import java.util.concurrent.CancellationException
+import kotlin.test.*
+
+class SdkSourceExtensionsTest {
+    @Test
+    fun testReadToByteArray() = runTest {
+        val file = RandomTempFile(32 * 1024)
+        val source = file.source()
+        val actual = source.readToByteArray()
+        assertEquals(file.length(), actual.size.toLong())
+        assertContentEquals(file.readBytes(), actual)
+    }
+
+    @Test
+    fun testToByteReadChannel() = runTest {
+        val file = RandomTempFile(1024)
+        val ch = file.source().toSdkByteReadChannel()
+
+        val buffer = ch.readToBuffer()
+        val actual = buffer.readByteArray()
+        assertEquals(file.length(), actual.size.toLong())
+        assertContentEquals(file.readBytes(), actual)
+        assertTrue(ch.isClosedForRead)
+        assertTrue(ch.isClosedForWrite)
+    }
+
+    @Test
+    fun testSourceToReadChannelJobCancellation() = runTest {
+        // coroutine launched in background will attempt to read
+        // we then will simulate a failure reading from the underlying source and ensure the channel/job are closed
+        // properly
+        val source = object : SdkSource {
+            val bufferChannel = Channel<SdkBuffer>(1)
+            override fun close() { }
+            override fun read(sink: SdkBuffer, limit: Long): Long {
+                val buffer = runBlocking {
+                    bufferChannel.receive()
+                }
+                val rc = buffer.size
+                sink.writeAll(buffer)
+                return rc
+            }
+        }
+
+        val ch = source.toSdkByteReadChannel()
+        yield()
+        assertFalse(ch.isClosedForRead)
+        assertFalse(ch.isClosedForWrite)
+
+        val jobCh = assertIs<JobChannel>(ch)
+        val job = assertNotNull(jobCh.job)
+        assertTrue(job.isActive)
+
+        // force the source.read() call to fail
+        val ex = CancellationException("test source cancellation")
+        source.bufferChannel.cancel(ex)
+
+        job.join()
+
+        assertTrue(job.isCancelled)
+        assertTrue(ch.isClosedForRead)
+        assertTrue(ch.isClosedForWrite)
+
+        // assert failed channel
+        assertNotNull(ch.closedCause)
+    }
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -100,7 +100,7 @@ internal class SdkStreamResponseHandler(
             // close is idempotent, if not previously closed then close with cause
             ch.close(cause)
         }
-        return object : HttpBody.Streaming() {
+        return object : HttpBody.ChannelContent() {
             override val contentLength: Long? = contentLength
             override fun readFrom(): SdkByteReadChannel = ch
         }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertFalse
 
 class RequestConversionTest {
     private fun byteStreamFromContents(contents: String): ByteStream =
-        object : ByteStream.OneShotStream() {
+        object : ByteStream.ChannelStream() {
             override val contentLength: Long = contents.length.toLong()
             override fun readFrom(): SdkByteReadChannel =
                 SdkByteReadChannel(contents.encodeToByteArray())

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -107,8 +107,8 @@ class SdkStreamResponseHandlerTest {
         assertEquals(HttpStatusCode.OK, resp.status)
 
         assertEquals(72, resp.body.contentLength)
-        assertTrue(resp.body is HttpBody.Streaming)
-        val respChan = (resp.body as HttpBody.Streaming).readFrom()
+        assertTrue(resp.body is HttpBody.ChannelContent)
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
         assertFalse(respChan.isClosedForWrite)
 
         assertFalse(mockConn.isClosed)
@@ -137,8 +137,8 @@ class SdkStreamResponseHandlerTest {
         assertEquals(HttpStatusCode.OK, resp.status)
 
         assertEquals(data.length.toLong(), resp.body.contentLength)
-        assertTrue(resp.body is HttpBody.Streaming)
-        val respChan = (resp.body as HttpBody.Streaming).readFrom()
+        assertTrue(resp.body is HttpBody.ChannelContent)
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
 
         assertTrue(respChan.isClosedForWrite)
 
@@ -166,7 +166,7 @@ class SdkStreamResponseHandlerTest {
         assertEquals(HttpStatusCode.OK, resp.status)
 
         assertEquals(data.length.toLong(), resp.body.contentLength)
-        val respChan = (resp.body as HttpBody.Streaming).readFrom()
+        val respChan = (resp.body as HttpBody.ChannelContent).readFrom()
 
         assertTrue(respChan.isClosedForWrite)
         assertFailsWith<CancellationException> {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
@@ -30,6 +30,12 @@ kotlin {
             }
         }
 
+        jvmTest {
+            dependencies {
+                implementation(project(":runtime:testing"))
+            }
+        }
+
         all {
             languageSettings.optIn("aws.smithy.kotlin.runtime.util.InternalApi")
         }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -45,7 +45,7 @@ public class OkHttpEngine(
             engineResponse.body.close()
         }
 
-        val response = engineResponse.toSdkResponse(callContext)
+        val response = engineResponse.toSdkResponse()
         val requestTime = Instant.fromEpochMilliseconds(engineResponse.sentRequestAtMillis)
         val responseTime = Instant.fromEpochMilliseconds(engineResponse.receivedResponseAtMillis)
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -56,7 +56,7 @@ internal fun HttpRequest.toOkHttpRequest(
         when (val body = body) {
             is HttpBody.Empty -> ByteArray(0).toRequestBody(null, 0, 0)
             is HttpBody.Bytes -> body.bytes().let { it.toRequestBody(null, 0, it.size) }
-            is HttpBody.Streaming -> ByteChannelRequestBody(body, callContext)
+            is HttpBody.SourceContent, is HttpBody.ChannelContent -> StreamingRequestBody(body, callContext)
         }
     } else {
         // assert we don't silently ignore a body even though one is unexpected here
@@ -93,7 +93,7 @@ internal fun OkHttpResponse.toSdkResponse(callContext: CoroutineContext): HttpRe
             ch.close(cause)
         }
 
-        object : HttpBody.Streaming() {
+        object : HttpBody.ChannelContent() {
             // -1 is used by okhttp as transfer-encoding chunked
             override val contentLength: Long? = if (body.contentLength() >= 0L) body.contentLength() else null
             override fun readFrom(): SdkByteReadChannel = ch

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
@@ -104,7 +104,7 @@ class OkHttpRequestTest {
         val content = "Hello OkHttp from HttpBody.Streaming".repeat(1024)
         val contentBytes = content.encodeToByteArray()
         val chan = SdkByteReadChannel(contentBytes)
-        val body = object : HttpBody.Streaming() {
+        val body = object : HttpBody.ChannelContent() {
             override val contentLength: Long = contentBytes.size.toLong()
             override fun readFrom(): SdkByteReadChannel = chan
         }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
@@ -98,7 +98,7 @@ class OkHttpResponseTest {
         yield()
 
         val body = sdkResponse.body
-        assertIs<HttpBody.Streaming>(body)
+        assertIs<HttpBody.ChannelContent>(body)
         val ch = body.readFrom()
         assertFalse(ch.isClosedForWrite)
 
@@ -163,7 +163,7 @@ class OkHttpResponseTest {
         yield()
 
         val body = sdkResponse.body
-        assertIs<HttpBody.Streaming>(body)
+        assertIs<HttpBody.ChannelContent>(body)
         val ch = body.readFrom()
         assertTrue(ch.isClosedForWrite)
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
@@ -8,14 +8,10 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 import aws.smithy.kotlin.runtime.client.ExecutionContext
 import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
-import aws.smithy.kotlin.runtime.io.readToBuffer
-import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
-import okhttp3.MediaType
 import okhttp3.Protocol
 import okhttp3.Response
-import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.*
 import org.junit.jupiter.api.Test
@@ -38,7 +34,7 @@ class OkHttpResponseTest {
             request(okRequest)
         }.build()
 
-        val sdkResponse = okResponse.toSdkResponse(EmptyCoroutineContext)
+        val sdkResponse = okResponse.toSdkResponse()
         assertIs<HttpBody.Empty>(sdkResponse.body)
     }
 
@@ -60,7 +56,7 @@ class OkHttpResponseTest {
             request(okRequest)
         }.build()
 
-        val sdkResponse = okResponse.toSdkResponse(EmptyCoroutineContext)
+        val sdkResponse = okResponse.toSdkResponse()
         assertEquals(HttpStatusCode.OK, sdkResponse.status)
         assertEquals("bar", sdkResponse.headers["foo"])
         assertEquals(content.size.toLong(), sdkResponse.body.contentLength)
@@ -70,115 +66,5 @@ class OkHttpResponseTest {
         }.await()
 
         assertContentEquals(content, actualBody)
-    }
-
-    @Test
-    fun testCallContextCancelsWriter() = runTest {
-        // call context cancelled should result in no children left
-        val request = HttpRequest(HttpMethod.GET, Url.parse("https://aws.amazon.com"), Headers.Empty, HttpBody.Empty)
-
-        val execContext = ExecutionContext()
-        val callJob = Job(coroutineContext.job)
-        val callContext = coroutineContext + callJob
-        val okRequest = request.toOkHttpRequest(execContext, callContext)
-
-        // something sufficiently large enough that a single write doesn't cause the coroutine to immediately complete
-        val content = ByteArray(16 * 1024 * 1024)
-
-        val okResponse = Response.Builder().apply {
-            protocol(Protocol.HTTP_1_1)
-            code(200)
-            body(content.toResponseBody())
-            message("OK")
-            addHeader("foo", "bar")
-            request(okRequest)
-        }.build()
-
-        val sdkResponse = okResponse.toSdkResponse(callContext)
-        yield()
-
-        val body = sdkResponse.body
-        assertIs<HttpBody.ChannelContent>(body)
-        val ch = body.readFrom()
-        assertFalse(ch.isClosedForWrite)
-
-        assertEquals(1, callContext.job.children.toList().size)
-        callJob.cancel()
-        callJob.complete()
-        callJob.join()
-        assertEquals(0, callContext.job.children.toList().size)
-        assertTrue(ch.isClosedForWrite)
-    }
-
-    @Test
-    fun testSourceReadError(): Unit = runBlocking {
-        var exceptionBubbledUp: Throwable? = null
-        val request = HttpRequest(HttpMethod.GET, Url.parse("https://aws.amazon.com"), Headers.Empty, HttpBody.Empty)
-
-        val execContext = ExecutionContext()
-
-        // replace default exception handler which will print out the stack trace by default.
-        // We are expecting an exception so this message is misleading/confusing
-        val exHandler = CoroutineExceptionHandler { _, t -> exceptionBubbledUp = t }
-
-        // don't tie this to the current job or else it will tear down the test as well
-        val callJob = Job()
-        val callContext = coroutineContext + callJob + exHandler
-        val okRequest = request.toOkHttpRequest(execContext, callContext)
-
-        val content = ByteArray(16 * 1024 * 1024)
-        val buffer = Buffer()
-        buffer.write(content)
-        val okSource = object : Source {
-            private var cnt = 0
-            override fun read(sink: Buffer, byteCount: Long): Long {
-                // wait to fail until we've gotten setup and are waiting on the channel to be read to make progress
-                // or else we won't be able to make assertions
-                if (cnt > 0) {
-                    throw RuntimeException("test read error")
-                }
-                cnt++
-                return buffer.read(sink, byteCount)
-            }
-            override fun close() {}
-            override fun timeout(): Timeout = Timeout.NONE
-        }
-
-        val okBody = object : ResponseBody() {
-            override fun contentLength(): Long = 1024
-            override fun contentType(): MediaType? = null
-            override fun source(): BufferedSource = okSource.buffer()
-        }
-
-        val okResponse = Response.Builder().apply {
-            protocol(Protocol.HTTP_1_1)
-            code(200)
-            body(okBody)
-            message("OK")
-            addHeader("foo", "bar")
-            request(okRequest)
-        }.build()
-
-        val sdkResponse = okResponse.toSdkResponse(callContext)
-        yield()
-
-        val body = sdkResponse.body
-        assertIs<HttpBody.ChannelContent>(body)
-        val ch = body.readFrom()
-        assertTrue(ch.isClosedForWrite)
-
-        assertEquals(0, callContext.job.children.toList().size)
-
-        assertFailsWith<RuntimeException> {
-            ch.readToBuffer()
-        }.message.shouldContain("test read error")
-        callJob.complete()
-        callJob.join()
-        assertEquals(0, callContext.job.children.toList().size)
-
-        assertNull(
-            exceptionBubbledUp,
-            "Unexpected exception bubbled up. It should've be pushed to channel's close() method instead.",
-        )
     }
 }

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
@@ -14,6 +14,7 @@ import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
 import aws.smithy.kotlin.runtime.http.test.util.test
 import aws.smithy.kotlin.runtime.http.test.util.testSetup
+import aws.smithy.kotlin.runtime.http.toSdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.util.encodeToHex
 import kotlin.test.*
@@ -77,8 +78,7 @@ class DownloadTest : AbstractEngineTest() {
                 check(contentLength < Int.MAX_VALUE)
 
                 val body = call.response.body
-                assertIs<HttpBody.ChannelContent>(body)
-                val chan = body.readFrom()
+                val chan = requireNotNull(body.toSdkByteReadChannel())
 
                 val readSha256 = reader(chan, contentLength.toInt())
                 assertEquals(expectedSha256, readSha256)
@@ -107,8 +107,7 @@ class DownloadTest : AbstractEngineTest() {
                 assertNull(call.response.body.contentLength, "${client.engine}")
 
                 val body = call.response.body
-                assertIs<HttpBody.ChannelContent>(body)
-                val chan = body.readFrom()
+                val chan = requireNotNull(body.toSdkByteReadChannel())
                 val bytes = chan.readToBuffer().readByteArray()
                 val actualSha256 = bytes.sha256().encodeToHex()
                 assertEquals(expectedSha256, actualSha256)

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/DownloadTest.kt
@@ -77,7 +77,7 @@ class DownloadTest : AbstractEngineTest() {
                 check(contentLength < Int.MAX_VALUE)
 
                 val body = call.response.body
-                assertIs<HttpBody.Streaming>(body)
+                assertIs<HttpBody.ChannelContent>(body)
                 val chan = body.readFrom()
 
                 val readSha256 = reader(chan, contentLength.toInt())
@@ -107,7 +107,7 @@ class DownloadTest : AbstractEngineTest() {
                 assertNull(call.response.body.contentLength, "${client.engine}")
 
                 val body = call.response.body
-                assertIs<HttpBody.Streaming>(body)
+                assertIs<HttpBody.ChannelContent>(body)
                 val chan = body.readFrom()
                 val bytes = chan.readToBuffer().readByteArray()
                 val actualSha256 = bytes.sha256().encodeToHex()

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpBody.kt
@@ -6,8 +6,7 @@ package aws.smithy.kotlin.runtime.http
 
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
-import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import aws.smithy.kotlin.runtime.io.readToBuffer
+import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.util.InternalApi
 
 /**
@@ -21,9 +20,23 @@ public sealed class HttpBody {
     public open val contentLength: Long? = null
 
     /**
+     * Flag indicating the body can be consumed only once
+     */
+    public open val isOneShot: Boolean = true
+
+    /**
+     * Flag indicating that this request body should be handled as a duplex stream by the underlying engine.
+     *
+     * Most request bodies are sent completely before the response is received. In full duplex mode the request
+     * and response bodies may be interleaved. Only HTTP/2 calls support duplex streaming.
+     */
+    public open val isDuplex: Boolean = false
+
+    /**
      * Variant of a [HttpBody] without a payload
      */
     public object Empty : HttpBody() {
+        final override val isOneShot: Boolean = false
         override val contentLength: Long = 0
     }
 
@@ -33,6 +46,10 @@ public sealed class HttpBody {
      * Useful for content that can be fully realized in memory (e.g. most text/JSON payloads)
      */
     public abstract class Bytes : HttpBody() {
+        // implementations MUST be idempotent and replayable or else they should be modeled differently
+        // this is meant for simple in-memory representations only
+        final override val isOneShot: Boolean = false
+
         /**
          * Provides [ByteArray] to be sent to peer
          */
@@ -40,36 +57,25 @@ public sealed class HttpBody {
     }
 
     /**
-     * Variant of an [HttpBody] with a streaming payload. Content is read from the given source
+     * Variant of an [HttpBody] with a streaming payload read from an [SdkSource]
      */
-    public abstract class Streaming : HttpBody() {
+    public abstract class SourceContent : HttpBody() {
         /**
-         * Provides [SdkByteReadChannel] for the content. Implementations MUST provide the same channel
-         * every time [readFrom] is invoked until a call to [reset]. Replayable streams that support reset
-         * MUST provide fresh channels after [reset] is invoked.
+         * Provides [SdkSource] that will be sent to peer. Replayable streams ([HttpBody.isOneShot] = `false`)
+         * MUST provide a fresh channel every time [readFrom] is invoked.
+         */
+        public abstract fun readFrom(): SdkSource
+    }
+
+    /**
+     * Variant of an [HttpBody] with a streaming payload read from an [SdkByteReadChannel]
+     */
+    public abstract class ChannelContent : HttpBody() {
+        /**
+         * Provides [SdkByteReadChannel] that will be sent to peer. Replayable streams ([HttpBody.isOneShot] = `false`)
+         * MUST provide a fresh channel every time [readFrom] is invoked.
          */
         public abstract fun readFrom(): SdkByteReadChannel
-
-        /**
-         * Flag indicating the stream can be consumed multiple times. If `false` [reset] will throw an
-         * [UnsupportedOperationException].
-         */
-        public open val isReplayable: Boolean = false
-
-        /**
-         * Flag indicating that this request body should be handled as a duplex stream by the underlying engine.
-         *
-         * Most request bodies are sent completely before the response is received. In full duplex mode the request
-         * and response bodies may be interleaved. Only HTTP/2 calls support duplex streaming.
-         */
-        public open val isDuplex: Boolean = false
-
-        /**
-         * Reset the stream such that the next call to [readFrom] provides a fresh channel.
-         * @throws UnsupportedOperationException if the stream can only be consumed once. Consumers can check
-         * [isReplayable] before calling
-         */
-        public open fun reset() { throw UnsupportedOperationException("${this::class.simpleName} can only be consumed once") }
     }
 
     public companion object {
@@ -98,19 +104,16 @@ public fun ByteStream.toHttpBody(): HttpBody = when (val byteStream = this) {
         override val contentLength: Long? = byteStream.contentLength
         override fun bytes(): ByteArray = byteStream.bytes()
     }
-    is ByteStream.OneShotStream -> object : HttpBody.Streaming() {
+
+    is ByteStream.ChannelStream -> object : HttpBody.ChannelContent() {
         override val contentLength: Long? = byteStream.contentLength
+        override val isOneShot: Boolean = byteStream.isOneShot
         override fun readFrom(): SdkByteReadChannel = byteStream.readFrom()
     }
-    is ByteStream.ReplayableStream -> object : HttpBody.Streaming() {
-        private var channel: SdkByteReadChannel? = null
+    is ByteStream.SourceStream -> object : HttpBody.SourceContent() {
         override val contentLength: Long? = byteStream.contentLength
-        override fun readFrom(): SdkByteReadChannel = channel ?: byteStream.newReader().also { channel = it }
-        override val isReplayable: Boolean = true
-        override fun reset() {
-            channel?.cancel(null)
-            channel = null
-        }
+        override val isOneShot: Boolean = byteStream.isOneShot
+        override fun readFrom(): SdkSource = byteStream.readFrom()
     }
 }
 
@@ -121,9 +124,9 @@ public fun ByteStream.toHttpBody(): HttpBody = when (val byteStream = this) {
 @InternalApi
 public fun SdkByteReadChannel.toHttpBody(contentLength: Long? = null): HttpBody {
     val ch = this
-    return object : HttpBody.Streaming() {
+    return object : HttpBody.ChannelContent() {
         override val contentLength: Long? = contentLength
-        override val isReplayable: Boolean = false
+        override val isOneShot: Boolean = true
         override fun readFrom(): SdkByteReadChannel = ch
     }
 }
@@ -137,11 +140,13 @@ public fun SdkByteReadChannel.toHttpBody(contentLength: Long? = null): HttpBody 
 public suspend fun HttpBody.readAll(): ByteArray? = when (this) {
     is HttpBody.Empty -> null
     is HttpBody.Bytes -> this.bytes()
-    is HttpBody.Streaming -> {
+    is HttpBody.ChannelContent -> {
         val readChan = readFrom()
         val bytes = readChan.readToBuffer().readByteArray()
         bytes
     }
+
+    is HttpBody.SourceContent -> readFrom().readToByteArray()
 }
 
 /**
@@ -153,9 +158,15 @@ public fun HttpBody.toByteStream(): ByteStream? = when (val body = this) {
         override val contentLength: Long? = body.contentLength
         override fun bytes(): ByteArray = body.bytes()
     }
-    is HttpBody.Streaming -> object : ByteStream.OneShotStream() {
+    is HttpBody.ChannelContent -> object : ByteStream.ChannelStream() {
         override val contentLength: Long? = body.contentLength
+        override val isOneShot: Boolean = body.isOneShot
         override fun readFrom(): SdkByteReadChannel = body.readFrom()
+    }
+    is HttpBody.SourceContent -> object : ByteStream.SourceStream() {
+        override val contentLength: Long? = body.contentLength
+        override val isOneShot: Boolean = body.isOneShot
+        override fun readFrom(): SdkSource = body.readFrom()
     }
 }
 
@@ -166,5 +177,6 @@ public fun HttpBody.toByteStream(): ByteStream? = when (val body = this) {
 public fun HttpBody.toSdkByteReadChannel(): SdkByteReadChannel? = when (val body = this) {
     is HttpBody.Empty -> null
     is HttpBody.Bytes -> SdkByteReadChannel(body.bytes())
-    is HttpBody.Streaming -> body.readFrom()
+    is HttpBody.ChannelContent -> body.readFrom()
+    is HttpBody.SourceContent -> body.readFrom().toSdkByteReadChannel()
 }

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/middleware/Retry.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
-import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.operation.deepCopy
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
@@ -42,11 +41,6 @@ public open class Retry<O>(
                 val requestCopy = request.deepCopy()
 
                 onAttempt(requestCopy, attempt)
-                when (val body = requestCopy.subject.body) {
-                    // Reset streaming bodies back to beginning
-                    is HttpBody.Streaming -> body.reset()
-                    else -> {}
-                }
 
                 attempt++
                 next.call(requestCopy)
@@ -83,7 +77,4 @@ private class PolicyLogger(
  * retries.
  */
 private val HttpRequestBuilder.isRetryable: Boolean
-    get() = when (val body = this.body) {
-        is HttpBody.Empty, is HttpBody.Bytes -> true
-        is HttpBody.Streaming -> body.isReplayable
-    }
+    get() = !body.isOneShot

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder.kt
@@ -104,7 +104,7 @@ public suspend fun dumpRequest(request: HttpRequestBuilder, dumpBody: Boolean): 
     if (dumpBody) {
         when (val body = request.body) {
             is HttpBody.Bytes -> buffer.write(body.bytes())
-            is HttpBody.Streaming -> {
+            is HttpBody.ChannelContent, is HttpBody.SourceContent -> {
                 // consume the stream and replace the body
                 val content = body.readAll()
                 if (content != null) {

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpCall.kt
@@ -57,7 +57,7 @@ public suspend fun HttpCall.complete() {
 
     try {
         // ensure the response is cancelled
-        (response.body as? HttpBody.Streaming)?.readFrom()?.cancel(null)
+        (response.body as? HttpBody.ChannelContent)?.readFrom()?.cancel(null)
     } catch (_: Throwable) {
     }
 

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/response/HttpResponse.kt
@@ -70,7 +70,7 @@ public suspend fun dumpResponse(response: HttpResponse, dumpBody: Boolean): Pair
     if (dumpBody) {
         when (val body = response.body) {
             is HttpBody.Bytes -> buffer.write(body.bytes())
-            is HttpBody.Streaming -> {
+            is HttpBody.ChannelContent, is HttpBody.SourceContent -> {
                 // consume the stream and replace the body. There isn't much rewinding we can do here, most engines
                 // use a stream that reads right off the wire.
                 val content = body.readAll()

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
@@ -58,16 +58,16 @@ class HttpRequestBuilderTest {
 
             // test streaming bodies get replaced
             val chan = SdkByteReadChannel(content.encodeToByteArray())
-            val stream = object : ByteStream.OneShotStream() {
+            val stream = object : ByteStream.ChannelStream() {
                 override val contentLength: Long = content.length.toLong()
                 override fun readFrom(): SdkByteReadChannel = chan
             }
             body = stream.toHttpBody()
         }
 
-        assertTrue(builder.body is HttpBody.Streaming)
+        assertTrue(builder.body is HttpBody.ChannelContent)
         dumpRequest(builder, false)
-        assertTrue(builder.body is HttpBody.Streaming)
+        assertTrue(builder.body is HttpBody.ChannelContent)
 
         val actual = dumpRequest(builder, true)
         assertTrue(builder.body is HttpBody.Bytes)

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/Md5ChecksumTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/middleware/Md5ChecksumTest.kt
@@ -56,7 +56,7 @@ class Md5ChecksumTest {
     @Test
     fun itOnlySetsHeaderForBytesContent() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = object : HttpBody.Streaming() {
+            body = object : HttpBody.ChannelContent() {
                 override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel("fooey".encodeToByteArray())
             }
         }

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
@@ -42,7 +42,7 @@ class HttpResponseTest {
     fun testDumpResponse() = runTest {
         val content = "Mom!...Dad!...Bingo!...Bluey!"
         val chan = SdkByteReadChannel(content.encodeToByteArray())
-        val stream = object : ByteStream.OneShotStream() {
+        val stream = object : ByteStream.ChannelStream() {
             override val contentLength: Long = content.length.toLong()
             override fun readFrom(): SdkByteReadChannel = chan
         }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
@@ -5,6 +5,7 @@
 package aws.smithy.kotlin.runtime.content
 
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.readToBuffer
 
 /**
@@ -18,9 +19,19 @@ public sealed class ByteStream {
     public open val contentLength: Long? = null
 
     /**
+     * Flag indicating if the body can only be consumed once. If false the underlying stream
+     * must be capable of being replayed.
+     */
+    public open val isOneShot: Boolean = true
+
+    /**
      * Variant of a [ByteStream] with payload represented as an in-memory byte buffer.
      */
     public abstract class Buffer : ByteStream() {
+        // implementations MUST be idempotent and replayable or else they should be modeled differently
+        // this is meant for simple in-memory representations only
+        final override val isOneShot: Boolean = false
+
         /**
          * Provides [ByteArray] to be consumed. This *MUST* be idempotent as the data may be
          * read multiple times.
@@ -29,26 +40,32 @@ public sealed class ByteStream {
     }
 
     /**
-     * Variant of a [ByteStream] with a streaming payload that can only be consumed once.
+     * Variant of a [ByteStream] with a streaming payload read from an [SdkByteReadChannel]
      */
-    public abstract class OneShotStream : ByteStream() {
+    public abstract class ChannelStream : ByteStream() {
         /**
-         * Provides [SdkByteReadChannel] to read from/consume. This function MUST be idempotent, implementations must
-         * return the same channel every time (or a channel in the equivalent state).
+         * Provides [SdkByteReadChannel] to read from/consume.
+         *
+         * Implementations that are replayable ([isOneShot] = `true`) MUST provide a fresh read channel
+         * reset to the original state on each invocation of [readFrom]. Consumers are allowed
+         * to close the stream and ask for a new one.
          */
         public abstract fun readFrom(): SdkByteReadChannel
     }
 
     /**
-     * Variant of an [ByteStream] with a streaming payload that can be consumed multiple times.
+     * Variant of a [ByteStream] with a streaming payload read from an [SdkSource]
      */
-    public abstract class ReplayableStream : ByteStream() {
+    public abstract class SourceStream : ByteStream() {
+
         /**
-         * Provides [SdkByteReadChannel] to read from/consume. Implementations MUST provide a fresh read channel
-         * reset to the original state on each invocation of [newReader]. Consumers are allowed
+         * Provides [SdkSource] to read from/consume.
+         *
+         * Implementations that are replayable ([isOneShot] = `true`) MUST provide a fresh source
+         * reset to the original state on each invocation of [readFrom]. Consumers are allowed
          * to close the stream and ask for a new one.
          */
-        public abstract fun newReader(): SdkByteReadChannel
+        public abstract fun readFrom(): SdkSource
     }
 
     public companion object {
@@ -64,12 +81,6 @@ public sealed class ByteStream {
     }
 }
 
-private suspend fun consumeStream(chan: SdkByteReadChannel): ByteArray {
-    val bytes = chan.readToBuffer().readByteArray()
-    check(chan.isClosedForRead) { "failed to read all bytes from ByteStream, more data still expected" }
-    return bytes
-}
-
 /**
  * Consume the [ByteStream] and pull the entire contents into memory as a [ByteArray].
  * Only do this if you are sure the contents fit in-memory as this will read the entire contents
@@ -77,8 +88,13 @@ private suspend fun consumeStream(chan: SdkByteReadChannel): ByteArray {
  */
 public suspend fun ByteStream.toByteArray(): ByteArray = when (val stream = this) {
     is ByteStream.Buffer -> stream.bytes()
-    is ByteStream.OneShotStream -> consumeStream(stream.readFrom())
-    is ByteStream.ReplayableStream -> consumeStream(stream.newReader())
+    is ByteStream.ChannelStream -> {
+        val chan = stream.readFrom()
+        val bytes = chan.readToBuffer().readByteArray()
+        check(chan.isClosedForRead) { "failed to read all bytes from ByteStream, more data still expected" }
+        bytes
+    }
+    is ByteStream.SourceStream -> consumeSourceAsByteArray(stream.readFrom())
 }
 
 public suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToString()
@@ -86,7 +102,9 @@ public suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToS
 public fun ByteStream.cancel() {
     when (val stream = this) {
         is ByteStream.Buffer -> stream.bytes()
-        is ByteStream.OneShotStream -> stream.readFrom().cancel(null)
-        is ByteStream.ReplayableStream -> stream.newReader().cancel(null)
+        is ByteStream.ChannelStream -> stream.readFrom().cancel(null)
+        is ByteStream.SourceStream -> stream.readFrom().close()
     }
 }
+
+internal expect suspend fun consumeSourceAsByteArray(source: SdkSource): ByteArray

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -85,7 +85,3 @@ private suspend fun File.writeAll(chan: SdkByteReadChannel): Long =
  * @return the number of bytes written
  */
 public suspend fun ByteStream.writeToFile(path: Path): Long = writeToFile(path.toFile())
-
-internal actual suspend fun consumeSourceAsByteArray(source: SdkSource): ByteArray = withContext(Dispatchers.IO) {
-    source.use { it.buffer().readByteArray() }
-}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
@@ -23,26 +23,3 @@ public class FileContent(
         get() = endInclusive - start + 1
     override fun readFrom(): SdkSource = file.source(start, endInclusive)
 }
-
-// FIXME - move to IO as utility class
-private class FileChannel(
-    private val delegate: SdkByteChannel = SdkByteChannel(true),
-) : SdkByteChannel by delegate {
-    var job: Job? = null
-
-    override fun cancel(cause: Throwable?): Boolean {
-        job?.cancel(CancellationException("channel was cancelled", cause))
-        return delegate.cancel(cause)
-    }
-
-    override fun close(cause: Throwable?): Boolean {
-        if (cause != null) {
-            job?.cancel(CancellationException("channel was closed with cause", cause))
-        }
-        return delegate.close(cause)
-    }
-
-    override fun close() {
-        delegate.close()
-    }
-}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/FileContent.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.content
 import aws.smithy.kotlin.runtime.io.*
 import kotlinx.coroutines.*
 import java.io.File
-import kotlin.io.use
 
 /**
  * ByteStream backed by a local [file]
@@ -17,30 +16,15 @@ public class FileContent(
     public val file: File,
     public val start: Long = 0,
     public val endInclusive: Long = file.length() - 1,
-) : ByteStream.ReplayableStream() {
+) : ByteStream.SourceStream() {
 
+    override val isOneShot: Boolean = false
     override val contentLength: Long
         get() = endInclusive - start + 1
-
-    override fun newReader(): SdkByteReadChannel {
-        val ch = FileChannel()
-        val job = CoroutineScope(Dispatchers.IO + CoroutineName("file-reader")).launch {
-            file.source(start, endInclusive).use {
-                ch.writeAll(it)
-            }
-        }
-
-        job.invokeOnCompletion { cause ->
-            ch.close(cause)
-        }
-
-        // attach the job and tie the lifetimes of the coroutine and channel together
-        ch.job = job
-
-        return ch
-    }
+    override fun readFrom(): SdkSource = file.source(start, endInclusive)
 }
 
+// FIXME - move to IO as utility class
 private class FileChannel(
     private val delegate: SdkByteChannel = SdkByteChannel(true),
 ) : SdkByteChannel by delegate {

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -93,7 +93,7 @@ public fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit): T
             val body: HttpBody = testBuilder.expected.body?.let {
                 // emulate a real response stream which typically can only be consumed once
                 // see: https://github.com/awslabs/aws-sdk-kotlin/issues/356
-                object : HttpBody.Streaming() {
+                object : HttpBody.ChannelContent() {
                     private var consumed = false
                     override fun readFrom(): SdkByteReadChannel {
                         val content = if (consumed) ByteArray(0) else it.encodeToByteArray()

--- a/tests/benchmarks/http-benchmarks/README.md
+++ b/tests/benchmarks/http-benchmarks/README.md
@@ -14,16 +14,17 @@ The download/upload throughput benchmarks are an approximation of how much data 
 
 ```
 jvm summary:
-Benchmark                                            (httpClientName)   Mode  Cnt      Score     Error  Units
-HttpEngineBenchmarks.downloadThroughputNoTls                   OkHttp  thrpt    5    467.323 ±  13.279  ops/s
-HttpEngineBenchmarks.downloadThroughputNoTls                      CRT  thrpt    5    415.115 ±   7.405  ops/s
-HttpEngineBenchmarks.roundTripConcurrentNoTls                  OkHttp  thrpt    5  36166.495 ± 312.450  ops/s
-HttpEngineBenchmarks.roundTripConcurrentNoTls                     CRT  thrpt    5  20070.294 ± 455.729  ops/s
-HttpEngineBenchmarks.roundTripSequentialNoTls                  OkHttp  thrpt    5   8308.011 ± 305.540  ops/s
-HttpEngineBenchmarks.roundTripSequentialNoTls                     CRT  thrpt    5   7710.832 ± 579.525  ops/s
-HttpEngineBenchmarks.uploadThroughputNoTls                     OkHttp  thrpt    5    206.267 ±   6.569  ops/s
-HttpEngineBenchmarks.uploadThroughputNoTls                        CRT  thrpt    5    216.031 ±   3.804  ops/s
-HttpEngineBenchmarks.uploadThroughputStreamingNoTls            OkHttp  thrpt    5    208.176 ±   6.893  ops/s
-HttpEngineBenchmarks.uploadThroughputStreamingNoTls               CRT  thrpt    5    115.984 ±   0.265  ops/s
+Benchmark                                                 (httpClientName)   Mode  Cnt      Score     Error  Units
+HttpEngineBenchmarks.downloadThroughputNoTls                        OkHttp  thrpt    5    613.108 ±  23.914  ops/s
+HttpEngineBenchmarks.downloadThroughputNoTls                           CRT  thrpt    5    406.408 ±  13.481  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls                       OkHttp  thrpt    5  36524.268 ± 186.314  ops/s
+HttpEngineBenchmarks.roundTripConcurrentNoTls                          CRT  thrpt    5  19593.107 ± 561.276  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls                       OkHttp  thrpt    5   8377.427 ± 533.683  ops/s
+HttpEngineBenchmarks.roundTripSequentialNoTls                          CRT  thrpt    5   7352.441 ± 661.062  ops/s
+HttpEngineBenchmarks.uploadThroughputChannelContentNoTls            OkHttp  thrpt    5    202.921 ±   4.127  ops/s
+HttpEngineBenchmarks.uploadThroughputChannelContentNoTls               CRT  thrpt    5    115.932 ±   0.241  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls                          OkHttp  thrpt    5    196.034 ±   5.392  ops/s
+HttpEngineBenchmarks.uploadThroughputNoTls                             CRT  thrpt    5    206.827 ±   3.650  ops/s
+HttpEngineBenchmarks.uploadThroughputSourceContentNoTls             OkHttp  thrpt    5    216.396 ±   7.071  ops/s
+HttpEngineBenchmarks.uploadThroughputSourceContentNoTls                CRT  thrpt    5    211.232 ±  17.247  ops/s
 ```
-

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -14,6 +14,8 @@ import aws.smithy.kotlin.runtime.http.request.headers
 import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -114,7 +116,7 @@ open class HttpEngineBenchmarks {
     }
 
     // creates a new streaming body
-    private fun uploadRequestStreamingBody() = HttpRequest {
+    private fun uploadRequestStreamingBody(useSource: Boolean = false) = HttpRequest {
         url {
             scheme = Protocol.HTTP
             method = HttpMethod.POST
@@ -122,10 +124,17 @@ open class HttpEngineBenchmarks {
             port = serverPort
             path = "/upload"
         }
-        body = object : HttpBody.ChannelContent() {
-            override val contentLength: Long = largeData.size.toLong()
-            private val ch = SdkByteReadChannel(largeData)
-            override fun readFrom(): SdkByteReadChannel = ch
+        body = if (useSource) {
+            object : HttpBody.SourceContent() {
+                override val contentLength: Long = largeData.size.toLong()
+                override fun readFrom(): SdkSource = largeData.source()
+            }
+        } else {
+            object : HttpBody.ChannelContent() {
+                override val contentLength: Long = largeData.size.toLong()
+                private val ch = SdkByteReadChannel(largeData)
+                override fun readFrom(): SdkByteReadChannel = ch
+            }
         }
     }
 
@@ -221,12 +230,29 @@ open class HttpEngineBenchmarks {
     }
 
     /**
-     * Raw upload throughput for a streaming body (output MB/s will be roughly op/sec * MB/op)
+     * Raw upload throughput for a streaming body with SdkByteChannel content (output MB/s will be roughly op/sec * MB/op)
      */
     @Benchmark
     @OperationsPerInvocation(MB_PER_THROUGHPUT_OP)
-    fun uploadThroughputStreamingNoTls(blackhole: Blackhole) = runBlocking {
+    fun uploadThroughputChannelContentNoTls(blackhole: Blackhole) = runBlocking {
         val call = httpClient.call(uploadRequestStreamingBody())
+        try {
+            val body = call.response.body.readAll()
+            blackhole.consume(body)
+        } catch (ex: Exception) {
+            println("failed to consume body: ${ex.message}")
+        } finally {
+            call.complete()
+        }
+    }
+
+    /**
+     * Raw upload throughput for a streaming body with SdkSource content (output MB/s will be roughly op/sec * MB/op)
+     */
+    @Benchmark
+    @OperationsPerInvocation(MB_PER_THROUGHPUT_OP)
+    fun uploadThroughputSourceContentNoTls(blackhole: Blackhole) = runBlocking {
+        val call = httpClient.call(uploadRequestStreamingBody(useSource = true))
         try {
             val body = call.response.body.readAll()
             blackhole.consume(body)

--- a/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
+++ b/tests/benchmarks/http-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/http/HttpEngineBenchmarks.kt
@@ -122,7 +122,7 @@ open class HttpEngineBenchmarks {
             port = serverPort
             path = "/upload"
         }
-        body = object : HttpBody.Streaming() {
+        body = object : HttpBody.ChannelContent() {
             override val contentLength: Long = largeData.size.toLong()
             private val ch = SdkByteReadChannel(largeData)
             override fun readFrom(): SdkByteReadChannel = ch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Refactor `ByteStream` and `HttpBody` to allow an `SdkSource` variant. The primary effect of this is:
1. Http engine implementations (and customers if they are unwrapping `ByteStream` and not using a convenience function) have to deal with a new variant
    * `SdkSource` is a blocking interface which should be fine on JVM/Native but not on JS. We haven't fully thought this through but I expect the answer will be that we shuffle everything on JS through the channel variant and error if we see anything else. We won't be able to make this a compile time error unfortunately without knee capping `ByteStream`/`HttpBody` in common source sets. I chose not to go this route, I'm fine with the experience on JS being slightly less than ideal if you carve your own path outside the one we will define
2. File based input doesn't have to proxy itself through a channel, removing an extra layer of buffering/overhead 

I've also cleaned up `ByteStream` and `HttpBody` to move some of the less common parameters around like `isOneShot` flag, etc. The reason for this is we now have effectively two streaming input variants and duplicating these flags in specific variants of a sealed class felt wrong. It forced engines to unwrap the body to make decisions. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
