### PR TITLE
fix: correct codegen tests' build config to correctly pull in smithy-cli

### DIFF
--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -3,20 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import software.amazon.smithy.gradle.tasks.SmithyBuild
+import software.amazon.smithy.gradle.tasks.Validate as SmithyValidate
 
 plugins {
     kotlin("jvm")
     id("software.amazon.smithy")
-}
-
-buildscript {
-    dependencies {
-        val smithyVersion: String by project
-        val smithyCliConfig = configurations.maybeCreate("smithyCli")
-
-        classpath("software.amazon.smithy:smithy-cli:$smithyVersion")
-        smithyCliConfig("software.amazon.smithy:smithy-cli:$smithyVersion")
-    }
 }
 
 extra.set("skipPublish", true)
@@ -33,16 +24,22 @@ kotlin.sourceSets.getByName("main") {
 
 tasks["smithyBuildJar"].enabled = false
 
+val smithyVersion: String by project
 val codegen by configurations.creating
 dependencies {
     codegen(project(":codegen:smithy-kotlin-codegen"))
+    codegen("software.amazon.smithy:smithy-cli:$smithyVersion")
 }
 
 val generateSdk = tasks.register<SmithyBuild>("generateSdk") {
     group = "codegen"
-    classpath = configurations.getByName("codegen")
+    classpath = codegen
     inputs.file(projectDir.resolve("smithy-build.json"))
-    inputs.files(configurations.getByName("codegen"))
+    inputs.files(codegen)
+}
+
+tasks.named<SmithyValidate>("smithyValidate") {
+    classpath = codegen
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>{


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adding a new **smithy-client** package interfered with **smithy-cli** classpath detection [because of string similarity](https://github.com/awslabs/smithy-gradle-plugin/blob/91845e8e0ae7c033e088197e6e15e176c458551b/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java#L244). Developers attempting to build the **paginator-tests** project may see the following error:

```
> Task :tests:codegen:paginator-tests:smithyValidate FAILED
Running smithy validate
software.amazon.smithy.cli.Cli
```

<details>
  <summary>Additional details</summary>
  
  ### More verbose error
  
  Running Gradle with additional logging (e.g., `./gradlew :tests:codegen:paginator-tests:build --info`) produces a more verbose and helpful error
  ```
  > Task :tests:codegen:paginator-tests:smithyValidate FAILED
  Caching disabled for task ':tests:codegen:paginator-tests:smithyValidate' because:
    Build cache is disabled
  Task ':tests:codegen:paginator-tests:smithyValidate' is not up-to-date because:
    Task has not declared any outputs despite executing actions.
  Running smithy validate
  Smithy CLI classpath already has the CLI in it
  Executing Smithy CLI in a thread: validate --discover; using classpath /local/home/issmith/workplace/sanity-test/smithy-kotlin/tests/codegen/paginator-tests/build/libs/paginator-tests.jar:/local/home/issmith/workplace/sanity-test/smithy-kotlin/runtime/protocol/http/build/libs/http-jvm-0.15.2-SNAPSHOT.jar:/local/home/issmith/workplace/sanity-test/smithy-kotlin/runtime/tracing/tracing-core/build/libs/tracing-core-jvm-0.15.2-SNAPSHOT.jar:/local/home/issmith/workplace/sanity-test/smithy-kotlin/runtime/smithy-client/build/libs/smithy-client-jvm-0.15.2-SNAPSHOT.jar:/local/home/issmith/workplace/sanity-test/smithy-kotlin/runtime/logging/build/libs/logging-jvm-0.15.2-SNAPSHOT.jar:/local/home/issmith/workplace/sanity-test/smithy-kotlin/runtime/runtime-core/build/libs/runtime-core-jvm-0.15.2-SNAPSHOT.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.6.4/2c997cd1c0ef33f3e751d3831929aeff1390cb30/kotlinx-coroutines-core-jvm-1.6.4.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/io.github.microutils/kotlin-logging-jvm/3.0.0/d4a4862e3f8f2ee074f2f8c06a907fb70bb4881c/kotlin-logging-jvm-3.0.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio-jvm/3.3.0/2d175add2d06a67bda111ae5455e49b42d0bb287/okio-jvm-3.3.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.8.0/ed04f49e186a116753ad70d34f0ac2925d1d8020/kotlin-stdlib-jdk8-1.8.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.8.0/3c91271347f678c239607abb676d4032a7898427/kotlin-stdlib-jdk7-1.8.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/d908bc5fb333d9dd2bce3d6dd54d637391a7690a/atomicfu-jvm-0.19.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.8.0/1796921c7a3e2e2665a83e6c8d33399336cd39bc/kotlin-stdlib-1.8.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.8.0/f7197e7cc76453ac59f8b0f8d5137cc600becd36/kotlin-stdlib-common-1.8.0.jar:/home/issmith/.m2/repository/org/jetbrains/annotations/13.0/annotations-13.0.jar:/local/home/issmith/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.1/f48d81adce2abf5ad3cfe463df517952749e03bc/slf4j-api-2.0.1.jar
  Error executing Smithy CLI (thread handler)
  java.lang.RuntimeException: java.lang.ClassNotFoundException: software.amazon.smithy.cli.Cli
          at software.amazon.smithy.gradle.SmithyUtils.lambda$executeCliThread$2(SmithyUtils.java:305)
          at java.base/java.lang.Thread.run(Thread.java:833)
  Caused by: java.lang.ClassNotFoundException: software.amazon.smithy.cli.Cli
          at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
          at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:587)
          at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
          at software.amazon.smithy.gradle.SmithyUtils.lambda$executeCliThread$2(SmithyUtils.java:297)
          ... 1 more
  software.amazon.smithy.cli.Cli
  :tests:codegen:paginator-tests:smithyValidate (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.027 secs.
  ```
</details>

This change explicitly adds the **smithy-cli** to the classpath for the **smithyValidate** task for both **paginator-tests** and **waiter-tests** (which follows a similar pattern). It also removes the unnecessary `buildscript` configuration which will only be used by Smithy if no task-level classpath is set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
