### PR TITLE
feat: interceptor config

### DIFF
--- a/docs/design/interceptors.md
+++ b/docs/design/interceptors.md
@@ -364,7 +364,12 @@ public interface Interceptor<
 /**
  * [Interceptor] context used for all phases that only have access to the operation input (request)
  */
-public interface RequestInterceptorContext<I> : Attributes {
+public interface RequestInterceptorContext<I> {
+  
+  /**
+   * The [ExecutionContext] used to drive the execution of a single request/response
+   */
+  public val executionContext: ExecutionContext
 
     /**
      * Retrieve the modeled request for the operation being invoked

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/InterceptorExecutor.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/InterceptorExecutor.kt
@@ -127,7 +127,7 @@ internal class InterceptorExecutor<I, O>(
         }
     }
 
-    fun modifyBeforeSerialization(input: I): I {
+    suspend fun modifyBeforeSerialization(input: I): I {
         val context = HttpInputInterceptorContext(input as Any, execContext)
         val modified = interceptors.fold(context) { ctx, interceptor ->
             val modified = interceptor.modifyBeforeSerialization(ctx)
@@ -186,7 +186,7 @@ internal class InterceptorExecutor<I, O>(
         interceptor.readAfterSerialization(context)
     }
 
-    fun modifyBeforeRetryLoop(request: HttpRequest): HttpRequest =
+    suspend fun modifyBeforeRetryLoop(request: HttpRequest): HttpRequest =
         modifyHttpRequestHook(request) { interceptor, context ->
             interceptor.modifyBeforeRetryLoop(context)
         }
@@ -201,7 +201,7 @@ internal class InterceptorExecutor<I, O>(
         }
     }
 
-    fun modifyBeforeSigning(request: HttpRequest): HttpRequest =
+    suspend fun modifyBeforeSigning(request: HttpRequest): HttpRequest =
         modifyHttpRequestHook(request) { interceptor, context ->
             interceptor.modifyBeforeSigning(context)
         }
@@ -214,7 +214,7 @@ internal class InterceptorExecutor<I, O>(
         interceptor.readAfterSigning(context)
     }
 
-    fun modifyBeforeTransmit(request: HttpRequest): HttpRequest =
+    suspend fun modifyBeforeTransmit(request: HttpRequest): HttpRequest =
         modifyHttpRequestHook(request) { interceptor, context ->
             interceptor.modifyBeforeTransmit(context)
         }
@@ -228,7 +228,7 @@ internal class InterceptorExecutor<I, O>(
             interceptor.readAfterTransmit(context)
         }
 
-    fun modifyBeforeDeserialization(call: HttpCall): HttpResponse {
+    suspend fun modifyBeforeDeserialization(call: HttpCall): HttpResponse {
         val input = checkNotNull(_lastInput)
         val context = HttpProtocolResponseInterceptorContext(input as Any, call.request, call.response, execContext)
         val modified = runCatching {
@@ -252,7 +252,7 @@ internal class InterceptorExecutor<I, O>(
         interceptors.forEach { interceptor -> interceptor.readAfterDeserialization(context) }
     }
 
-    fun modifyBeforeAttemptCompletion(result: Result<O>, httpRequest: HttpRequest, httpResponse: HttpResponse?): Result<O> {
+    suspend fun modifyBeforeAttemptCompletion(result: Result<O>, httpRequest: HttpRequest, httpResponse: HttpResponse?): Result<O> {
         val input = checkNotNull(_lastInput)
 
         @Suppress("UNCHECKED_CAST")
@@ -286,7 +286,7 @@ internal class InterceptorExecutor<I, O>(
         return readResult.getOrThrow()
     }
 
-    fun modifyBeforeCompletion(result: Result<O>): Result<O> {
+    suspend fun modifyBeforeCompletion(result: Result<O>): Result<O> {
         // SAFETY: If we started executing an operation at all the input will be set at least once
         val input = checkNotNull(_lastInput)
 

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/InterceptorExecutor.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/interceptors/InterceptorExecutor.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.http.operation.OperationTypeInfo
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
-import aws.smithy.kotlin.runtime.util.Attributes
 import kotlin.reflect.KClass
 
 // Various contexts for each hook based on available information.
@@ -25,36 +24,36 @@ import kotlin.reflect.KClass
 
 private data class HttpInputInterceptorContext<I>(
     override var request: I,
-    private val executionContext: ExecutionContext,
-) : RequestInterceptorContext<I>, Attributes by executionContext
+    override val executionContext: ExecutionContext,
+) : RequestInterceptorContext<I>
 
 private data class HttpProtocolRequestInterceptorContext<I>(
     override val request: I,
     override var protocolRequest: HttpRequest,
-    private val executionContext: ExecutionContext,
-) : ProtocolRequestInterceptorContext<I, HttpRequest>, Attributes by executionContext
+    override val executionContext: ExecutionContext,
+) : ProtocolRequestInterceptorContext<I, HttpRequest>
 
 private data class HttpProtocolResponseInterceptorContext<I>(
     override val request: I,
     override val protocolRequest: HttpRequest,
     override var protocolResponse: HttpResponse,
-    private val executionContext: ExecutionContext,
-) : ProtocolResponseInterceptorContext<I, HttpRequest, HttpResponse>, Attributes by executionContext
+    override val executionContext: ExecutionContext,
+) : ProtocolResponseInterceptorContext<I, HttpRequest, HttpResponse>
 
 private data class HttpAttemptInterceptorContext<I, O>(
     override val request: I,
     override var response: Result<O>,
     override val protocolRequest: HttpRequest,
     override val protocolResponse: HttpResponse?,
-    private val executionContext: ExecutionContext,
-) : ResponseInterceptorContext<I, O, HttpRequest, HttpResponse?>, Attributes by executionContext
+    override val executionContext: ExecutionContext,
+) : ResponseInterceptorContext<I, O, HttpRequest, HttpResponse?>
 
 private data class HttpInputOutputInterceptorContext<I, O>(
     override val request: I,
     override var response: Result<O>,
     private val call: HttpCall,
-    private val executionContext: ExecutionContext,
-) : ResponseInterceptorContext<I, O, HttpRequest, HttpResponse>, Attributes by executionContext {
+    override val executionContext: ExecutionContext,
+) : ResponseInterceptorContext<I, O, HttpRequest, HttpResponse> {
 
     override val protocolRequest: HttpRequest = call.request
     override val protocolResponse: HttpResponse = call.response
@@ -65,8 +64,8 @@ private data class HttpFinalInterceptorContext<I, O>(
     override var response: Result<O>,
     override val protocolRequest: HttpRequest?,
     override val protocolResponse: HttpResponse?,
-    private val executionContext: ExecutionContext,
-) : ResponseInterceptorContext<I, O, HttpRequest?, HttpResponse?>, Attributes by executionContext
+    override val executionContext: ExecutionContext,
+) : ResponseInterceptorContext<I, O, HttpRequest?, HttpResponse?>
 
 // TODO - investigate propagating Any as upper bounds for SdkHttpOperation <I,O> generics
 /**

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -43,7 +43,7 @@ public class SdkHttpOperation<I, O> internal constructor(
      * is the former is internal only whereas the latter is external customer facing. Middleware is also allowed to
      * suspend whereas interceptors are meant to be executed quickly.
      */
-    internal val interceptors = mutableListOf<HttpInterceptor>()
+    public val interceptors: MutableList<HttpInterceptor> = mutableListOf()
 
     /**
      * Install a middleware into this operation's execution stack

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTypeValidationTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTypeValidationTest.kt
@@ -21,7 +21,7 @@ class HttpInterceptorTypeValidationTest {
     @Test
     fun testModifyBeforeSerializationTypeFailure() = runTest {
         val i1 = object : HttpInterceptor {
-            override fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
+            override suspend fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
                 val input = assertIs<TestInput>(context.request)
                 assertEquals("initial", input.value)
                 return TestInput("modified")
@@ -29,7 +29,7 @@ class HttpInterceptorTypeValidationTest {
         }
 
         val i2 = object : HttpInterceptor {
-            override fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
+            override suspend fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
                 val input = assertIs<TestInput>(context.request)
                 assertEquals("modified", input.value)
                 return TestOutput("wrong")
@@ -49,14 +49,14 @@ class HttpInterceptorTypeValidationTest {
     @Test
     fun testModifyBeforeAttemptCompletionTypeFailure() = runTest {
         val i1 = object : HttpInterceptor {
-            override fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
+            override suspend fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
                 assertIs<TestOutput>(context.response.getOrThrow())
                 return Result.success(TestOutput("modified"))
             }
         }
 
         val i2 = object : HttpInterceptor {
-            override fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
+            override suspend fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
                 val output = assertIs<TestOutput>(context.response.getOrThrow())
                 assertEquals("modified", output.value)
                 return Result.success("wrong")
@@ -76,14 +76,14 @@ class HttpInterceptorTypeValidationTest {
     @Test
     fun testModifyBeforeCompletionTypeFailure() = runTest {
         val i1 = object : HttpInterceptor {
-            override fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
+            override suspend fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
                 assertIs<TestOutput>(context.response.getOrThrow())
                 return Result.success(TestOutput("modified"))
             }
         }
 
         val i2 = object : HttpInterceptor {
-            override fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
+            override suspend fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
                 val output = assertIs<TestOutput>(context.response.getOrThrow())
                 assertEquals("modified", output.value)
                 return Result.success("wrong")

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/operation/TracingTestInterceptor.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/operation/TracingTestInterceptor.kt
@@ -73,7 +73,7 @@ open class TracingTestInterceptor(
         trace("readBeforeExecution")
     }
 
-    override fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
+    override suspend fun modifyBeforeSerialization(context: RequestInterceptorContext<Any>): Any {
         trace("modifyBeforeSerialization")
         return super.modifyBeforeSerialization(context)
     }
@@ -88,7 +88,7 @@ open class TracingTestInterceptor(
         super.readAfterSerialization(context)
     }
 
-    override fun modifyBeforeRetryLoop(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+    override suspend fun modifyBeforeRetryLoop(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         trace("modifyBeforeRetryLoop")
         return super.modifyBeforeRetryLoop(context)
     }
@@ -98,7 +98,7 @@ open class TracingTestInterceptor(
         super.readBeforeAttempt(context)
     }
 
-    override fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+    override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         trace("modifyBeforeSigning")
         return super.modifyBeforeSigning(context)
     }
@@ -113,7 +113,7 @@ open class TracingTestInterceptor(
         super.readAfterSigning(context)
     }
 
-    override fun modifyBeforeTransmit(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+    override suspend fun modifyBeforeTransmit(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         trace("modifyBeforeTransmit")
         return super.modifyBeforeTransmit(context)
     }
@@ -128,7 +128,7 @@ open class TracingTestInterceptor(
         super.readAfterTransmit(context)
     }
 
-    override fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
+    override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
         trace("modifyBeforeDeserialization")
         return super.modifyBeforeDeserialization(context)
     }
@@ -143,7 +143,7 @@ open class TracingTestInterceptor(
         super.readAfterDeserialization(context)
     }
 
-    override fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
+    override suspend fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>): Result<Any> {
         trace("modifyBeforeAttemptCompletion")
         return super.modifyBeforeAttemptCompletion(context)
     }
@@ -153,7 +153,7 @@ open class TracingTestInterceptor(
         super.readAfterAttempt(context)
     }
 
-    override fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
+    override suspend fun modifyBeforeCompletion(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>): Result<Any> {
         trace("modifyBeforeCompletion")
         return super.modifyBeforeCompletion(context)
     }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/Interceptor.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/Interceptor.kt
@@ -53,7 +53,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [modifyBeforeCompletion]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeSerialization(context: RequestInterceptorContext<Input>): Input = context.request
+    public suspend fun modifyBeforeSerialization(context: RequestInterceptorContext<Input>): Input = context.request
 
     /**
      * A hook called before the input message is marshalled into a (protocol) transport message.
@@ -89,7 +89,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [modifyBeforeCompletion]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeRetryLoop(
+    public suspend fun modifyBeforeRetryLoop(
         context: ProtocolRequestInterceptorContext<Input, ProtocolRequest>,
     ): ProtocolRequest =
         context.protocolRequest
@@ -125,7 +125,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [modifyBeforeAttemptCompletion]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeSigning(
+    public suspend fun modifyBeforeSigning(
         context: ProtocolRequestInterceptorContext<Input, ProtocolRequest>,
     ): ProtocolRequest =
         context.protocolRequest
@@ -172,7 +172,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [modifyBeforeAttemptCompletion]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeTransmit(
+    public suspend fun modifyBeforeTransmit(
         context: ProtocolRequestInterceptorContext<Input, ProtocolRequest>,
     ): ProtocolRequest =
         context.protocolRequest
@@ -219,7 +219,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [modifyBeforeAttemptCompletion]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeDeserialization(
+    public suspend fun modifyBeforeDeserialization(
         context: ProtocolResponseInterceptorContext<Input, ProtocolRequest, ProtocolResponse>,
     ): ProtocolResponse =
         context.protocolResponse
@@ -269,7 +269,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [readAfterAttempt]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Input, Output, ProtocolRequest, ProtocolResponse?>): Result<Output> =
+    public suspend fun modifyBeforeAttemptCompletion(context: ResponseInterceptorContext<Input, Output, ProtocolRequest, ProtocolResponse?>): Result<Output> =
         context.response
 
     /**
@@ -307,7 +307,7 @@ public interface Interceptor<
      * **Error Behavior**: If errors are raised by this hook, execution will jump to [readAfterExecution]
      * with the raised error as the [ResponseInterceptorContext.response] result.
      */
-    public fun modifyBeforeCompletion(context: ResponseInterceptorContext<Input, Output, ProtocolRequest?, ProtocolResponse?>): Result<Output> =
+    public suspend fun modifyBeforeCompletion(context: ResponseInterceptorContext<Input, Output, ProtocolRequest?, ProtocolResponse?>): Result<Output> =
         context.response
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/Interceptor.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/client/Interceptor.kt
@@ -5,8 +5,6 @@
 
 package aws.smithy.kotlin.runtime.client
 
-import aws.smithy.kotlin.runtime.util.Attributes
-
 /**
  * An interceptor allows injecting code into the request execution pipeline of a generated SDK client.
  *
@@ -330,7 +328,12 @@ public interface Interceptor<
 /**
  * [Interceptor] context used for all phases that only have access to the operation input (request)
  */
-public interface RequestInterceptorContext<I> : Attributes {
+public interface RequestInterceptorContext<I> {
+
+    /**
+     * The [ExecutionContext] used to drive the execution of a single request/response
+     */
+    public val executionContext: ExecutionContext
 
     /**
      * Retrieve the modeled request for the operation being invoked

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -47,6 +47,7 @@ object RuntimeTypes {
             val HttpRequestBuilder = runtimeSymbol("HttpRequestBuilder", KotlinDependency.HTTP, "request")
             val url = runtimeSymbol("url", KotlinDependency.HTTP, "request")
             val headers = runtimeSymbol("headers", KotlinDependency.HTTP, "request")
+            val toBuilder = runtimeSymbol("toBuilder", KotlinDependency.HTTP, "request")
         }
 
         object Response {
@@ -65,6 +66,7 @@ object RuntimeTypes {
             val HttpDeserialize = runtimeSymbol("HttpDeserialize", KotlinDependency.HTTP, "operation")
             val HttpSerialize = runtimeSymbol("HttpSerialize", KotlinDependency.HTTP, "operation")
             val SdkHttpOperation = runtimeSymbol("SdkHttpOperation", KotlinDependency.HTTP, "operation")
+            val SdkHttpRequest = runtimeSymbol("SdkHttpRequest", KotlinDependency.HTTP, "operation")
             val OperationRequest = runtimeSymbol("OperationRequest", KotlinDependency.HTTP, "operation")
             val context = runtimeSymbol("context", KotlinDependency.HTTP, "operation")
             val roundTrip = runtimeSymbol("roundTrip", KotlinDependency.HTTP, "operation")
@@ -144,6 +146,11 @@ object RuntimeTypes {
         object Smithy {
             val Document = runtimeSymbol("Document", KotlinDependency.CORE, "smithy")
             val buildDocument = runtimeSymbol("buildDocument", KotlinDependency.CORE, "smithy")
+        }
+
+        object Client {
+            val RequestInterceptorContext = runtimeSymbol("RequestInterceptorContext", KotlinDependency.CORE, "client")
+            val ProtocolRequestInterceptorContext = runtimeSymbol("ProtocolRequestInterceptorContext", KotlinDependency.CORE, "client")
         }
     }
 
@@ -245,11 +252,12 @@ object RuntimeTypes {
 
     object Tracing {
         object Core {
-            val DefaultTracer = runtimeSymbol("DefaultTracer", KotlinDependency.CORE, "tracing")
-            val LoggingTraceProbe = runtimeSymbol("LoggingTraceProbe", KotlinDependency.CORE, "tracing")
-            val TraceProbe = runtimeSymbol("TraceProbe", KotlinDependency.CORE, "tracing")
-            val Tracer = runtimeSymbol("Tracer", KotlinDependency.CORE, "tracing")
-            val withRootTraceSpan = runtimeSymbol("withRootTraceSpan", KotlinDependency.CORE, "tracing")
+            val debug = runtimeSymbol("debug", KotlinDependency.TRACING_CORE)
+            val DefaultTracer = runtimeSymbol("DefaultTracer", KotlinDependency.TRACING_CORE)
+            val LoggingTraceProbe = runtimeSymbol("LoggingTraceProbe", KotlinDependency.TRACING_CORE)
+            val TraceProbe = runtimeSymbol("TraceProbe", KotlinDependency.TRACING_CORE)
+            val Tracer = runtimeSymbol("Tracer", KotlinDependency.TRACING_CORE)
+            val withRootTraceSpan = runtimeSymbol("withRootTraceSpan", KotlinDependency.TRACING_CORE)
         }
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -92,6 +92,9 @@ object RuntimeTypes {
             val HttpClientEngine = runtimeSymbol("HttpClientEngine", KotlinDependency.HTTP, "engine")
             val HttpClientEngineConfig = runtimeSymbol("HttpClientEngineConfig", KotlinDependency.HTTP, "engine")
         }
+        object Interceptors {
+            val HttpInterceptor = runtimeSymbol("HttpInterceptor", KotlinDependency.HTTP, "interceptors")
+        }
     }
 
     object Core {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -36,10 +36,42 @@ object KotlinTypes {
 
     object Collections {
         val List: Symbol = builtInSymbol("List", "kotlin.collections")
+        val MutableList: Symbol = builtInSymbol("MutableList", "kotlin.collections")
         val Set: Symbol = builtInSymbol("Set", "kotlin.collections")
         val Map: Symbol = builtInSymbol("Map", "kotlin.collections")
         val mutableListOf: Symbol = builtInSymbol("mutableListOf", "kotlin.collections")
         val mutableMapOf: Symbol = builtInSymbol("mutableMapOf", "kotlin.collections")
+
+        private fun listType(
+            listType: Symbol,
+            target: Symbol,
+            isNullable: Boolean = false,
+            default: String? = null,
+        ): Symbol = buildSymbol {
+            name = "${listType.fullName}<${target.fullName}>"
+            nullable = isNullable
+            defaultValue = default
+            reference(listType)
+            reference(target)
+        }
+
+        /**
+         * Convenience function to get a `List<target>` as a symbol
+         */
+        fun list(
+            target: Symbol,
+            isNullable: Boolean = false,
+            default: String? = null,
+        ): Symbol = listType(List, target, isNullable, default)
+
+        /**
+         * Convenience function to get a `MutableList<target>` as a symbol
+         */
+        fun mutableList(
+            target: Symbol,
+            isNullable: Boolean = false,
+            default: String? = null,
+        ): Symbol = listType(MutableList, target, isNullable, default)
     }
 
     object Jvm {

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
@@ -45,6 +45,7 @@ class ClientConfigGenerator(
             add(KotlinClientRuntimeConfigProperty.SdkLogMode)
             if (context.protocolGenerator?.applicationProtocol?.isHttpProtocol == true) {
                 add(KotlinClientRuntimeConfigProperty.HttpClientEngine)
+                add(KotlinClientRuntimeConfigProperty.HttpInterceptors)
             }
             if (context.shape != null && context.shape.hasIdempotentTokenMember(context.model)) {
                 add(KotlinClientRuntimeConfigProperty.IdempotencyTokenProvider)
@@ -205,6 +206,7 @@ class ClientConfigGenerator(
                     .forEach { prop ->
                         prop.documentation?.let { ctx.writer.dokka(it) }
                         write("public var #L: #D", prop.propertyName, prop.symbol)
+                        write("")
                     }
                 write("")
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGenerator.kt
@@ -208,7 +208,6 @@ class ClientConfigGenerator(
                         write("public var #L: #D", prop.propertyName, prop.symbol)
                         write("")
                     }
-                write("")
 
                 write("@PublishedApi")
                 write("internal fun build(): #configClass.name:L = #configClass.name:L(this)")

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
@@ -34,7 +34,7 @@ class ResolveEndpointMiddlewareGenerator(
     private val renderPostResolution: () -> Unit = {},
 ) {
     companion object {
-        const val CLASS_NAME = "ResolveEndpointMiddleware"
+        const val CLASS_NAME = "ResolveEndpoint"
 
         fun getSymbol(settings: KotlinSettings): Symbol =
             buildSymbol {
@@ -44,12 +44,12 @@ class ResolveEndpointMiddlewareGenerator(
     }
 
     fun render() {
-        writer.openBlock("internal class #L<I, O>(", CLASS_NAME)
+        writer.openBlock("internal class #L<I>(", CLASS_NAME)
         renderConstructorParams()
-        writer.closeAndOpenBlock(") : #T<I, O> {", RuntimeTypes.Http.Operation.InlineMiddleware)
+        writer.closeAndOpenBlock("): #T {", RuntimeTypes.Http.Interceptors.HttpInterceptor)
         renderClassMembers()
         writer.write("")
-        renderInstall()
+        renderBody()
         writer.closeBlock("}")
     }
 
@@ -59,30 +59,35 @@ class ResolveEndpointMiddlewareGenerator(
     }
 
     private fun renderClassMembers() {
-        writer.write("private lateinit var endpoint: #T", RuntimeTypes.Http.Endpoints.Endpoint)
+        writer.write("private lateinit var params: #T", EndpointParametersGenerator.getSymbol(ctx.settings))
     }
 
-    private fun renderInstall() {
-        writer.withBlock("override fun install(op: #T<I, O>) {", "}", RuntimeTypes.Http.Operation.SdkHttpOperation) {
-            renderInitialize()
-            write("")
-            renderMutate()
+    private fun renderBody() {
+        writer.withBlock(
+            "override fun readBeforeSerialization(context: #T<Any>) {",
+            "}",
+            RuntimeTypes.Core.Client.RequestInterceptorContext,
+        ) {
+            write("@Suppress(#S)", "UNCHECKED_CAST")
+            write("val input = context.request as I")
+            write("params = #T { buildParams(input) }", EndpointParametersGenerator.getSymbol(ctx.settings))
         }
-    }
 
-    private fun renderInitialize() {
-        writer.withBlock("op.execution.initialize.intercept { req, next ->", "}") {
-            write("val params = #T { buildParams(req.subject) }", EndpointParametersGenerator.getSymbol(ctx.settings))
-            write("endpoint = endpointProvider.resolveEndpoint(params)")
-            write("next.call(req)")
-        }
-    }
-
-    private fun renderMutate() {
-        writer.withBlock("op.execution.mutate.intercept { req, next ->", "}") {
+        writer.write("")
+        writer.withBlock(
+            "override suspend fun modifyBeforeRetryLoop(context: #1T<Any, #2T>): #2T {",
+            "}",
+            RuntimeTypes.Core.Client.ProtocolRequestInterceptorContext,
+            RuntimeTypes.Http.Request.HttpRequest,
+        ) {
+            // import aws.smithy.kotlin.runtime.tracing.debug
+            write("val endpoint = endpointProvider.resolveEndpoint(params)")
+            write("#T.#T<$CLASS_NAME<*>>{ \"resolved endpoint: \$endpoint\"}", RuntimeTypes.KotlinCoroutines.coroutineContext, RuntimeTypes.Tracing.Core.debug)
+            write("val reqBuilder = context.protocolRequest.#T()", RuntimeTypes.Http.Request.toBuilder)
+            write("val req = #T(context.executionContext, reqBuilder)", RuntimeTypes.Http.Operation.SdkHttpRequest)
             write("#T(req, endpoint)", RuntimeTypes.Http.Endpoints.setResolvedEndpoint)
             renderPostResolution()
-            write("next.call(req)")
+            write("return req.subject.build()")
         }
     }
 }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
@@ -80,9 +80,8 @@ class ResolveEndpointMiddlewareGenerator(
             RuntimeTypes.Core.Client.ProtocolRequestInterceptorContext,
             RuntimeTypes.Http.Request.HttpRequest,
         ) {
-            // import aws.smithy.kotlin.runtime.tracing.debug
             write("val endpoint = endpointProvider.resolveEndpoint(params)")
-            write("#T.#T<$CLASS_NAME<*>>{ \"resolved endpoint: \$endpoint\"}", RuntimeTypes.KotlinCoroutines.coroutineContext, RuntimeTypes.Tracing.Core.debug)
+            write("#T.#T<$CLASS_NAME<*>>{ \"resolved endpoint: \$endpoint\" }", RuntimeTypes.KotlinCoroutines.coroutineContext, RuntimeTypes.Tracing.Core.debug)
             write("val reqBuilder = context.protocolRequest.#T()", RuntimeTypes.Http.Request.toBuilder)
             write("val req = #T(context.executionContext, reqBuilder)", RuntimeTypes.Http.Operation.SdkHttpRequest)
             write("#T(req, endpoint)", RuntimeTypes.Http.Endpoints.setResolvedEndpoint)

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -121,6 +121,7 @@ abstract class HttpProtocolClientGenerator(
         writer.openBlock("override #L {", signature)
             .call { renderOperationSetup(writer, opIndex, op) }
             .call { renderOperationMiddleware(op, writer) }
+            .call { renderFinalizeBeforeExecute(writer, opIndex, op) }
             .call { renderOperationExecute(writer, opIndex, op) }
             .closeBlock("}")
     }
@@ -198,9 +199,12 @@ abstract class HttpProtocolClientGenerator(
             }
         }
 
-        writer.write("op.interceptors.addAll(config.interceptors)")
-
         writer.write("op.execution.retryStrategy = config.retryStrategy")
+    }
+
+    protected open fun renderFinalizeBeforeExecute(writer: KotlinWriter, opIndex: OperationIndex, op: OperationShape) {
+        // add config interceptors last (after all middleware and SDK defaults have had a chance to register)
+        writer.write("op.interceptors.addAll(config.interceptors)")
     }
 
     /**

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -198,6 +198,8 @@ abstract class HttpProtocolClientGenerator(
             }
         }
 
+        writer.write("op.interceptors.addAll(config.interceptors)")
+
         writer.write("op.execution.retryStrategy = config.retryStrategy")
     }
 

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ProtocolMiddleware.kt
@@ -8,6 +8,9 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.model.shapes.OperationShape
 
+// TODO - we should probably rename this, it's not restricted to middleware really since render() allows you to do
+// whatever you need/want to register and interact with an operation. This includes not being a middleware
+// at all (e.g. HttpInterceptor). OperationCustomization?
 /**
  * Interface that allows middleware to be registered and configured with the generated protocol client
  * How this interface is used is entirely protocol/generator dependent

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
@@ -21,13 +21,13 @@ class ResolveEndpointMiddleware : ProtocolMiddleware {
     override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
         val inputSymbol = ctx.symbolProvider.toSymbol(ctx.model.expectShape(op.inputShape))
         writer.withBlock(
-            "op.interceptors.add(#T<#T>(config.endpointProvider) {",
+            "op.interceptors.add(#T<#T>(config.endpointProvider) { ein -> ",
             "})",
             ResolveEndpointMiddlewareGenerator.getSymbol(ctx.settings),
             inputSymbol,
         ) {
             ctx.service.getEndpointRules()?.let { rules ->
-                EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "it.").render()
+                EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "ein.").render()
             }
         }
     }

--- a/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
+++ b/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/ResolveEndpointMiddleware.kt
@@ -19,10 +19,15 @@ class ResolveEndpointMiddleware : ProtocolMiddleware {
     override val name: String = "ResolveEndpoint"
 
     override fun render(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
-        val middlewareSymbol = ResolveEndpointMiddlewareGenerator.getSymbol(ctx.settings)
-        writer.withBlock("op.install(#T(config.endpointProvider) {", "})", middlewareSymbol) {
+        val inputSymbol = ctx.symbolProvider.toSymbol(ctx.model.expectShape(op.inputShape))
+        writer.withBlock(
+            "op.interceptors.add(#T<#T>(config.endpointProvider) {",
+            "})",
+            ResolveEndpointMiddlewareGenerator.getSymbol(ctx.settings),
+            inputSymbol,
+        ) {
             ctx.service.getEndpointRules()?.let { rules ->
-                EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "input.").render()
+                EndpointParameterBindingGenerator(ctx.model, ctx.service, writer, op, rules, "it.").render()
             }
         }
     }

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -153,23 +153,23 @@ public class Config private constructor(builder: Builder) {
         contents.shouldContain(expectedCtor)
 
         val expectedProps = """
-        public var boolProp: Boolean? = null
-        /**
-         * non-null-int
-         */
-        public var intProp: Int = 1
-        public var nullIntProp: Int? = null
-        public var stringProp: String? = null
+    public val boolProp: Boolean? = builder.boolProp
+    public val intProp: Int = builder.intProp
+    public val nullIntProp: Int? = builder.nullIntProp
+    public val stringProp: String? = builder.stringProp
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilderProps = """
         public var boolProp: Boolean? = null
+
         /**
          * non-null-int
          */
         public var intProp: Int = 1
+
         public var nullIntProp: Int? = null
+
         public var stringProp: String? = null
 """
         contents.shouldContainWithDiff(expectedBuilderProps)
@@ -342,9 +342,13 @@ public class Config private constructor(builder: Builder) {
 
         val expectedImplProps = """
         public var defaultFoo: Foo = DefaultFoo
+
         public var nullFoo: Foo? = null
+
         public var requiredDefaultedFoo: Foo? = null
+
         public var requiredFoo: Foo? = null
+
         public var requiredFoo2: Foo? = null
 """
         contents.shouldContainWithDiff(expectedImplProps)

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ClientConfigGeneratorTest.kt
@@ -46,6 +46,7 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
     override val httpClientEngine: HttpClientEngine? = builder.httpClientEngine
     public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider? = builder.idempotencyTokenProvider
+    public val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     public val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
     override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, "${TestModelDefault.SERVICE_NAME}")
@@ -60,20 +61,32 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
          * client will not close it when the client is closed.
          */
         public var httpClientEngine: HttpClientEngine? = null
+
         /**
          * The endpoint provider used to determine where to make service requests.
          */
         public var endpointProvider: EndpointProvider? = null
+
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
          * that represent idempotent tokens when not explicitly set by the caller using this generator.
          */
         public var idempotencyTokenProvider: IdempotencyTokenProvider? = null
+
+        /**
+         * Add an [aws.smithy.kotlin.runtime.client.Interceptor] that will have access to read and modify
+         * the request and response objects as they are processed by the SDK.
+         * Interceptors added using this method are executed in the order they are configured and are always
+         * later than any added automatically by the SDK.
+         */
+        public var interceptors: kotlin.collections.MutableList<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = kotlin.collections.mutableListOf()
+
         /**
          * The [RetryStrategy] implementation to use for service calls. All API calls will be wrapped by the
          * strategy.
          */
         public var retryStrategy: RetryStrategy? = null
+
         /**
          * Configure events that will be logged. By default clients will not output
          * raw requests or responses. Use this setting to opt-in to additional debug logging.
@@ -85,6 +98,7 @@ public class Config private constructor(builder: Builder): HttpClientConfig, Ide
          * debug purposes.
          */
         public var sdkLogMode: SdkLogMode = SdkLogMode.Default
+
         /**
          * The tracer that is responsible for creating trace spans and wiring them up to a tracing backend (e.g.,
          * a trace probe). By default, this will create a standard tracer that uses the service name for the root

--- a/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -88,6 +88,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFoo-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -107,6 +108,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooNoInput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -126,6 +128,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooNoOutput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -145,6 +148,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooStreamingInput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -164,6 +168,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooStreamingOutput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.execute(client, input, block)
@@ -183,6 +188,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooStreamingOutputNoInput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.execute(client, input, block)
@@ -202,6 +208,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooStreamingInputNoOutput-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -221,6 +228,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooNoRequired-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)
@@ -240,6 +248,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.execution.retryStrategy = config.retryStrategy
         op.install(MockMiddleware(configurationField1 = "testing"))
+        op.interceptors.addAll(config.interceptors)
         val rootSpan = config.tracer.createRootSpan("GetFooSomeRequired-${'$'}{op.context.sdkRequestId}")
         return coroutineContext.withRootTraceSpan(rootSpan) {
             op.roundTrip(client, input)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/122

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Refactor modify hooks to be `suspend`
* Add interceptors to client config
* Refactor endpoint resolver middleware to implement `HttpInterceptor`.
    * This is our first use case of "internal" interceptors. Everything other customization/default feature is implemented as a middleware. This refactor came about because the endpoint resolver needs the _final_ version of the operation input. The way interceptors are structured the `initialize` middleware phase comes _before_ `Interceptor.modifyBeforeSerialization`. They are effectively the same phase but the ordering means that `initialize` middleware cannot ever depend on the input type during this phase since it won't necessarily be the final value. Refactoring to make use of `Interceptor.readBeforeSerialization` (which guarantees no new modifications are coming after this hook fires) is the proper place to finally resolve endpoint parameters based on the input type.
    * This will likely change again in the near-ish future

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
