### PR TITLE
fix: stop logging "null" when exceptions are not present in trace events

### DIFF
--- a/.changes/1e1425f8-c911-4d42-a54f-f2330e5cbfff.json
+++ b/.changes/1e1425f8-c911-4d42-a54f-f2330e5cbfff.json
@@ -1,0 +1,5 @@
+{
+    "id": "1e1425f8-c911-4d42-a54f-f2330e5cbfff",
+    "type": "bugfix",
+    "description": "Stop logging \"null\" when exceptions are not present in trace events"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ kotlinLoggingVersion=3.0.0
 slf4jVersion=2.0.6
 
 # crt
-crtKotlinVersion=0.6.7
+crtKotlinVersion=0.6.8-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ kotlinLoggingVersion=3.0.0
 slf4jVersion=2.0.6
 
 # crt
-crtKotlinVersion=0.6.8-SNAPSHOT
+crtKotlinVersion=0.6.7

--- a/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
+++ b/runtime/tracing/tracing-core/common/src/aws/smithy/kotlin/runtime/tracing/LoggingTraceProbe.kt
@@ -7,36 +7,41 @@ package aws.smithy.kotlin.runtime.tracing
 import mu.KLogger
 import mu.KotlinLogging
 
+private fun EventLevel.loggerMethod(): (KLogger, () -> Any?) -> Unit = when (this) {
+    EventLevel.Fatal,
+    EventLevel.Error,
+    -> KLogger::error
+    EventLevel.Warning -> KLogger::warn
+    EventLevel.Info -> KLogger::info
+    EventLevel.Debug -> KLogger::debug
+    EventLevel.Trace -> KLogger::trace
+}
+
+private fun EventLevel.throwableLoggerMethod(): (KLogger, Throwable, () -> Any?) -> Unit = when (this) {
+    EventLevel.Fatal,
+    EventLevel.Error,
+    -> KLogger::error
+    EventLevel.Warning -> KLogger::warn
+    EventLevel.Info -> KLogger::info
+    EventLevel.Debug -> KLogger::debug
+    EventLevel.Trace -> KLogger::trace
+}
+
 /**
  * A [TraceProbe] that sends logs events to downstream logging libraries (e.g., Slf4j on JVM). Those downstream
  * libraries may require configuration before messages will actually appear in logs.
  */
 public object LoggingTraceProbe : TraceProbe {
-    private fun EventLevel.loggerMethod(): (KLogger, () -> Any?) -> Unit = when (this) {
-        EventLevel.Fatal,
-        EventLevel.Error,
-        -> KLogger::error
-        EventLevel.Warning -> KLogger::warn
-        EventLevel.Info -> KLogger::info
-        EventLevel.Debug -> KLogger::debug
-        EventLevel.Trace -> KLogger::trace
-    }
-
-    private fun log(spanId: String, event: TraceEvent) {
+    private fun log(spanId: String, event: TraceEvent, message: TraceEventData.Message) {
         val logger = KotlinLogging.logger(event.sourceComponent)
-        val method = event.level.loggerMethod()
-        method(logger) {
-            val message = event.data as TraceEventData.Message
-
-            val content = message.content()
-            val exception = message.exception?.let { ": $it" } ?: ""
-
-            "$spanId: $content$exception"
+        when (message.exception) {
+            null -> event.level.loggerMethod()(logger) { "$spanId: ${message.content()}" }
+            else -> event.level.throwableLoggerMethod()(logger, message.exception) { "$spanId: ${message.content()}" }
         }
     }
 
     override fun postEvent(span: TraceSpan, event: TraceEvent) {
-        if (event.data is TraceEventData.Message) log(span.hierarchicalId, event)
+        if (event.data is TraceEventData.Message) log(span.hierarchicalId, event, event.data)
     }
 
     override fun spanClosed(span: TraceSpan) { } // No action necessary


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

#785 mistakenly started logging `null` on all trace events where no exception was present. This change fixes that by specifically detecting whether an exception is present and dispatching to the correct logger method (i.e., the overload with or without an exception).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
