### PR TITLE
chore: move codegen test utilities to new smithy-kotlin-codegen-testutils package

### DIFF
--- a/.changes/9ab15fa5-76b7-4bf0-9931-eaa50fd57a19.json
+++ b/.changes/9ab15fa5-76b7-4bf0-9931-eaa50fd57a19.json
@@ -1,0 +1,5 @@
+{
+    "id": "9ab15fa5-76b7-4bf0-9931-eaa50fd57a19",
+    "type": "misc",
+    "description": "Move test utilities out of **smithy-kotlin-codegen** package into new **smithy-kotlin-codegen-testutils** package. This eliminates the need for the codegen package to declare runtime dependencies on JUnit and other test packages."
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ include(":runtime:tracing:tracing-core")
 include(":runtime:utils")
 
 include(":smithy-kotlin-codegen")
+include(":smithy-kotlin-codegen-testutils")
 
 include(":tests")
 include(":tests:benchmarks:aws-signing-benchmarks")

--- a/smithy-kotlin-codegen-testutils/build.gradle.kts
+++ b/smithy-kotlin-codegen-testutils/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
     `maven-publish`
 }
 
-description = "Generates Kotlin code from Smithy models"
-extra["displayName"] = "Smithy :: Kotlin :: Codegen"
-extra["moduleName"] = "software.amazon.smithy.kotlin.codegen"
+description = "Provides common test utilities for Smithy-Kotlin code generation"
+extra["displayName"] = "Smithy :: Kotlin :: Codegen Utils"
+extra["moduleName"] = "software.amazon.smithy.kotlin.codegen.test"
 
 val sdkVersion: String by project
 group = "software.amazon.smithy.kotlin"
@@ -24,40 +24,20 @@ val jsoupVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
-    api("software.amazon.smithy:smithy-waiters:$smithyVersion")
-    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
-    implementation("org.jsoup:jsoup:$jsoupVersion")
+    api(project(":smithy-kotlin-codegen"))
 
     // Test dependencies
-    testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
-    testImplementation(project(":smithy-kotlin-codegen-testutils"))
-}
-
-val generateSdkRuntimeVersion by tasks.registering {
-    // generate the version of the runtime to use as a resource.
-    // this keeps us from having to manually change version numbers in multiple places
-    val resourcesDir = "$buildDir/resources/main/software/amazon/smithy/kotlin/codegen/core"
-    val versionFile = file("$resourcesDir/sdk-version.txt")
-    val gradlePropertiesFile = rootProject.file("gradle.properties")
-    inputs.file(gradlePropertiesFile)
-    outputs.file(versionFile)
-    sourceSets.main.get().output.dir(resourcesDir)
-    doLast {
-        versionFile.writeText("$version")
-    }
+    implementation("org.junit.jupiter:junit-jupiter:$junitVersion")
+    implementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    implementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")
 }
 
 // unlike the runtime, smithy-kotlin codegen package is not expected to run on Android...we can target 1.8
 tasks.compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    dependsOn(generateSdkRuntimeVersion)
 }
 
 tasks.compileTestKotlin {
@@ -97,21 +77,9 @@ tasks.test {
     }
 }
 
