### PR TITLE
feat: rework max connections for OkHttp engine

### DIFF
--- a/.changes/73e8719a-3ed4-4316-a1a6-d673f1c85282.json
+++ b/.changes/73e8719a-3ed4-4316-a1a6-d673f1c85282.json
@@ -1,0 +1,5 @@
+{
+    "id": "73e8719a-3ed4-4316-a1a6-d673f1c85282",
+    "type": "bugfix",
+    "description": "Correctly apply `maxConnections` configuration setting to OkHttp engines"
+}

--- a/.changes/f71de744-44c0-4404-8d93-04ecda57650b.json
+++ b/.changes/f71de744-44c0-4404-8d93-04ecda57650b.json
@@ -1,0 +1,5 @@
+{
+    "id": "f71de744-44c0-4404-8d93-04ecda57650b",
+    "type": "feature",
+    "description": "Add new `maxConnectionsPerHost` configuration setting for OkHttp engines"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -70,19 +70,28 @@ private fun OkHttpEngineConfig.buildClient(): OkHttpClient {
         followSslRedirects(false)
 
         // see: https://github.com/ktorio/ktor/issues/1708#issuecomment-609988128
+        // TODO disable this once better transient exception handling is in place
         retryOnConnectionFailure(true)
 
         connectTimeout(config.connectTimeout.toJavaDuration())
         readTimeout(config.socketReadTimeout.toJavaDuration())
         writeTimeout(config.socketWriteTimeout.toJavaDuration())
 
-        // use our own pool configured with the settings taken from config
+        // use our own pool configured with the timeout settings taken from config
         val pool = ConnectionPool(
-            maxIdleConnections = config.maxConnections.toInt(),
+            maxIdleConnections = 5, // The default from the no-arg ConnectionPool() constructor
             keepAliveDuration = config.connectionIdleTimeout.inWholeMilliseconds,
             TimeUnit.MILLISECONDS,
         )
         connectionPool(pool)
+
+        // Configure a dispatcher that uses maxConnections as a proxy for maxRequests. Note that this isn't precisely
+        // the same since some protocols (e.g., HTTP2) may use a single connection for multiple requests.
+        val dispatcher = Dispatcher().apply {
+            maxRequests = config.maxConnections.toInt()
+            maxRequestsPerHost = config.maxConnectionsPerHost.toInt()
+        }
+        dispatcher(dispatcher)
 
         // Log events coming from okhttp. Allocate a new listener per-call to facilitate dedicated trace spans.
         eventListenerFactory { call -> HttpEngineEventListener(pool, config.hostResolver, call) }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
@@ -8,6 +8,11 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
 
 public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClientEngineConfig(builder) {
+    /**
+     * The maximum number of connections to open to a single host.
+     */
+    public val maxConnectionsPerHost: UInt = builder.maxConnectionsPerHost
+
     public companion object {
         /**
          * The default engine config. Most clients should use this.
@@ -19,6 +24,10 @@ public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClie
     }
 
     public class Builder : HttpClientEngineConfig.Builder() {
+        /**
+         * The maximum number of connections to open to a single host. Defaults to 5.
+         */
+        public var maxConnectionsPerHost: UInt = 5u
 
         internal fun build(): OkHttpEngineConfig = OkHttpEngineConfig(this)
     }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
@@ -11,7 +11,7 @@ public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClie
     /**
      * The maximum number of connections to open to a single host.
      */
-    public val maxConnectionsPerHost: UInt = builder.maxConnectionsPerHost
+    public val maxConnectionsPerHost: UInt = builder.maxConnectionsPerHost ?: builder.maxConnections
 
     public companion object {
         /**
@@ -25,9 +25,9 @@ public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClie
 
     public class Builder : HttpClientEngineConfig.Builder() {
         /**
-         * The maximum number of connections to open to a single host. Defaults to 5.
+         * The maximum number of connections to open to a single host. Defaults to [maxConnections].
          */
-        public var maxConnectionsPerHost: UInt = 5u
+        public var maxConnectionsPerHost: UInt? = null
 
         internal fun build(): OkHttpEngineConfig = OkHttpEngineConfig(this)
     }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

A few connections config-related changes for OkHttp:
* Make `maxConnections` actually do something by setting up a custom `Dispatcher` instead of using it for the connection pool's idle count
* Add a new `maxConnectionsPerHost` parameter to allow greater throughput to a single endpoint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
