### PR TITLE
fix(rt): add special-casing for CrtHttpEngine `aws-chunked` requests

### DIFF
--- a/.changes/f0ec11be-3875-498a-8e33-74c49416f3b8.json
+++ b/.changes/f0ec11be-3875-498a-8e33-74c49416f3b8.json
@@ -1,0 +1,8 @@
+{
+    "id": "f0ec11be-3875-498a-8e33-74c49416f3b8",
+    "type": "bugfix",
+    "description": "Fix `aws-chunked` requests in the CRT HTTP engine",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/759"
+    ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ kotlinLoggingVersion=2.1.21
 slf4jVersion=1.7.36
 
 # crt
-crtKotlinVersion=0.6.6
+crtKotlinVersion=0.6.7-SNAPSHOT

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -103,7 +103,7 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
         val stream = conn.makeRequest(engineRequest, respHandler)
         stream.activate()
 
-        if (request.isAwsChunked) {
+        if (request.isChunked) {
             val bytesToRead = 65536L
 
             when (request.body) {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -120,8 +120,7 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
 
                         stream.writeChunk(buffer.readToByteArray(), isFinalChunk)
 
-                        if (isFinalChunk) { break }
-                        else { buffer = nextBuffer }
+                        if (isFinalChunk) break else buffer = nextBuffer
                     }
                 }
                 is HttpBody.ChannelContent -> {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -34,18 +34,17 @@ internal val HttpRequest.uri: Uri
 internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.kotlin.crt.http.HttpRequest {
     val body = this.body
     check(!body.isDuplex) { "CrtHttpEngine does not yet support full duplex streams" }
-    val bodyStream = when {
-        body is HttpBody.Empty || this.isChunked -> null
-        body is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
-        body is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), callContext)
-        body is HttpBody.SourceContent -> {
+    val bodyStream = if (isChunked) null else when (body) {
+        is HttpBody.Empty -> null
+        is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
+        is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), callContext)
+        is HttpBody.SourceContent -> {
             val source = body.readFrom()
             callContext.job.invokeOnCompletion {
                 source.close()
             }
             SdkSourceBodyStream(source)
         }
-        else -> null
     }
 
     val crtHeaders = HeadersBuilder()

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -34,17 +34,19 @@ internal val HttpRequest.uri: Uri
 internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.kotlin.crt.http.HttpRequest {
     val body = this.body
     check(!body.isDuplex) { "CrtHttpEngine does not yet support full duplex streams" }
-    val bodyStream = when (body) {
-        is HttpBody.Empty -> null
-        is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
-        is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), callContext)
-        is HttpBody.SourceContent -> {
+    val bodyStream = when {
+        body is HttpBody.Empty -> null
+        body is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
+        body is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), callContext)
+        body is HttpBody.SourceContent && this.isAwsChunked -> null // aws-chunked bodies must be null
+        body is HttpBody.SourceContent -> {
             val source = body.readFrom()
             callContext.job.invokeOnCompletion {
                 source.close()
             }
             SdkSourceBodyStream(source)
         }
+        else -> null
     }
 
     val crtHeaders = HeadersBuilder()
@@ -61,3 +63,9 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
 
     return aws.sdk.kotlin.crt.http.HttpRequest(method.name, url.encodedPath, crtHeaders.build(), bodyStream)
 }
+
+/**
+ * @return whether this HttpRequest is an aws-chunked request.
+ * Specifically, this means return `true` if a request contains a `Transfer-Encoding` header with the value `chunked`.
+ */
+internal val HttpRequest.isAwsChunked: Boolean get() = this.headers.getAll("Transfer-Encoding")?.contains("chunked") == true

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.engine.crt
 
 import aws.sdk.kotlin.crt.http.HeadersBuilder
 import aws.sdk.kotlin.crt.http.HttpRequestBodyStream
+import aws.sdk.kotlin.crt.http.HttpStream
 import aws.sdk.kotlin.crt.io.Protocol
 import aws.sdk.kotlin.crt.io.Uri
 import aws.sdk.kotlin.crt.io.UserInfo
@@ -14,6 +15,9 @@ import aws.smithy.kotlin.runtime.crt.ReadChannelBodyStream
 import aws.smithy.kotlin.runtime.crt.SdkSourceBodyStream
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.io.buffer
+import aws.smithy.kotlin.runtime.io.readToByteArray
 import kotlinx.coroutines.job
 import kotlin.coroutines.CoroutineContext
 
@@ -68,4 +72,37 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
  * and the body is either [HttpBody.SourceContent] or [HttpBody.ChannelContent].
  */
 internal val HttpRequest.isChunked: Boolean get() = (this.body is HttpBody.SourceContent || this.body is HttpBody.ChannelContent) &&
