### PR TITLE
fix: lazily open random access files

### DIFF
--- a/.changes/0cc34a91-f764-49d8-b24e-b170973e1f9d.json
+++ b/.changes/0cc34a91-f764-49d8-b24e-b170973e1f9d.json
@@ -1,0 +1,8 @@
+{
+    "id": "0cc34a91-f764-49d8-b24e-b170973e1f9d",
+    "type": "bugfix",
+    "description": "Lazily open random access files to prevent exhausting file handles in highly concurrent scenarios",
+    "issues": [
+        "awslabs/smithy-kotlin#781"
+    ]
+}

--- a/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/FileSourceTest.kt
+++ b/runtime/io/jvm/test/aws/smithy/kotlin/runtime/io/FileSourceTest.kt
@@ -7,24 +7,31 @@ package aws.smithy.kotlin.runtime.io
 
 import aws.smithy.kotlin.runtime.testing.RandomTempFile
 import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FileSourceTest {
     @Test
-    fun testStartPositionValidation() {
+    fun testStartPositionValidation() = runTest {
         val file = RandomTempFile(1024)
+        val source = file.source(-1)
         assertFailsWith<IllegalArgumentException> {
-            file.source(-1)
+            // Files are opened lazily...IAE won't be thrown until a read is attempted
+            source.readToByteArray()
         }.message.shouldContain("start position should be >= 0, found -1")
     }
 
     @Test
-    fun testEndPositionValidation() {
+    fun testEndPositionValidation() = runTest {
         val file = RandomTempFile(1024)
+        val source = file.source(endInclusive = 1024)
         assertFailsWith<IllegalArgumentException> {
-            file.source(endInclusive = 1024)
+            // Files are opened lazily...IAE won't be thrown until a read is attempted
+            source.readToByteArray()
         }.message.shouldContain("endInclusive should be less than or equal to the length of the file, was 1024")
 
         file.source(1023).close()


### PR DESCRIPTION
## Issue \#

Closes #781 

## Description of changes

This change makes file opening in `RandomAccessFileSource` lazy to prevent file handle exhaustion in highly-concurrent scenarios. It also defers all verification of file "correctness" (e.g., file exists, range is valid, etc.) until the file is opened. This is desirable because a long time may elapse between the instantiation of a `RandomAccessFileSource` and the time it's actually used, during which the file may have changed or been deleted/created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
