### PR TITLE
feat: Add `readFully` extension method to `SdkSource` which reads an exact amount of bytes

### DIFF
--- a/.changes/55bff483-d8ae-4872-9d64-6187c28ba923.json
+++ b/.changes/55bff483-d8ae-4872-9d64-6187c28ba923.json
@@ -1,0 +1,5 @@
+{
+    "id": "55bff483-d8ae-4872-9d64-6187c28ba923",
+    "type": "feature",
+    "description": "Add readFully extension method to SdkSource"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ kotlinLoggingVersion=3.0.0
 slf4jVersion=2.0.6
 
 # crt
-crtKotlinVersion=0.6.8-SNAPSHOT
+crtKotlinVersion=0.6.9-SNAPSHOT

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
@@ -70,7 +70,7 @@ public fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long) {
         val rc = read(sink, byteCount - totalBytesRead)
 
         if (rc == -1L) {
-            throw EOFException("Unexpected EOF: expected ${byteCount - rc} more bytes; consumed: $rc")
+            throw EOFException("Unexpected EOF: expected ${byteCount - totalBytesRead} more bytes; consumed: $totalBytesRead")
         }
 
         totalBytesRead += rc

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
@@ -53,3 +53,13 @@ public expect suspend fun SdkSource.readToByteArray(): ByteArray
  */
 @InternalApi
 public expect fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope? = null): SdkByteReadChannel
+
+/**
+ * Remove exactly [byteCount] bytes from this source and appends them to [sink].
+ * @param sink The sink to append bytes to
+ * @param byteCount the number of bytes to read from the source
+ * @throws [IllegalArgumentException] when [byteCount] is less than zero
+ * @throws [EOFException] when the source is exhausted before [byteCount] bytes could be read
+ */
+@Throws(IOException::class)
+public expect fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/SdkSource.kt
@@ -62,4 +62,17 @@ public expect fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope?
  * @throws [EOFException] when the source is exhausted before [byteCount] bytes could be read
  */
 @Throws(IOException::class)
-public expect fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long)
+public fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long) {
+    require(byteCount >= 0L) { "Invalid length ($byteCount) must be >= 0L" }
+
+    var totalBytesRead = 0L
+    while (totalBytesRead != byteCount) {
+        val rc = read(sink, byteCount - totalBytesRead)
+
+        if (rc == -1L) {
+            throw EOFException("Unexpected EOF: expected ${byteCount - rc} more bytes; consumed: $rc")
+        }
+
+        totalBytesRead += rc
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkBufferedSourceTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkBufferedSourceTest.kt
@@ -334,6 +334,7 @@ abstract class BufferedSourceTest(
             source.readFully(dest, -1)
         }
     }
+
     @Test
     fun testReadFullyEOFException() {
         val data = "123456789".repeat(1024)

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkBufferedSourceTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkBufferedSourceTest.kt
@@ -315,4 +315,34 @@ abstract class BufferedSourceTest(
             source.require(1024 * 9 + 1)
         }
     }
+
+    @Test
+    fun testReadFully() {
+        val data = "123456789".repeat(1024)
+        sink.writeUtf8(data)
+        sink.flush()
+
+        val dest = SdkBuffer()
+        source.readFully(dest, data.length.toLong())
+        assertEquals(data, dest.readUtf8())
+    }
+
+    @Test
+    fun testReadFullyIllegalArgumentException() {
+        val dest = SdkBuffer()
+        assertFailsWith<IllegalArgumentException> {
+            source.readFully(dest, -1)
+        }
+    }
+    @Test
+    fun testReadFullyEOFException() {
+        val data = "123456789".repeat(1024)
+        sink.writeUtf8(data)
+        sink.flush()
+
+        val dest = SdkBuffer()
+        assertFailsWith<EOFException> {
+            source.readFully(dest, data.length.toLong() + 1)
+        }
+    }
 }

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
@@ -40,19 +40,3 @@ public actual fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope?
 
     return ch
 }
-
-@InternalApi
-public actual fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long) {
-    require(byteCount >= 0L) { "Invalid length ($byteCount) must be >= 0L" }
-
-    var totalBytesRead = 0L
-    while (totalBytesRead != byteCount) {
-        val rc = read(sink, byteCount - totalBytesRead)
-
-        if (rc == -1L) {
-            throw EOFException("Unexpected EOF: expected ${byteCount - rc} more bytes; consumed: $rc")
-        }
-
-        totalBytesRead += rc
-    }
-}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkSourceJVM.kt
@@ -40,3 +40,19 @@ public actual fun SdkSource.toSdkByteReadChannel(coroutineScope: CoroutineScope?
 
     return ch
 }
+
+@InternalApi
+public actual fun SdkSource.readFully(sink: SdkBuffer, byteCount: Long) {
+    require(byteCount >= 0L) { "Invalid length ($byteCount) must be >= 0L" }
+
+    var totalBytesRead = 0L
+    while (totalBytesRead != byteCount) {
+        val rc = read(sink, byteCount - totalBytesRead)
+
+        if (rc == -1L) {
+            throw EOFException("Unexpected EOF: expected ${byteCount - rc} more bytes; consumed: $rc")
+        }
+
+        totalBytesRead += rc
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a `readFully` extension method to `SdkSource`, which is used to read an exact amount of bytes
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Helps solve https://github.com/awslabs/aws-sdk-kotlin/issues/836

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required because `SdkSource` has no method to read an exact amount of bytes. Before this PR, users of `SdkSource` must use `read` in a loop to ensure they read the number of bytes they expected. When this loop is not used it could result in reading fewer bytes than expected and this unchecked behavior could cause issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
