### PR TITLE
feat(rt): unsigned `aws-chunked`

### DIFF
--- a/.changes/af027b16-c6f7-4885-9835-1a75315860cf.json
+++ b/.changes/af027b16-c6f7-4885-9835-1a75315860cf.json
@@ -1,0 +1,5 @@
+{
+    "id": "af027b16-c6f7-4885-9835-1a75315860cf",
+    "type": "feature",
+    "description": "Add support for unsigned `aws-chunked` requests"
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
@@ -40,6 +40,11 @@ public sealed class HashSpecification {
     public object StreamingAws4HmacSha256PayloadWithTrailers : HashLiteral("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")
 
     /**
+     * The hash value used for streaming unsigned requests with trailers
+     */
+    public object StreamingUnsignedPayloadWithTrailers : HashLiteral("STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+
+    /**
      * The hash value should indicate ???
      */
     public object StreamingAws4HmacSha256Events : HashLiteral("STREAMING-AWS4-HMAC-SHA256-EVENTS")

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification.kt
@@ -45,7 +45,7 @@ public sealed class HashSpecification {
     public object StreamingUnsignedPayloadWithTrailers : HashLiteral("STREAMING-UNSIGNED-PAYLOAD-TRAILER")
 
     /**
-     * The hash value should indicate ???
+     * The hash value indicates that the streaming request is an event stream
      */
     public object StreamingAws4HmacSha256Events : HashLiteral("STREAMING-AWS4-HMAC-SHA256-EVENTS")
 

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
@@ -185,7 +185,7 @@ internal class AwsChunkedReader(
         }
 
         // append the body
-        unsignedChunk.write(bodyBuffer.readByteArray())
+        unsignedChunk.writeAll(bodyBuffer)
 
         return unsignedChunk
     }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
@@ -95,10 +95,7 @@ internal class AwsChunkedReader(
      */
     private suspend fun getFinalChunk(): SdkBuffer {
         // empty chunk
-        val lastChunk = checkNotNull(
-            if (signingConfig.isUnsigned) getUnsignedChunk(SdkBuffer())
-            else getSignedChunk(SdkBuffer())
-        )
+        val lastChunk = checkNotNull(if (signingConfig.isUnsigned) getUnsignedChunk(SdkBuffer()) else getSignedChunk(SdkBuffer()))
 
         // + any trailers
         if (!trailingHeaders.isEmpty()) {

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
@@ -71,7 +71,7 @@ internal class AwsChunkedReader(
         val nextChunk = when {
             stream.isClosedForRead() && hasLastChunkBeenSent -> null
             else -> {
-                var next = getSignedChunk()
+                var next = if (signingConfig.isUnsigned) getUnsignedChunk() else getSignedChunk()
                 if (next == null) {
                     check(stream.isClosedForRead()) { "Expected underlying reader to be closed" }
                     next = getFinalChunk()
@@ -95,7 +95,10 @@ internal class AwsChunkedReader(
      */
     private suspend fun getFinalChunk(): SdkBuffer {
         // empty chunk
-        val lastChunk = checkNotNull(getSignedChunk(SdkBuffer()))
+        val lastChunk = checkNotNull(
+            if (signingConfig.isUnsigned) getUnsignedChunk(SdkBuffer())
+            else getSignedChunk(SdkBuffer())
+        )
 
         // + any trailers
         if (!trailingHeaders.isEmpty()) {
@@ -106,7 +109,28 @@ internal class AwsChunkedReader(
     }
 
     /**
-     * Get an aws-chunked encoding of [data].
+     * Read a chunk from the underlying [stream], suspending until a whole chunk has been read OR the channel is exhausted.
+     * @return an SdkBuffer containing a chunk of data, or null if the channel is exhausted.
+     */
+    private suspend fun Stream.readChunk(): SdkBuffer? {
+        val sink = SdkBuffer()
+
+        // fill up to chunk size bytes
+        var remaining = CHUNK_SIZE_BYTES.toLong()
+        while (remaining > 0L) {
+            val rc = read(sink, remaining)
+            if (rc == -1L) break
+            remaining -= rc
+        }
+
+        return when (sink.size) {
+            0L -> null // delegate closed without reading any data
+            else -> sink
+        }
+    }
+
+    /**
+     * Get a signed aws-chunked encoding of [data].
      * If [data] is not set, read the next chunk from [delegate] and add hex-formatted chunk size and chunk signature to the front.
      * Note that this function will suspend until the whole chunk has been read OR the channel is exhausted.
      * The chunk structure is: `string(IntHexBase(chunk-size)) + ";chunk-signature=" + signature + \r\n + chunk-data + \r\n`
@@ -116,23 +140,7 @@ internal class AwsChunkedReader(
      * @return a buffer containing the chunked data or null if no data is available (channel is closed)
      */
     private suspend fun getSignedChunk(data: SdkBuffer? = null): SdkBuffer? {
-        val bodyBuffer = if (data == null) {
-            val sink = SdkBuffer()
-
-            // fill up to chunk size bytes
-            var remaining = CHUNK_SIZE_BYTES.toLong()
-            while (remaining > 0L) {
-                val rc = stream.read(sink, remaining)
-                if (rc == -1L) break
-                remaining -= rc
-            }
-            when (sink.size) {
-                0L -> null // delegate closed without reading any data
-                else -> sink
-            }
-        } else {
-            data
-        }
+        val bodyBuffer = data ?: stream.readChunk()
 
         // signer takes a ByteArray unfortunately...
         val chunkBody = bodyBuffer?.readByteArray() ?: return null
@@ -158,6 +166,34 @@ internal class AwsChunkedReader(
     }
 
     /**
+     * Get an unsigned aws-chunked encoding of [data].
+     * If [data] is not set, read the next chunk from [delegate] and add hex-formatted chunk size to the front.
+     * Note that this function will suspend until the whole chunk has been read OR the channel is exhausted.
+     * The unsigned chunk structure is: `string(IntHexBase(chunk-size)) + \r\n + chunk-data + \r\n`
+     *
+     * @param data the data which will be encoded to aws-chunked. if not provided, will default to
+     * reading up to [CHUNK_SIZE_BYTES] from [delegate].
+     * @return a buffer containing the chunked data or null if no data is available (channel is closed)
+     */
+    private suspend fun getUnsignedChunk(data: SdkBuffer? = null): SdkBuffer? {
+        val bodyBuffer = data ?: stream.readChunk()
+        bodyBuffer ?: return null
+
+        val unsignedChunk = SdkBuffer()
+
+        // headers
+        unsignedChunk.apply {
+            writeUtf8(bodyBuffer.size.toString(16))
+            writeUtf8("\r\n")
+        }
+
+        // append the body
+        unsignedChunk.write(bodyBuffer.readByteArray())
+
+        return unsignedChunk
+    }
+
+    /**
      * Get the trailing headers chunk. The grammar for trailing headers is:
      * trailing-header-A:value CRLF
      * trailing-header-B:value CRLF
@@ -172,7 +208,11 @@ internal class AwsChunkedReader(
         previousSignature = trailerSignature
 
         val trailerBody = SdkBuffer()
-        trailerBody.writeTrailers(trailingHeaders, trailerSignature.decodeToString())
+        trailerBody.writeTrailers(trailingHeaders)
+        if (!signingConfig.isUnsigned) {
+            trailerBody.writeTrailerSignature(trailerSignature.decodeToString())
+        }
+
         return trailerBody
     }
 
@@ -195,4 +235,6 @@ internal class AwsChunkedReader(
         signatureType = AwsSignatureType.HTTP_REQUEST_TRAILING_HEADERS // signature is for trailing headers
         hashSpecification = HashSpecification.CalculateFromPayload // calculate the hash from the trailing headers payload
     }.build()
+
+    private val AwsSigningConfig.isUnsigned: Boolean get() = hashSpecification == HashSpecification.StreamingUnsignedPayloadWithTrailers
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedReader.kt
@@ -173,8 +173,7 @@ internal class AwsChunkedReader(
      * @return a buffer containing the chunked data or null if no data is available (channel is closed)
      */
     private suspend fun getUnsignedChunk(data: SdkBuffer? = null): SdkBuffer? {
-        val bodyBuffer = data ?: stream.readChunk()
-        bodyBuffer ?: return null
+        val bodyBuffer = data ?: stream.readChunk() ?: return null
 
         val unsignedChunk = SdkBuffer()
 
@@ -182,10 +181,8 @@ internal class AwsChunkedReader(
         unsignedChunk.apply {
             writeUtf8(bodyBuffer.size.toString(16))
             writeUtf8("\r\n")
+            writeAll(bodyBuffer) // append the body
         }
-
-        // append the body
-        unsignedChunk.writeAll(bodyBuffer)
 
         return unsignedChunk
     }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
@@ -21,8 +21,7 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
 public const val CHUNK_SIZE_BYTES: Int = 65_536
 
 internal fun SdkBuffer.writeTrailers(
-    trailers: Headers,
-    signature: String,
+    trailers: Headers
 ) {
     trailers
         .entries()
@@ -33,6 +32,9 @@ internal fun SdkBuffer.writeTrailers(
             writeUtf8(entry.value.joinToString(",") { v -> v.trim() })
             writeUtf8("\r\n")
         }
+}
+
+internal fun SdkBuffer.writeTrailerSignature(signature: String) {
     writeUtf8("x-amz-trailer-signature:${signature}\r\n")
 }
 
@@ -48,7 +50,9 @@ internal val HttpBody.isEligibleForAwsChunkedStreaming: Boolean
  */
 internal val AwsSigningConfig.useAwsChunkedEncoding: Boolean
     get() = when (hashSpecification) {
-        is HashSpecification.StreamingAws4HmacSha256Payload, is HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers -> true
+        is HashSpecification.StreamingAws4HmacSha256Payload,
+        is HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers,
+        is HashSpecification.StreamingUnsignedPayloadWithTrailers -> true
         else -> false
     }
 

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
@@ -20,9 +20,7 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
  */
 public const val CHUNK_SIZE_BYTES: Int = 65_536
 
-internal fun SdkBuffer.writeTrailers(
-    trailers: Headers
-) {
+internal fun SdkBuffer.writeTrailers(trailers: Headers) {
     trailers
         .entries()
         .sortedBy { entry -> entry.key.lowercase() }
@@ -52,7 +50,7 @@ internal val AwsSigningConfig.useAwsChunkedEncoding: Boolean
     get() = when (hashSpecification) {
         is HashSpecification.StreamingAws4HmacSha256Payload,
         is HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers,
-        is HashSpecification.StreamingUnsignedPayloadWithTrailers -> true
+        is HashSpecification.StreamingUnsignedPayloadWithTrailers, -> true
         else -> false
     }
 

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/middleware/AwsSigningMiddleware.kt
@@ -143,8 +143,7 @@ public class AwsSigningMiddleware(private val config: Config) : ModifyRequestMid
                 body is HttpBody.Empty -> HashSpecification.EmptyBody
                 body.isEligibleForAwsChunkedStreaming -> {
                     if (req.subject.headers.contains("x-amz-trailer")) {
-                        if (config.isUnsignedPayload) HashSpecification.StreamingUnsignedPayloadWithTrailers
-                        else HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers
+                        if (config.isUnsignedPayload) HashSpecification.StreamingUnsignedPayloadWithTrailers else HashSpecification.StreamingAws4HmacSha256PayloadWithTrailers
                     } else {
                         HashSpecification.StreamingAws4HmacSha256Payload
                     }

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedTestBase.kt
@@ -107,7 +107,8 @@ abstract class AwsChunkedTestBase(
     fun getChunkSizes(bytes: String, isUnsignedChunk: Boolean = false): List<Int> =
         if (isUnsignedChunk) {
             UNSIGNED_CHUNK_SIZE_REGEX.findAll(bytes).map {
-                result -> result.value.split("\r\n")[0].toInt(16)
+                    result ->
+                result.value.split("\r\n")[0].toInt(16)
             }.toList()
         } else {
             CHUNK_SIZE_REGEX.findAll(bytes).map {
@@ -139,7 +140,7 @@ abstract class AwsChunkedTestBase(
             append("\r\n")
         }.length
     }.reduce { acc, len -> acc + len } +
-            if (!isUnsignedChunk) "x-amz-trailer-signature:".length + 64 + "\r\n".length else 0
+        if (!isUnsignedChunk) "x-amz-trailer-signature:".length + 64 + "\r\n".length else 0
 
     /**
      * Given the length of the chunk body, returns the length of the entire encoded chunk.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds support for making unsigned requests using `aws-chunked`.

Users can specify an unsigned request by setting the `isUnsignedPayload` field when configuring `AwsSigningMiddleware`.

## Issue \#
N/A

## Description of changes
This change is required to enable sending unsigned requests using aws-chunked. This is particularly useful for flexible checksums because users may want to make unsigned requests but still provide a checksum as a trailing header. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.