### PR TITLE
fix: correctly deserialize lists of documents

### DIFF
--- a/.changes/2032f172-904d-474b-b554-4d7fa04e160c.json
+++ b/.changes/2032f172-904d-474b-b554-4d7fa04e160c.json
@@ -1,0 +1,5 @@
+{
+    "id": "2032f172-904d-474b-b554-4d7fa04e160c",
+    "type": "bugfix",
+    "description": "Fix deserialization error for shapes with lists of document types"
+}

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -38,6 +38,8 @@ object KotlinTypes {
         val List: Symbol = builtInSymbol("List", "kotlin.collections")
         val Set: Symbol = builtInSymbol("Set", "kotlin.collections")
         val Map: Symbol = builtInSymbol("Map", "kotlin.collections")
+        val mutableListOf: Symbol = builtInSymbol("mutableListOf", "kotlin.collections")
+        val mutableMapOf: Symbol = builtInSymbol("mutableMapOf", "kotlin.collections")
     }
 
     object Jvm {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

After syncing AWS models, a new structure was found containing a list of `Document` shapes. Our deserialization code didn't properly handle this, leading to a build failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.