-    this.headers.getAll("Transfer-Encoding")?.contains("chunked") == true
+    headers.contains("Transfer-Encoding", "chunked")
+
+/**
+ * Send a chunked body using the CRT writeChunk bindings.
+ * @param body an HTTP body that has a chunked content encoding. Must be [HttpBody.SourceContent] or [HttpBody.ChannelContent]
+ */
+internal suspend fun HttpStream.sendChunkedBody(body: HttpBody) {
+    when (body) {
+        is HttpBody.SourceContent -> {
+            val source = body.readFrom()
+            val bufferedSource = source.buffer()
+
+            while (!bufferedSource.exhausted()) {
+                bufferedSource.request(CHUNK_BUFFER_SIZE)
+                writeChunk(bufferedSource.buffer.readByteArray(), isFinalChunk = bufferedSource.exhausted())
+            }
+        }
+        is HttpBody.ChannelContent -> {
+            val chan = body.readFrom()
+            var buffer = SdkBuffer()
+            val nextBuffer = SdkBuffer()
+
+            while (!chan.isClosedForRead) {
+                chan.read(buffer, CHUNK_BUFFER_SIZE)
+
+                val isFinalChunk = chan.read(nextBuffer, CHUNK_BUFFER_SIZE) == -1L
+
+                writeChunk(buffer.readToByteArray(), isFinalChunk)
+                if (isFinalChunk) break else buffer = nextBuffer
+            }
+        }
+        else -> error("sendChunkedBody should not be called for non-chunked body types")
+    }
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -68,4 +68,4 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
  * Specifically, this means return `true` if a request contains a `Transfer-Encoding` header with the value `chunked`.
  */
 internal val HttpRequest.isAwsChunked: Boolean get() = (this.body is HttpBody.SourceContent || this.body is HttpBody.ChannelContent) &&
-        this.headers.getAll("Transfer-Encoding")?.contains("chunked") == true
+    this.headers.getAll("Transfer-Encoding")?.contains("chunked") == true

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -115,7 +115,7 @@ class RequestConversionTest {
             object : HttpBody.ChannelContent() {
                 override val contentLength: Long = testData.size.toLong()
                 override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(testData)
-            }
+            },
         )
 
         val testContext = EmptyCoroutineContext + Job()
@@ -135,7 +135,7 @@ class RequestConversionTest {
             object : HttpBody.SourceContent() {
                 override val contentLength: Long = testData.size.toLong()
                 override fun readFrom(): SdkSource = testData.source()
-            }
+            },
         )
 
         val testContext = EmptyCoroutineContext + Job()
@@ -143,5 +143,4 @@ class RequestConversionTest {
         assertNotNull(request.body)
         assertNull(crtRequest.body)
     }
