### PR TITLE
feat: continue header

### DIFF
--- a/.changes/8f1ff251-7fed-4543-a077-51b2fe0aa684.json
+++ b/.changes/8f1ff251-7fed-4543-a077-51b2fe0aa684.json
@@ -1,0 +1,8 @@
+{
+    "id": "8f1ff251-7fed-4543-a077-51b2fe0aa684",
+    "type": "feature",
+    "description": "Add an interceptor for adding `Expect: 100-continue` headers to HTTP requests",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#839"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -92,6 +92,7 @@ object RuntimeTypes {
         }
 
         object Interceptors : RuntimeTypePackage(KotlinDependency.HTTP, "interceptors") {
+            val ContinueInterceptor = symbol("ContinueInterceptor")
             val HttpInterceptor = symbol("HttpInterceptor")
             val Md5ChecksumInterceptor = symbol("Md5ChecksumInterceptor")
             val FlexibleChecksumsRequestInterceptor = symbol("FlexibleChecksumsRequestInterceptor")

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -71,7 +71,7 @@ private fun OkHttpEngineConfig.buildClient(): OkHttpClient {
 
         // see: https://github.com/ktorio/ktor/issues/1708#issuecomment-609988128
         // TODO disable this once better transient exception handling is in place
-        retryOnConnectionFailure(true)
+        retryOnConnectionFailure(false)
 
         connectTimeout(config.connectTimeout.toJavaDuration())
         readTimeout(config.socketReadTimeout.toJavaDuration())

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -71,7 +71,7 @@ private fun OkHttpEngineConfig.buildClient(): OkHttpClient {
 
         // see: https://github.com/ktorio/ktor/issues/1708#issuecomment-609988128
         // TODO disable this once better transient exception handling is in place
-        retryOnConnectionFailure(false)
+        retryOnConnectionFailure(true)
 
         connectTimeout(config.connectTimeout.toJavaDuration())
         readTimeout(config.socketReadTimeout.toJavaDuration())

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.header
+import aws.smithy.kotlin.runtime.http.request.toBuilder
+
+/**
+ * An interceptor that adds an HTTP `Expect: 100-continue` header to requests with bodies at a certain length threshold.
+ * Bodies with an unset `contentLength` will get the continue header added regardless of length.
+ * @param thresholdLengthBytes The body length (in bytes) at which a continue header will be set. Bodies under this
+ * length will not get a continue header.
+ */
+public class ContinueInterceptor(public val thresholdLengthBytes: Long) : HttpInterceptor {
+    override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+        val req = context.protocolRequest
+
+        return if ((req.body.contentLength ?: Long.MAX_VALUE) >= thresholdLengthBytes) {
+            req
+                .toBuilder()
+                .apply { header("Expect", "100-continue") }
+                .build()
+        } else {
+            req
+        }
+    }
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.interceptors
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.header
@@ -15,6 +16,7 @@ import aws.smithy.kotlin.runtime.http.request.toBuilder
  * @param thresholdLengthBytes The body length (in bytes) at which a continue header will be set. Bodies under this
  * length will not get a continue header.
  */
+@InternalApi
 public class ContinueInterceptor(public val thresholdLengthBytes: Long) : HttpInterceptor {
     override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         val req = context.protocolRequest

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptorTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpMethod
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.header
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.net.Url
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.fail
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContinueInterceptorTest {
+    private fun context(request: HttpRequest) = object : ProtocolRequestInterceptorContext<Any, HttpRequest> {
+        override val protocolRequest: HttpRequest = request
+        override val executionContext: ExecutionContext get() = fail("Shouldn't have invoked `executionContext`")
+        override val request: Any get() = fail("Shouldn't have invoked `request`")
+    }
+
+    private fun request(contentLength: Long?) = HttpRequest {
+        method = HttpMethod.POST
+        url(Url.parse("https://localhost"))
+        header("foo", "bar")
+        body = object : HttpBody.SourceContent() {
+            override val contentLength: Long? = contentLength
+            override fun readFrom(): SdkSource = fail("Shouldn't have invoked `readFrom`")
+        }
+    }
+
+    @Test
+    fun testInterceptorSmallBody() = runTest {
+        val input = request(50)
+        val interceptor = ContinueInterceptor(100)
+        val output = interceptor.modifyBeforeSigning(context(input))
+        assertEquals("bar", output.headers["foo"])
+        assertNull(output.headers["Expect"])
+    }
+
+    @Test
+    fun testInterceptorLargeBody() = runTest {
+        val input = request(150)
+        val interceptor = ContinueInterceptor(100)
+        val output = interceptor.modifyBeforeSigning(context(input))
+        assertEquals("bar", output.headers["foo"])
+        assertEquals("100-continue", output.headers["Expect"])
+    }
+
+    @Test
+    fun testInterceptorUnknownLengthBody() = runTest {
+        val input = request(null)
+        val interceptor = ContinueInterceptor(100)
+        val output = interceptor.modifyBeforeSigning(context(input))
+        assertEquals("bar", output.headers["foo"])
+        assertEquals("100-continue", output.headers["Expect"])
+    }
+}


### PR DESCRIPTION
## Issue \#

Prerequisite of [aws-sdk-kotlin#839](https://github.com/awslabs/aws-sdk-kotlin/issues/839)

## Description of changes

This change creates a new interceptor which will add `Expect: 100-continue` headers to HTTP requests at a specified length threshold.

Also makes a few changes in **ModelTestUtils.kt** to support testing of companion PR.

**Companion PR**: [aws-sdk-kotlin#845](https://github.com/awslabs/aws-sdk-kotlin/pull/845)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