-// Configure jacoco (code coverage) to generate an HTML report
-tasks.jacocoTestReport {
-    reports {
-        xml.isEnabled = false
-        csv.isEnabled = false
-        html.destination = file("$buildDir/reports/jacoco")
-    }
-}
-
-// Always run the jacoco test report after testing.
-tasks["test"].finalizedBy(tasks["jacocoTestReport"])
-
 publishing {
     publications {
-        create<MavenPublication>("codegen") {
+        create<MavenPublication>("codegen-testutils") {
             from(components["java"])
             artifact(sourcesJar)
         }

--- a/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/CodegenTestUtils.kt
+++ b/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/CodegenTestUtils.kt
@@ -21,12 +21,9 @@ import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.utils.StringUtils
 
-/**
- * This file houses test classes and functions relating to the code generator (protocols, serializers, etc)
- *
- * Items contained here should be relatively high-level, utilizing all members of codegen classes, Smithy, and
- * anything else necessary for test functionality.
- */
+// This file houses test classes and functions relating to the code generator (protocols, serializers, etc)
+// Items contained here should be relatively high-level, utilizing all members of codegen classes, Smithy, and
+// anything else necessary for test functionality.
 
 /**
  * Container for type instances necessary for tests
@@ -37,8 +34,8 @@ data class TestContext(
     val generator: ProtocolGenerator,
 )
 
-// Execute the codegen and return the generated output
-internal fun testRender(
+/** Execute the codegen and return the generated output */
+fun testRender(
     members: List<MemberShape>,
     renderFn: (List<MemberShape>, KotlinWriter) -> Unit,
 ): String {
@@ -47,8 +44,8 @@ internal fun testRender(
     return writer.toString()
 }
 
-// Drive codegen for serialization of a given shape
-internal fun codegenSerializerForShape(model: Model, shapeId: String, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): String {
+/** Drive codegen for serialization of a given shape */
+fun codegenSerializerForShape(model: Model, shapeId: String, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): String {
     val ctx = model.newTestContext()
 
     val op = ctx.generationCtx.model.expectShape(ShapeId.from(shapeId))
@@ -62,8 +59,8 @@ internal fun codegenSerializerForShape(model: Model, shapeId: String, location: 
     }
 }
 
-// Drive codegen for deserialization of a given shape
-internal fun codegenDeserializerForShape(model: Model, shapeId: String, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): String {
+/** Drive codegen for deserialization of a given shape */
+fun codegenDeserializerForShape(model: Model, shapeId: String, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): String {
     val ctx = model.newTestContext()
     val op = ctx.generationCtx.model.expectShape(ShapeId.from(shapeId))
 
@@ -77,8 +74,8 @@ internal fun codegenDeserializerForShape(model: Model, shapeId: String, location
     }
 }
 
-// Drive codegen for serializer of a union of a given shape
-internal fun codegenUnionSerializerForShape(model: Model, shapeId: String): String {
+/** Drive codegen for serializer of a union of a given shape */
+fun codegenUnionSerializerForShape(model: Model, shapeId: String): String {
     val ctx = model.newTestContext()
 
     val bindingIndex = HttpBindingIndex.of(ctx.generationCtx.model)
@@ -98,8 +95,8 @@ internal fun codegenUnionSerializerForShape(model: Model, shapeId: String): Stri
     }
 }
 
-// Retrieves Response Document members for HttpTrait-enabled protocols
-internal fun TestContext.responseMembers(shape: Shape, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): List<MemberShape> {
+/** Retrieves response document members for HttpTrait-enabled protocols */
+fun TestContext.responseMembers(shape: Shape, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): List<MemberShape> {
     val bindingIndex = HttpBindingIndex.of(this.generationCtx.model)
     val responseBindings = bindingIndex.getResponseBindings(shape)
 
@@ -109,8 +106,8 @@ internal fun TestContext.responseMembers(shape: Shape, location: HttpBinding.Loc
         .map { it.member }
 }
 
-// Retrieves Request Document members for HttpTrait-enabled protocols
-internal fun TestContext.requestMembers(shape: Shape, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): List<MemberShape> {
+/** Retrieves Request Document members for HttpTrait-enabled protocols */
+fun TestContext.requestMembers(shape: Shape, location: HttpBinding.Location = HttpBinding.Location.DOCUMENT): List<MemberShape> {
     val bindingIndex = HttpBindingIndex.of(this.generationCtx.model)
     val responseBindings = bindingIndex.getRequestBindings(shape)
 
@@ -120,21 +117,21 @@ internal fun TestContext.requestMembers(shape: Shape, location: HttpBinding.Loca
         .map { it.member }
 }
 
-internal fun TestContext.toGenerationContext(): GenerationContext =
+fun TestContext.toGenerationContext(): GenerationContext =
     GenerationContext(generationCtx.model, generationCtx.symbolProvider, generationCtx.settings, generator)
 
 fun <T : Shape> TestContext.toRenderingContext(writer: KotlinWriter, forShape: T? = null): RenderingContext<T> =
     toGenerationContext().toRenderingContext(writer, forShape)
 
-// A HttpProtocolClientGenerator for testing
-internal class TestProtocolClientGenerator(
+/** An HttpProtocolClientGenerator for testing */
+class TestProtocolClientGenerator(
     ctx: ProtocolGenerator.GenerationContext,
     features: List<ProtocolMiddleware>,
     httpBindingResolver: HttpBindingResolver,
 ) : HttpProtocolClientGenerator(ctx, features, httpBindingResolver)
 
-// A HttpBindingProtocolGenerator for testing (nothing is rendered for serializing/deserializing payload bodies)
-internal class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
+/** An HttpBindingProtocolGenerator for testing (nothing is rendered for serializing/deserializing payload bodies) */
+class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
     override fun getProtocolHttpBindingResolver(model: Model, serviceShape: ServiceShape): HttpBindingResolver =
         HttpTraitResolver(model, serviceShape, ProtocolContentTypes.consistent("application/json"))
@@ -192,7 +189,7 @@ internal class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
     }
 }
 
-// Create a test harness with all necessary codegen types
+/** Create a test harness with all necessary codegen types */
 fun codegenTestHarnessForModelSnippet(
     generator: ProtocolGenerator,
     namespace: String = TestModelDefault.NAMESPACE,
@@ -219,8 +216,10 @@ data class CodegenTestHarness(
     val protocol: String,
 )
 
-// Create and use a writer to drive codegen from a function taking a writer.
-// Strip off comment and package preamble.
+/**
+ * Create and use a writer to drive codegen from a function taking a writer.
+ * Strip off comment and package preamble.
+ */
 fun generateCode(generator: (KotlinWriter) -> Unit): String {
     val packageDeclaration = "some-unique-thing-that-will-never-be-codegened"
     val writer = KotlinWriter(packageDeclaration)

--- a/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/LangTestUtils.kt
+++ b/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/LangTestUtils.kt
@@ -6,11 +6,9 @@ package software.amazon.smithy.kotlin.codegen.test
 
 import kotlin.test.assertEquals
 
-/**
- * This file houses test functions specific to Kotlin language particulars.
- */
+// This file houses test functions specific to Kotlin language particulars.
 
-internal fun String.assertBalancedBracesAndParens() {
+fun String.assertBalancedBracesAndParens() {
     // sanity check since we are testing fragments
     var openBraces = 0
     var closedBraces = 0

--- a/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/MiscTestUtils.kt
+++ b/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/MiscTestUtils.kt
@@ -8,12 +8,9 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import kotlin.test.assertNotNull
 
-/**
- * This file houses miscellaneous test functions that do not fall under other
- * test categories specified in this package.
- */
+// This file houses miscellaneous test functions that do not fall under other test categories specified in this package.
 
-// Will generate an IDE diff in the case of a test assertion failure.
+/** Generate an IDE diff in the case of a test assertion failure. */
 fun String?.shouldContainOnlyOnceWithDiff(expected: String) {
     try {
         this.shouldContainOnlyOnce(expected)
@@ -22,8 +19,8 @@ fun String?.shouldContainOnlyOnceWithDiff(expected: String) {
     }
 }
 
-// Will generate an IDE diff in the case of a test assertion failure.
-internal fun String?.shouldContainWithDiff(expected: String) {
+/** Generate an IDE diff in the case of a test assertion failure. */
+fun String?.shouldContainWithDiff(expected: String) {
     try {
         this.shouldContain(expected)
     } catch (originalException: AssertionError) {
@@ -46,7 +43,7 @@ fun String.shouldContain(expectedStart: String, expectedEnd: String) {
 fun <T> List<T>.indexOfSublistOrNull(sublist: List<T>, startFrom: Int = 0): Int? =
     drop(startFrom).windowed(sublist.size).indexOf(sublist)
 
-// Format a multi-line string suitable for comparison with codegen, defaults to one level of indention.
+/** Format a multi-line string suitable for comparison with codegen, defaults to one level of indention. */
 fun String.formatForTest(indent: String = "    ") =
     trimIndent()
         .prependIndent(indent)
@@ -54,7 +51,7 @@ fun String.formatForTest(indent: String = "    ") =
         .map { if (it.isBlank()) "" else it }
         .joinToString(separator = "\n") { it }
 
-internal fun String.stripCodegenPrefix(packageName: String = "test"): String {
+fun String.stripCodegenPrefix(packageName: String = "test"): String {
     val packageDirective = "package $packageName"
     return this.substring(this.indexOf(packageDirective) + packageDirective.length).trim()
 }

--- a/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
+++ b/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.*
+import software.amazon.smithy.kotlin.codegen.inferService
 import software.amazon.smithy.kotlin.codegen.model.OperationNormalizer
 import software.amazon.smithy.kotlin.codegen.model.shapes
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
@@ -21,12 +22,8 @@ import software.amazon.smithy.model.shapes.SmithyIdlModelSerializer
 import software.amazon.smithy.model.validation.ValidatedResultException
 import java.net.URL
 
-/**
- * This file houses classes and functions to help with testing with Smithy models.
- *
- * These functions should be relatively low-level and deal directly with types provided
- * by smithy-codegen.
- */
+// This file houses classes and functions to help with testing with Smithy models.
+// These functions should be relatively low-level and deal directly with types provided by smithy-codegen.
 
 /**
  * Unless necessary to deviate for test reasons, the following literals should be used in test models:
@@ -35,7 +32,7 @@ import java.net.URL
  *  namespace: TestDefault.NAMESPACE
  *  service name: "Test"
  */
-internal object TestModelDefault {
+object TestModelDefault {
     const val SMITHY_IDL_VERSION = "1"
     const val MODEL_VERSION = "1.0.0"
     const val NAMESPACE = "com.test"
@@ -64,7 +61,7 @@ private fun Model.applyKotlinCodegenTransforms(serviceShapeId: String?): Model {
 /**
  * Load and initialize a model from a Java resource URL
  */
-internal fun URL.toSmithyModel(serviceShapeId: String? = null): Model {
+fun URL.toSmithyModel(serviceShapeId: String? = null): Model {
     val model = Model.assembler()
         .addImport(this)
         .discoverModels()
@@ -98,7 +95,7 @@ fun String.toSmithyModel(sourceLocation: String? = null, serviceShapeId: String?
  *
  * NOTE: this is used for debugging / unit test generation, please don't remove.
  */
-internal fun Model.toSmithyIDL(): String {
+fun Model.toSmithyIDL(): String {
     val builtInModelIds = setOf("smithy.test.smithy", "aws.auth.smithy", "aws.protocols.smithy", "aws.api.smithy")
     val ms: SmithyIdlModelSerializer = SmithyIdlModelSerializer.builder().build()
     val node = ms.serialize(this)
@@ -167,7 +164,7 @@ fun Model.defaultSettings(
     generateDefaultBuildFiles: Boolean = false,
 ): KotlinSettings {
     val serviceId = if (serviceName == null) {
-        KotlinSettings.inferService(this)
+        this.inferService()
     } else {
         this.getShape(ShapeId.from("$packageName#$serviceName")).getOrNull()?.id
             ?: error("Unable to find service '$serviceName' in model.")
@@ -193,8 +190,8 @@ fun Model.defaultSettings(
     )
 }
 
-// Generate a Smithy IDL model based on input parameters and source string
-internal fun String.generateTestModel(
+/** Generate a Smithy IDL model based on input parameters and source string */
+fun String.generateTestModel(
     protocol: String,
     namespace: String = TestModelDefault.NAMESPACE,
     serviceName: String = TestModelDefault.SERVICE_NAME,
@@ -256,5 +253,5 @@ fun String.prependNamespaceAndService(
         
 
         """.trimIndent() + this.trimIndent()
-        )
+    )
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -133,14 +133,12 @@ fun Model.inferService(): ShapeId {
     return when {
         services.isEmpty() -> {
             throw CodegenException(
-                "Cannot infer a service to generate because the model does not " +
-                        "contain any service shapes",
+                "Cannot infer a service to generate because the model does not contain any service shapes",
             )
         }
         services.size > 1 -> {
             throw CodegenException(
-                "Cannot infer service to generate because the model contains " +
-                        "multiple service shapes: " + services,
+                "Cannot infer service to generate because the model contains multiple service shapes: $services",
             )
         }
         else -> services.single()


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

It was recently observed that our **smithy-kotlin-codegen** package takes runtime dependencies on JUnit and other test packages because it provides test utilities for consuming code generators. That's not ideal so this PR creates a new **smithy-kotlin-codegen-testutils** package and moves the test utilities there.

**Companion PR**: [aws-sdk-kotlin#794](https://github.com/awslabs/aws-sdk-kotlin/pull/794)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
