### PR TITLE
feat: add additional connection tracing for CRT engine

### DIFF
--- a/.changes/f20a2e6c-7e63-4fa5-9be4-311e7b56869f.json
+++ b/.changes/f20a2e6c-7e63-4fa5-9be4-311e7b56869f.json
@@ -1,0 +1,5 @@
+{
+    "id": "f20a2e6c-7e63-4fa5-9be4-311e7b56869f",
+    "type": "feature",
+    "description": "Add additional tracing events for connections in CRT engines"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ kotlinLoggingVersion=3.0.0
 slf4jVersion=2.0.6
 
 # crt
-crtKotlinVersion=0.6.7
+crtKotlinVersion=0.6.8-SNAPSHOT

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/CrtHttpEngine.kt
@@ -95,10 +95,11 @@ public class CrtHttpEngine(public val config: CrtHttpEngineConfig) : HttpClientE
         val conn = withTimeoutOrNull(config.connectionAcquireTimeout) {
             manager.acquireConnection()
         } ?: throw ClientException("timed out waiting for an HTTP connection to be acquired from the pool")
+        logger.trace { "Acquired connection ${conn.id}" }
 
         val respHandler = SdkStreamResponseHandler(conn, callContext)
         callContext.job.invokeOnCompletion {
-            logger.warn { "completing handler; cause=$it" }
+            logger.trace { "completing handler; cause=$it" }
             // ensures the stream is driven to completion regardless of what the downstream consumer does
             respHandler.complete()
         }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -200,11 +200,12 @@ internal class SdkStreamResponseHandler(
             val forceClose = !streamCompleted
 
             if (forceClose) {
-                logger.debug { "stream did not complete before job, forcing connection shutdown! handler=$this; conn=$conn; stream=$crtStream" }
+                logger.debug { "stream did not complete before job, forcing connection shutdown! handler=$this; conn=$conn; conn.id=${conn.id}; stream=$crtStream" }
                 conn.shutdown()
                 cancelled = true
             }
 
+            logger.trace { "Closing connection ${conn.id}" }
             conn.close()
         }
     }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -32,6 +32,7 @@ class SdkStreamResponseHandlerTest {
     }
 
     private class MockHttpClientConnection : HttpClientConnection {
+        override val id: String = "<mock connection>"
         var isClosed: Boolean = false
         override fun close() { isClosed = true }
         override fun makeRequest(httpReq: HttpRequest, handler: HttpStreamResponseHandler): HttpStream { throw UnsupportedOperationException("not implemented for test") }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adds additional tracing to CRT engine for tracking connections.

**Companion PR**: [aws-crt-kotlin#63](https://github.com/awslabs/aws-crt-kotlin/pull/63)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
