### PR TITLE
fix(rt): CRC32C incorrect result on inputs longer than 7 bytes

### DIFF
--- a/.changes/4c3348fe-3e51-411b-98e6-6ac2e6a2bba0.json
+++ b/.changes/4c3348fe-3e51-411b-98e6-6ac2e6a2bba0.json
@@ -1,0 +1,6 @@
+{
+    "id": "4c3348fe-3e51-411b-98e6-6ac2e6a2bba0",
+    "type": "bugfix",
+    "description": "Fix incorrect CRC32c output when trying to hash more than 7 bytes",
+    "module": "runtime"
+}

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
@@ -101,7 +101,7 @@ private class CRC32CImpl {
         crc = localCrc
     }
 
-    fun getValue(): Int = crc.inv() and 0xffffffff.toInt()
+    fun getValue(): Int = crc.inv()
 
     fun update(b: Int) {
         crc = crc ushr 8 xor T[(T8_0_start + ((crc xor b) and 0xff))].toInt()

--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
@@ -6,7 +6,6 @@ package aws.smithy.kotlin.runtime.hashing
 
 import aws.smithy.kotlin.runtime.util.InternalApi
 import kotlin.experimental.and
-import kotlin.experimental.xor
 
 /**
  * Compute the CRC32C hash of the current [ByteArray]
@@ -64,9 +63,9 @@ public class Crc32c : Crc32Base() {
  */
 private class CRC32CImpl {
     /** the current CRC value, bit-flipped */
-    var crc = 0xffffffff
+    var crc = 0xffffffff.toInt()
 
-    fun reset() { crc = 0xffffffff }
+    fun reset() { crc = 0xffffffff.toInt() }
 
     fun update(b: ByteArray, offset: Int, length: Int) {
         var localCrc = crc
@@ -74,38 +73,38 @@ private class CRC32CImpl {
         var len = length
 
         while (len > 7) {
-            val c0 = (b[off + 0] xor localCrc.toByte()) and 0xff.toByte()
-            val c1 = (b[off + 1] xor ((localCrc ushr 8).toByte())) and 0xff.toByte()
+            val c0 = (b[off + 0].toInt() xor localCrc) and 0xff
             localCrc = localCrc ushr 8
-            val c2 = (b[off + 2] xor ((localCrc ushr 8).toByte())) and 0xff.toByte()
+            val c1 = (b[off + 1].toInt() xor localCrc) and 0xff
             localCrc = localCrc ushr 8
-            val c3 = (b[off + 3] xor ((localCrc ushr 8).toByte())) and 0xff.toByte()
-            localCrc = (T[T8_7_start + c0] xor T[T8_6_start + c1]) xor (T[T8_5_start + c2] xor T[T8_4_start + c3])
+            val c2 = (b[off + 2].toInt() xor localCrc) and 0xff
+            localCrc = localCrc ushr 8
+            val c3 = (b[off + 3].toInt() xor localCrc) and 0xff
+            localCrc = (T[T8_7_start + c0] xor T[T8_6_start + c1] xor T[T8_5_start + c2] xor T[T8_4_start + c3]).toInt()
 
             val c4 = b[off + 4] and 0xff.toByte()
             val c5 = b[off + 5] and 0xff.toByte()
             val c6 = b[off + 6] and 0xff.toByte()
             val c7 = b[off + 7] and 0xff.toByte()
 
-            localCrc = localCrc xor (T[T8_3_start + c4] xor T[T8_2_start + c5]) xor (T[T8_1_start + c6] xor T[T8_0_start + c7])
+            localCrc = localCrc xor (T[T8_3_start + c4] xor T[T8_2_start + c5] xor T[T8_1_start + c6] xor T[T8_0_start + c7]).toInt()
 
             off += 8
             len -= 8
         }
 
-        for (i in 1..len) {
-            localCrc = ((localCrc ushr 8) xor T[((T8_0_start + ((localCrc xor b[off].toLong()) and 0xff)).toInt())])
+        for (i in 0 until len) {
+            localCrc = (localCrc ushr 8 xor T[T8_0_start + (localCrc xor b[off].toInt() and 0xff)].toInt())
             off += 1
         }
 
-        // Publish localCrc out to object
         crc = localCrc
     }
 
-    fun getValue(): Long = crc.inv() and 0xffffffffL
+    fun getValue(): Int = crc.inv() and 0xffffffff.toInt()
 
     fun update(b: Int) {
-        crc = (crc ushr 8) xor (T[(T8_0_start + ((crc xor b.toLong()) and 0xff)).toInt()])
+        crc = crc ushr 8 xor T[(T8_0_start + ((crc xor b) and 0xff))].toInt()
     }
 
     companion object {

--- a/runtime/hashing/common/test/aws/smithy/kotlin/runtime/hashing/Crc32cTest.kt
+++ b/runtime/hashing/common/test/aws/smithy/kotlin/runtime/hashing/Crc32cTest.kt
@@ -60,4 +60,24 @@ class Crc32cTest {
         crc.digest()
         assertEquals(0U, crc.digestValue()) // checksum should be reset
     }
+
+    @Test
+    fun testNonAsciiInput() {
+        val crc = Crc32c()
+        val input = byteArrayOf(0)
+        crc.update(input, 0, 1)
+        val bytes = crc.digest()
+
+        assertEquals("Un1TUQ==", bytes.encodeBase64String())
+    }
+
+    @Test
+    fun testLargeInput() {
+        val crc = Crc32c()
+        val input = ByteArray(1024) { 0 }
+        crc.update(input, 0, input.size)
+
+        val bytes = crc.digest()
+        assertEquals("7q7efA==", bytes.encodeBase64String())
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

During flexible checksums testing, a bug was discovered in the CRC32c hash function when trying to hash more than 7 bytes at a time. The elements were being cast `toByte()`, truncating information and leading to incorrect output. 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change ensures that CRC32C outputs the correct value when `update()` is called with a `length` greater than 7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
