### PR TITLE
fix(rt): allow root spans to inherit their parent from the context when not already set

### DIFF
--- a/.changes/0b232d1e-06b5-4557-a5f5-90245238f2ab.json
+++ b/.changes/0b232d1e-06b5-4557-a5f5-90245238f2ab.json
@@ -1,0 +1,8 @@
+{
+    "id": "0b232d1e-06b5-4557-a5f5-90245238f2ab",
+    "type": "bugfix",
+    "description": "Allow root trace spans to inherit their parent from current context",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#759"
+    ]
+}

--- a/runtime/tracing/tracing-core/build.gradle.kts
+++ b/runtime/tracing/tracing-core/build.gradle.kts
@@ -8,6 +8,7 @@ extra["displayName"] = "Smithy :: Kotlin :: Tracing :: Core"
 extra["moduleName"] = "aws.smithy.kotlin.runtime.tracing"
 
 val kotlinLoggingVersion: String by project
+val coroutinesVersion: String by project
 
 kotlin {
     sourceSets {
@@ -26,6 +27,12 @@ kotlin {
                 api(project(":runtime:logging"))
 
                 implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
             }
         }
 

--- a/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanCoroutineUtilsTest.kt
+++ b/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanCoroutineUtilsTest.kt
@@ -57,7 +57,6 @@ class TraceSpanCoroutineUtilsTest {
         }
 
         coroutineContext.withRootTraceSpan(rootSpan1) {
-            val outerSpan = coroutineContext.traceSpan
             assertFailsWith<IllegalStateException> {
                 coroutineContext.withRootTraceSpan(illegalRoot) { Unit }
             }.message.shouldContain("when no current span exists or the new span is a child of the active span")

--- a/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanCoroutineUtilsTest.kt
+++ b/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanCoroutineUtilsTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class TraceSpanTest {
+class TraceSpanCoroutineUtilsTest {
     @Test
     fun testRootSpanNoExisting() = runTest {
         val tracer = DefaultTracer(NoOpTraceProbe, "test")

--- a/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanTest.kt
+++ b/runtime/tracing/tracing-core/common/test/aws/smithy/kotlin/runtime/tracing/TraceSpanTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.tracing
+
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TraceSpanTest {
+    @Test
+    fun testRootSpanNoExisting() = runTest {
+        val tracer = DefaultTracer(NoOpTraceProbe, "test")
+        val rootSpan = tracer.createRootSpan("root")
+        coroutineContext.withRootTraceSpan(rootSpan) {
+            val actualSpan = coroutineContext.traceSpan
+            assertEquals(rootSpan, actualSpan)
+        }
+    }
+
+    @Test
+    fun testRootSpanExistingIsParent() = runTest {
+        val tracer = DefaultTracer(NoOpTraceProbe, "test")
+        val rootSpan = tracer.createRootSpan("root")
+
+        coroutineContext.withRootTraceSpan(rootSpan) {
+            val currSpan = coroutineContext.traceSpan
+            assertNull(currSpan.parent)
+            val nestedTracer = currSpan.asNestedTracer("nested")
+            val nestedRoot = nestedTracer.createRootSpan("root2")
+            // this should be allowed since the existing span is the parent
+            coroutineContext.withRootTraceSpan(nestedRoot) {
+                val actualSpan = coroutineContext.traceSpan
+                assertEquals(currSpan, actualSpan.parent)
+            }
+        }
+    }
+
+    @Test
+    fun testRootSpanExistingIsNotParent() = runTest {
+        val tracer = DefaultTracer(NoOpTraceProbe, "test")
+        val rootSpan1 = tracer.createRootSpan("root1")
+        val rootSpan2 = tracer.createRootSpan("root2")
+        val illegalRoot = object : TraceSpan {
+            override val parent: TraceSpan = rootSpan2
+            override val id: String = "illegal span"
+            override fun postEvent(event: TraceEvent) {}
+            override fun child(id: String): TraceSpan { error("not needed for test") }
+            override fun close() {}
+        }
+
+        coroutineContext.withRootTraceSpan(rootSpan1) {
+            val outerSpan = coroutineContext.traceSpan
+            assertFailsWith<IllegalStateException> {
+                coroutineContext.withRootTraceSpan(illegalRoot) { Unit }
+            }.message.shouldContain("when no current span exists or the new span is a child of the active span")
+        }
+    }
+
+    @Test
+    fun testRootSpanExistingNoParent() = runTest {
+        // existing span with a new root created with no lineage, should become a child of the outer span automatically
+        val tracer = DefaultTracer(NoOpTraceProbe, "test")
+        val rootSpan1 = tracer.createRootSpan("root1")
+        val rootSpan2 = tracer.createRootSpan("root2")
+
+        coroutineContext.withRootTraceSpan(rootSpan1) {
+            val outerSpan = coroutineContext.traceSpan
+            coroutineContext.withRootTraceSpan(rootSpan2) {
+                val innerSpan = coroutineContext.traceSpan
+                assertEquals(outerSpan, innerSpan.parent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes https://github.com/awslabs/aws-sdk-kotlin/issues/789

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Allow a root span to be created when an existing span is present in the current coroutine context as long as the root span has no parent. An existing span and a root span with a parent is still not allowed because it would represent an illegal state (two different span lineages). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
