### PR TITLE
fix(rt): Crc32C incorrect results on negative inputs longer than 7 bytes

### DIFF
--- a/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
+++ b/runtime/hashing/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.hashing
 
 import aws.smithy.kotlin.runtime.util.InternalApi
-import kotlin.experimental.and
 
 /**
  * Compute the CRC32C hash of the current [ByteArray]
@@ -82,10 +81,10 @@ private class CRC32CImpl {
             val c3 = (b[off + 3].toInt() xor localCrc) and 0xff
             localCrc = (T[T8_7_start + c0] xor T[T8_6_start + c1] xor T[T8_5_start + c2] xor T[T8_4_start + c3]).toInt()
 
-            val c4 = b[off + 4] and 0xff.toByte()
-            val c5 = b[off + 5] and 0xff.toByte()
-            val c6 = b[off + 6] and 0xff.toByte()
-            val c7 = b[off + 7] and 0xff.toByte()
+            val c4 = b[off + 4].toInt() and 0xff
+            val c5 = b[off + 5].toInt() and 0xff
+            val c6 = b[off + 6].toInt() and 0xff
+            val c7 = b[off + 7].toInt() and 0xff
 
             localCrc = localCrc xor (T[T8_3_start + c4] xor T[T8_2_start + c5] xor T[T8_1_start + c6] xor T[T8_0_start + c7]).toInt()
 
@@ -102,10 +101,6 @@ private class CRC32CImpl {
     }
 
     fun getValue(): Int = crc.inv()
-
-    fun update(b: Int) {
-        crc = crc ushr 8 xor T[(T8_0_start + ((crc xor b) and 0xff))].toInt()
-    }
 
     companion object {
         private const val T8_0_start: Int = 0 * 256

--- a/runtime/hashing/common/test/aws/smithy/kotlin/runtime/hashing/Crc32cTest.kt
+++ b/runtime/hashing/common/test/aws/smithy/kotlin/runtime/hashing/Crc32cTest.kt
@@ -80,4 +80,14 @@ class Crc32cTest {
         val bytes = crc.digest()
         assertEquals("7q7efA==", bytes.encodeBase64String())
     }
+
+    @Test
+    fun testNegativeByteInput() {
+        val crc = Crc32c()
+        val input = ByteArray(1024) { -1 }
+        crc.update(input)
+
+        val bytes = crc.digest()
+        assertEquals("R+XN5A==", bytes.encodeBase64String())
+    }
 }


### PR DESCRIPTION
## Issue \#
N/A

## Description of changes
A [previous PR](https://github.com/awslabs/smithy-kotlin/pull/766) was merged to fix a bug in the CRC32C implementation. When inputs longer than 7 bytes were used, the algorithm produced incorrect results due to incorrectly casting elements to `Byte`. 

This was fixed in the previous PR, but some `toByte` casts were overlooked. These are causing an IndexOutOfBoundsException only when negative bytes are provided as input. Example:
```kotlin
val byte: Byte = -1 
byte and 0xff.toByte() // -1
byte.toInt() and 0xff // 255, the expected output
```

This PR fixes the issue by removing all `.toByte()` casts. It also removes an unused function `update(b: Int)` from the implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
