### PR TITLE
fix: include exceptions in logging from trace probes

### DIFF
--- a/.changes/6ef995dd-8bce-411f-84df-7790179d5ffa.json
+++ b/.changes/6ef995dd-8bce-411f-84df-7790179d5ffa.json
@@ -1,0 +1,8 @@
+{
+    "id": "6ef995dd-8bce-411f-84df-7790179d5ffa",
+    "type": "bugfix",
+    "description": "Include exceptions in logging from trace probes",
+    "issues": [
+        "awslabs/smithy-kotlin#784"
+    ]
+}

--- a/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
+++ b/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
@@ -29,7 +29,7 @@ public object LoggingTraceProbe : TraceProbe {
             val message = event.data as TraceEventData.Message
 
             val content = message.content()
-            val exception = message.exception?.let { ": $it" }
+            val exception = message.exception?.let { ": $it" } ?: ""
 
             "$spanId: $content$exception"
         }

--- a/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
+++ b/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
@@ -26,8 +26,12 @@ public object LoggingTraceProbe : TraceProbe {
         val logger = KotlinLogging.logger(event.sourceComponent)
         val method = event.level.loggerMethod()
         method(logger) {
-            val msg = (event.data as TraceEventData.Message).content()
-            "$spanId: $msg"
+            val message = event.data as TraceEventData.Message
+
+            val content = message.content()
+            val exception = message.exception?.let { ": $it" }
+
+            "$spanId: $content$exception"
         }
     }
 


### PR DESCRIPTION
## Issue \#

Closes #784 

## Description of changes

This change adds correct handling of exceptions in message events in the `LoggingTraceProbe`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