-
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -11,12 +11,12 @@ import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
+import kotlin.test.*
 
 class RequestConversionTest {
     private fun byteStreamFromContents(contents: String): ByteStream =
@@ -103,4 +103,45 @@ class RequestConversionTest {
         val crtRequest = request.toCrtRequest(testContext)
         assertFalse(crtRequest.headers.contains("Content-Length"))
     }
+
+    @Test
+    fun testEngineSetsNullBodyForChannelContentChunkedRequests() {
+        val testData = ByteArray(1024) { 0 }
+
+        val request = HttpRequest(
+            HttpMethod.POST,
+            Url.parse("https://test.aws.com?foo=bar"),
+            Headers.invoke { append("Transfer-Encoding", "chunked") },
+            object : HttpBody.ChannelContent() {
+                override val contentLength: Long = testData.size.toLong()
+                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(testData)
+            }
+        )
+
+        val testContext = EmptyCoroutineContext + Job()
+        val crtRequest = request.toCrtRequest(testContext)
+        assertNotNull(request.body)
+        assertNull(crtRequest.body)
+    }
+
+    @Test
+    fun testEngineSetsNullBodyForSourceContentChunkedRequests() {
+        val testData = ByteArray(1024) { 0 }
+
+        val request = HttpRequest(
+            HttpMethod.POST,
+            Url.parse("https://test.aws.com?foo=bar"),
+            Headers.invoke { append("Transfer-Encoding", "chunked") },
+            object : HttpBody.SourceContent() {
+                override val contentLength: Long = testData.size.toLong()
+                override fun readFrom(): SdkSource = testData.source()
+            }
+        )
+
+        val testContext = EmptyCoroutineContext + Job()
+        val crtRequest = request.toCrtRequest(testContext)
+        assertNotNull(request.body)
+        assertNull(crtRequest.body)
+    }
+
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -28,6 +28,7 @@ class SdkStreamResponseHandlerTest {
         override fun activate() {}
         override fun close() { closed = true }
         override fun incrementWindow(size: Int) {}
+        override fun writeChunk(chunkData: ByteArray, isFinalChunk: Boolean) {}
     }
 
     private class MockHttpClientConnection : HttpClientConnection {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package aws.smithy.kotlin.runtime.http.engine.crt
 
 import aws.sdk.kotlin.crt.http.HttpStream
@@ -8,7 +13,6 @@ import aws.smithy.kotlin.runtime.io.source
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
-
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SendChunkedBodyTest {
@@ -98,6 +102,4 @@ class SendChunkedBodyTest {
         // there should definitely be more than 1 call to `writeChunk`, but in practice we don't care how many there are
         assertTrue(stream.numChunksWritten > 1)
     }
-
-
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
@@ -1,0 +1,103 @@
+package aws.smithy.kotlin.runtime.http.engine.crt
+
+import aws.sdk.kotlin.crt.http.HttpStream
+import aws.smithy.kotlin.runtime.http.toHttpBody
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.readToByteArray
+import aws.smithy.kotlin.runtime.io.source
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendChunkedBodyTest {
+    private class MockHttpStream(override val responseStatusCode: Int) : HttpStream {
+        var closed: Boolean = false
+        var numChunksWritten = 0
+        override fun activate() {}
+        override fun close() { closed = true }
+        override fun incrementWindow(size: Int) {}
+        override fun writeChunk(chunkData: ByteArray, isFinalChunk: Boolean) { numChunksWritten += 1 }
+    }
+
+    @Test
+    fun testSourceContent() = runTest {
+        val stream = MockHttpStream(200)
+
+        val chunkedBytes = """
+           100;chunk-signature=${"0".repeat(64)}\r\n${"0".repeat(256)}\r\n\r\n 
+        """.trimIndent().toByteArray()
+
+        val source = chunkedBytes.source()
+
+        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()))
+
+        // source should be fully consumed with 1 chunk written
+        assertEquals(0, source.readToByteArray().size)
+        assertEquals(1, stream.numChunksWritten)
+    }
+
+    @Test
+    fun testChannelContentMultipleChunks() = runTest {
+        val stream = MockHttpStream(200)
+
+        val chunkSize = (CHUNK_BUFFER_SIZE * 5).toInt()
+
+        val chunkedBytes = """
+           ${chunkSize.toString(16)};chunk-signature=${"0".repeat(64)}\r\n${"0".repeat(chunkSize)}\r\n\r\n 
+        """.trimIndent().toByteArray()
+
+        val source = chunkedBytes.source()
+
+        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()))
+
+        // source should be fully consumed
+        assertEquals(0, source.readToByteArray().size)
+
+        // there should definitely be more than 1 call to `writeChunk`, but in practice we don't care how many there are
+        assertTrue(stream.numChunksWritten > 1)
+    }
+
+    @Test
+    fun testChannelContent() = runTest {
+        val stream = MockHttpStream(200)
+
+        val chunkedBytes = """
+           100;chunk-signature=${"0".repeat(64)}\r\n${"0".repeat(256)}\r\n\r\n 
+        """.trimIndent().toByteArray()
+
+        val channel = SdkByteReadChannel(chunkedBytes)
+
+        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()))
+
+        // channel should be fully consumed with 1 chunk written
+        assertEquals(0, channel.availableForRead)
+        assertTrue(channel.isClosedForRead)
+        assertEquals(1, stream.numChunksWritten)
+    }
+
+    @Test
+    fun testSourceContentMultipleChunks() = runTest {
+        val stream = MockHttpStream(200)
+
+        val chunkSize = (CHUNK_BUFFER_SIZE * 5).toInt()
+
+        val chunkedBytes = """
+           ${chunkSize.toString(16)};chunk-signature=${"0".repeat(64)}\r\n${"0".repeat(chunkSize)}\r\n\r\n 
+        """.trimIndent().toByteArray()
+
+        val channel = SdkByteReadChannel(chunkedBytes)
+
+        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()))
+
+        // source should be fully consumed
+        assertEquals(0, channel.availableForRead)
+        assertTrue(channel.isClosedForRead)
+
+        // there should definitely be more than 1 call to `writeChunk`, but in practice we don't care how many there are
+        assertTrue(stream.numChunksWritten > 1)
+    }
+
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CRT requires `aws-chunked` requests to use a specific API instead of a normal streaming request body. This PR adds a special-case to the CRT engine, which will use this new API instead of sending an `aws-chunked` body.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/759

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Currently `aws-chunked` requests do not work when using the CrtHttpEngine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.