### PR TITLE
feat: add configurable retry policy to clients

### DIFF
--- a/.changes/fbd99a2c-dd01-4b42-8c9a-55d2bf8e42fe.json
+++ b/.changes/fbd99a2c-dd01-4b42-8c9a-55d2bf8e42fe.json
@@ -1,0 +1,5 @@
+{
+    "id": "fbd99a2c-dd01-4b42-8c9a-55d2bf8e42fe",
+    "type": "feature",
+    "description": "Add configuration for retry policy on clients"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -137,6 +137,7 @@ object RuntimeTypes {
                 val OutputAcceptor = symbol("OutputAcceptor")
                 val RetryDirective = symbol("RetryDirective")
                 val RetryErrorType = symbol("RetryErrorType")
+                val RetryPolicy = symbol("RetryPolicy")
                 val StandardRetryPolicy = symbol("StandardRetryPolicy")
                 val SuccessAcceptor = symbol("SuccessAcceptor")
             }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigProperty.kt
@@ -169,6 +169,19 @@ class ConfigProperty private constructor(builder: Builder) {
             builtInProperty(name, builtInSymbol("String", defaultValue), documentation, baseClass)
     }
 
+    fun toBuilder(): Builder = Builder().apply {
+        symbol = this@ConfigProperty.symbol
+        builderSymbol = this@ConfigProperty.builderSymbol.takeUnless { it == this@ConfigProperty.symbol }
+        toBuilderExpression = this@ConfigProperty.toBuilderExpression
+        name = this@ConfigProperty.propertyName
+        documentation = this@ConfigProperty.documentation
+        baseClass = this@ConfigProperty.baseClass
+        builderBaseClass = this@ConfigProperty.builderBaseClass
+        propertyType = this@ConfigProperty.propertyType
+        additionalImports = this@ConfigProperty.additionalImports
+        order = this@ConfigProperty.order
+    }
+
     class Builder {
         var symbol: Symbol? = null
         var builderSymbol: Symbol? = null

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering.util
 
 import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
@@ -50,6 +51,26 @@ object RuntimeConfigProperty {
         Override the default idempotency token generator. SDK clients will generate tokens for members
         that represent idempotent tokens when not explicitly set by the caller using this generator.
         """.trimIndent()
+    }
+
+    val RetryPolicy = ConfigProperty {
+        symbol = buildSymbol {
+            name = "RetryPolicy<Any?>"
+            reference(RuntimeTypes.Core.Retries.Policy.RetryPolicy, SymbolReference.ContextOption.USE)
+        }
+        name = "retryPolicy"
+        documentation = """
+            The policy to use for evaluating operation results and determining whether/how to retry.
+        """.trimIndent()
+
+        propertyType = ConfigPropertyType.RequiredWithDefault("StandardRetryPolicy.Default")
+        baseClass = RuntimeTypes.SmithyClient.SdkClientConfig
+        builderBaseClass = buildSymbol {
+            name = "${baseClass!!.name}.Builder<Config>"
+            namespace = baseClass!!.namespace
+        }
+
+        additionalImports = listOf(RuntimeTypes.Core.Retries.Policy.StandardRetryPolicy)
     }
 
     val RetryStrategy = ConfigProperty {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
@@ -5,6 +5,7 @@
 package aws.smithy.kotlin.runtime.client
 
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.util.Buildable
 
 /**
@@ -23,6 +24,11 @@ public interface SdkClientConfig {
      */
     public val sdkLogMode: SdkLogMode
         get() = SdkLogMode.Default
+
+    /**
+     * The policy to use for evaluating operation results and determining whether/how to retry.
+     */
+    public val retryPolicy: RetryPolicy<Any?>
 
     /**
      * The [RetryStrategy] the client will use to retry failed operations.
@@ -46,6 +52,11 @@ public interface SdkClientConfig {
          * debug purposes.
          */
         public var sdkLogMode: SdkLogMode
+
+        /**
+         * The policy to use for evaluating operation results and determining whether/how to retry.
+         */
+        public var retryPolicy: RetryPolicy<Any?>?
 
         /**
          * Configure the [RetryStrategy] the client will use to retry failed operations.


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change adds:
* Retry policy configuration to service clients, enabling users to customize their own exception handling in existing retry logic.
* Merging of config properties by name during service client codegen. This enables _replacing_ an existing config property (like retry policy) with a new property that changes some values (e.g., the default).

**Companion PR**: [aws-sdk-kotlin#838](https://github.com/awslabs/aws-sdk-kotlin/pull/838)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
