### PR TITLE
refactor: relocate endpoints, document type, and credential provider util types

### DIFF
--- a/.changes/88c3a8ce-5e7b-4754-96d3-42c4de1fcddd.json
+++ b/.changes/88c3a8ce-5e7b-4754-96d3-42c4de1fcddd.json
@@ -1,0 +1,5 @@
+{
+    "id": "88c3a8ce-5e7b-4754-96d3-42c4de1fcddd",
+    "type": "misc",
+    "description": "Refactor: move EndpointProvider out of http package into aws.smithy.kotlin.runtime.client.endpoints"
+}

--- a/.changes/88c3a8ce-5e7b-4754-96d3-42c4de1fcddd.json
+++ b/.changes/88c3a8ce-5e7b-4754-96d3-42c4de1fcddd.json
@@ -1,5 +1,5 @@
 {
     "id": "88c3a8ce-5e7b-4754-96d3-42c4de1fcddd",
     "type": "misc",
-    "description": "Refactor: move EndpointProvider out of http package into aws.smithy.kotlin.runtime.client.endpoints"
+    "description": "Refactor: move `EndpointProvider` out of http package into `aws.smithy.kotlin.runtime.client.endpoints`"
 }

--- a/.changes/90312c67-354c-426d-bd15-b4f5901a3da5.json
+++ b/.changes/90312c67-354c-426d-bd15-b4f5901a3da5.json
@@ -1,5 +1,5 @@
 {
     "id": "90312c67-354c-426d-bd15-b4f5901a3da5",
     "type": "misc",
-    "description": "Refactor: relocate CachedCredentialsProvider and CredentialsProviderChain from aws-sdk-kotlin"
+    "description": "Refactor: relocate `CachedCredentialsProvider` and `CredentialsProviderChain` from `aws-sdk-kotlin`"
 }

--- a/.changes/90312c67-354c-426d-bd15-b4f5901a3da5.json
+++ b/.changes/90312c67-354c-426d-bd15-b4f5901a3da5.json
@@ -1,0 +1,5 @@
+{
+    "id": "90312c67-354c-426d-bd15-b4f5901a3da5",
+    "type": "misc",
+    "description": "Refactor: relocate CachedCredentialsProvider and CredentialsProviderChain from aws-sdk-kotlin"
+}

--- a/.changes/91436071-ff83-4476-aa11-35ea73e255c7.json
+++ b/.changes/91436071-ff83-4476-aa11-35ea73e255c7.json
@@ -1,5 +1,5 @@
 {
     "id": "91436071-ff83-4476-aa11-35ea73e255c7",
     "type": "misc",
-    "description": "Refactor: move Document type to aws.smithy.kotlin.runtime.content package"
+    "description": "Refactor: move `Document` type to `aws.smithy.kotlin.runtime.content` package"
 }

--- a/.changes/91436071-ff83-4476-aa11-35ea73e255c7.json
+++ b/.changes/91436071-ff83-4476-aa11-35ea73e255c7.json
@@ -1,0 +1,5 @@
+{
+    "id": "91436071-ff83-4476-aa11-35ea73e255c7",
+    "type": "misc",
+    "description": "Refactor: move Document type to aws.smithy.kotlin.runtime.content package"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -204,22 +204,19 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     }
 
     override fun blobShape(shape: BlobShape): Symbol = if (shape.hasTrait<StreamingTrait>()) {
-        val dependency = KotlinDependency.CORE
-        createSymbolBuilder(shape, "ByteStream", boxed = true)
-            .namespace("${dependency.namespace}.content", ".")
-            .addDependency(dependency)
+        val byteStreamType = RuntimeTypes.Core.Content.ByteStream
+        byteStreamType.toBuilder()
+            .boxed()
             .build()
     } else {
         createSymbolBuilder(shape, "ByteArray", boxed = true, namespace = "kotlin").build()
     }
 
-    override fun documentShape(shape: DocumentShape?): Symbol {
-        val dependency = KotlinDependency.CORE
-        return createSymbolBuilder(shape, "Document", boxed = true)
-            .namespace("${dependency.namespace}.smithy", ".")
-            .addDependency(dependency)
+    override fun documentShape(shape: DocumentShape?): Symbol =
+        RuntimeTypes.Core.Content.Document
+            .toBuilder()
+            .boxed()
             .build()
-    }
 
     override fun unionShape(shape: UnionShape): Symbol {
         val name = shape.defaultName(service)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -204,19 +204,13 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
     }
 
     override fun blobShape(shape: BlobShape): Symbol = if (shape.hasTrait<StreamingTrait>()) {
-        val byteStreamType = RuntimeTypes.Core.Content.ByteStream
-        byteStreamType.toBuilder()
-            .boxed()
-            .build()
+        RuntimeTypes.Core.Content.ByteStream.asNullable()
     } else {
         createSymbolBuilder(shape, "ByteArray", boxed = true, namespace = "kotlin").build()
     }
 
     override fun documentShape(shape: DocumentShape?): Symbol =
-        RuntimeTypes.Core.Content.Document
-            .toBuilder()
-            .boxed()
-            .build()
+        RuntimeTypes.Core.Content.Document.asNullable()
 
     override fun unionShape(shape: UnionShape): Symbol {
         val name = shape.defaultName(service)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -111,9 +111,11 @@ object RuntimeTypes {
         object Content : RuntimeTypePackage(KotlinDependency.CORE, "content") {
             val ByteArrayContent = symbol("ByteArrayContent")
             val ByteStream = symbol("ByteStream")
+            val buildDocument = symbol("buildDocument")
+            val decodeToString = symbol("decodeToString")
+            val Document = symbol("Document")
             val StringContent = symbol("StringContent")
             val toByteArray = symbol("toByteArray")
-            val decodeToString = symbol("decodeToString")
         }
 
         object Retries : RuntimeTypePackage(KotlinDependency.CORE, "retries") {
@@ -144,10 +146,6 @@ object RuntimeTypes {
             }
         }
 
-        object Smithy : RuntimeTypePackage(KotlinDependency.CORE, "smithy") {
-            val Document = symbol("Document")
-            val buildDocument = symbol("buildDocument")
-        }
 
         object Hashing : RuntimeTypePackage(KotlinDependency.CORE, "hashing") {
             val Sha256 = symbol("Sha256")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -52,6 +52,7 @@ object RuntimeTypes {
             val MutateHeadersMiddleware = symbol("MutateHeaders")
             val RetryMiddleware = symbol("RetryMiddleware")
             val ResolveEndpoint = symbol("ResolveEndpoint")
+            val setResolvedEndpoint = symbol("setResolvedEndpoint")
         }
 
         object Operation : RuntimeTypePackage(KotlinDependency.HTTP, "operation") {
@@ -65,21 +66,6 @@ object RuntimeTypes {
             val sdkRequestId = symbol("sdkRequestId")
             val execute = symbol("execute")
             val InlineMiddleware = symbol("InlineMiddleware")
-        }
-
-        object Endpoints : RuntimeTypePackage(KotlinDependency.HTTP, "endpoints") {
-            val EndpointProvider = symbol("EndpointProvider")
-            val Endpoint = symbol("Endpoint")
-            val EndpointProviderException = symbol("EndpointProviderException")
-            val setResolvedEndpoint = symbol("setResolvedEndpoint")
-
-            object Functions : RuntimeTypePackage(KotlinDependency.HTTP, "endpoints.functions") {
-                val substring = symbol("substring")
-                val isValidHostLabel = symbol("isValidHostLabel")
-                val uriEncode = symbol("uriEncode")
-                val parseUrl = symbol("parseUrl")
-                val Url = symbol("Url")
-            }
         }
 
         object Config : RuntimeTypePackage(KotlinDependency.HTTP, "config") {
@@ -190,6 +176,19 @@ object RuntimeTypes {
         val IdempotencyTokenProvider = symbol("IdempotencyTokenProvider")
         val IdempotencyTokenConfig = symbol("IdempotencyTokenConfig")
         val IdempotencyTokenProviderExt = symbol("idempotencyTokenProvider")
+
+        object Endpoints : RuntimeTypePackage(KotlinDependency.SMITHY_CLIENT, "endpoints") {
+            val EndpointProvider = symbol("EndpointProvider")
+            val Endpoint = symbol("Endpoint")
+            val EndpointProviderException = symbol("EndpointProviderException")
+            object Functions : RuntimeTypePackage(KotlinDependency.SMITHY_CLIENT, "endpoints.functions") {
+                val substring = symbol("substring")
+                val isValidHostLabel = symbol("isValidHostLabel")
+                val uriEncode = symbol("uriEncode")
+                val parseUrl = symbol("parseUrl")
+                val Url = symbol("Url")
+            }
+        }
     }
 
     object Serde : RuntimeTypePackage(KotlinDependency.SERDE) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -138,7 +138,7 @@ class ShapeValueGenerator(
         override fun objectNode(node: ObjectNode) {
             if (currShape.type == ShapeType.DOCUMENT) {
                 writer
-                    .writeInline("#T {\n", RuntimeTypes.Core.Smithy.buildDocument)
+                    .writeInline("#T {\n", RuntimeTypes.Core.Content.buildDocument)
                     .indent()
             }
 
@@ -215,7 +215,7 @@ class ShapeValueGenerator(
                     writer.writeInline("#L", "$symbolName.$symbolMember")
                 }
 
-                ShapeType.DOCUMENT -> writer.writeInline("#T(#S)", RuntimeTypes.Core.Smithy.Document, node.value)
+                ShapeType.DOCUMENT -> writer.writeInline("#T(#S)", RuntimeTypes.Core.Content.Document, node.value)
 
                 else -> writer.writeInline("#S", node.value)
             }
@@ -228,7 +228,7 @@ class ShapeValueGenerator(
         override fun arrayNode(node: ArrayNode) {
             when (currShape.type) {
                 ShapeType.DOCUMENT -> {
-                    writer.withInlineBlock("#T(", ")", RuntimeTypes.Core.Smithy.Document) {
+                    writer.withInlineBlock("#T(", ")", RuntimeTypes.Core.Content.Document) {
                         writer.withInlineBlock("listOf(", ")") {
                             node.elements.forEach {
                                 generator.writeShapeValueInline(writer, currShape, it)
@@ -275,7 +275,7 @@ class ShapeValueGenerator(
 
                 ShapeType.DOCUMENT -> writer.writeInline(
                     "#T(#L#L)",
-                    RuntimeTypes.Core.Smithy.Document,
+                    RuntimeTypes.Core.Content.Document,
                     node.value,
                     if (node.isFloatingPointNumber) "F" else "L",
                 )
@@ -286,7 +286,7 @@ class ShapeValueGenerator(
 
         override fun booleanNode(node: BooleanNode) {
             when (currShape.type) {
-                ShapeType.DOCUMENT -> writer.writeInline("#T(#L)", RuntimeTypes.Core.Smithy.Document, node.value)
+                ShapeType.DOCUMENT -> writer.writeInline("#T(#L)", RuntimeTypes.Core.Content.Document, node.value)
                 ShapeType.BOOLEAN -> writer.writeInline("#L", if (node.value) "true" else "false")
                 else -> throw CodegenException("unexpected shape type $currShape for boolean value")
             }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -280,7 +280,7 @@ class ExpressionGenerator(
     }
 
     override fun visitRecord(value: MutableMap<Identifier, Literal>) {
-        writer.withInlineBlock("#T {", "}", RuntimeTypes.Core.Smithy.buildDocument) {
+        writer.withInlineBlock("#T {", "}", RuntimeTypes.Core.Content.buildDocument) {
             value.entries.forEachIndexed { index, (k, v) ->
                 writeInline("#S to ", k.asString())
                 v.accept(this@ExpressionGenerator as Literal.Vistor<Unit>)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -30,10 +30,10 @@ import software.amazon.smithy.rulesengine.language.visit.TemplateVisitor
  * The core set of standard library functions available to the rules language.
  */
 internal val coreFunctions: Map<String, Symbol> = mapOf(
-    "substring" to RuntimeTypes.HttpClient.Endpoints.Functions.substring,
-    "isValidHostLabel" to RuntimeTypes.HttpClient.Endpoints.Functions.isValidHostLabel,
-    "uriEncode" to RuntimeTypes.HttpClient.Endpoints.Functions.uriEncode,
-    "parseURL" to RuntimeTypes.HttpClient.Endpoints.Functions.parseUrl,
+    "substring" to RuntimeTypes.SmithyClient.Endpoints.Functions.substring,
+    "isValidHostLabel" to RuntimeTypes.SmithyClient.Endpoints.Functions.isValidHostLabel,
+    "uriEncode" to RuntimeTypes.SmithyClient.Endpoints.Functions.uriEncode,
+    "parseURL" to RuntimeTypes.SmithyClient.Endpoints.Functions.parseUrl,
 )
 
 /**
@@ -98,11 +98,11 @@ class DefaultEndpointProviderGenerator(
             "public override suspend fun resolveEndpoint(params: #T): #T {",
             "}",
             paramsSymbol,
-            RuntimeTypes.HttpClient.Endpoints.Endpoint,
+            RuntimeTypes.SmithyClient.Endpoints.Endpoint,
         ) {
             rules.rules.forEach(::renderRule)
             write("")
-            write("throw #T(\"endpoint rules were exhausted without a match\")", RuntimeTypes.HttpClient.Endpoints.EndpointProviderException)
+            write("throw #T(\"endpoint rules were exhausted without a match\")", RuntimeTypes.SmithyClient.Endpoints.EndpointProviderException)
         }
     }
 
@@ -145,7 +145,7 @@ class DefaultEndpointProviderGenerator(
 
     private fun renderEndpointRule(rule: EndpointRule) {
         withConditions(rule.conditions) {
-            writer.withBlock("return #T(", ")", RuntimeTypes.HttpClient.Endpoints.Endpoint) {
+            writer.withBlock("return #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
                 writeInline("#T.parse(", RuntimeTypes.Core.Net.Url)
                 renderExpression(rule.endpoint.url)
                 write("),")
@@ -189,7 +189,7 @@ class DefaultEndpointProviderGenerator(
 
     private fun renderErrorRule(rule: ErrorRule) {
         withConditions(rule.conditions) {
-            writer.writeInline("throw #T(", RuntimeTypes.HttpClient.Endpoints.EndpointProviderException)
+            writer.writeInline("throw #T(", RuntimeTypes.SmithyClient.Endpoints.EndpointProviderException)
             renderExpression(rule.error)
             writer.write(")")
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -94,7 +94,7 @@ class DefaultEndpointProviderTestGenerator(
 
     private fun renderTestCaseExpectation(case: EndpointTestCase) {
         if (case.expect.error.isPresent) {
-            writer.withBlock("val ex = assertFailsWith<#T> {", "}", RuntimeTypes.HttpClient.Endpoints.EndpointProviderException) {
+            writer.withBlock("val ex = assertFailsWith<#T> {", "}", RuntimeTypes.SmithyClient.Endpoints.EndpointProviderException) {
                 write("#T().resolveEndpoint(params)", providerSymbol)
             }
             writer.write("assertEquals(#S, ex.message)", case.expect.error.get())
@@ -105,7 +105,7 @@ class DefaultEndpointProviderTestGenerator(
             CodegenException("endpoint test case has neither an expected error nor endpoint")
         }
 
-        writer.withBlock("val expected = #T(", ")", RuntimeTypes.HttpClient.Endpoints.Endpoint) {
+        writer.withBlock("val expected = #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
             write("uri = #T.parse(#S),", RuntimeTypes.Core.Net.Url, endpoint.url)
 
             if (endpoint.headers.isNotEmpty()) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -31,7 +31,7 @@ class EndpointProviderGenerator(
 
     fun render() {
         renderDocumentation()
-        writer.write("public typealias EndpointProvider = #T<#T>", RuntimeTypes.HttpClient.Endpoints.EndpointProvider, paramsSymbol)
+        writer.write("public typealias EndpointProvider = #T<#T>", RuntimeTypes.SmithyClient.Endpoints.EndpointProvider, paramsSymbol)
     }
 
     private fun renderDocumentation() {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/ResolveEndpointMiddlewareGenerator.kt
@@ -84,7 +84,7 @@ class ResolveEndpointMiddlewareGenerator(
             write("#T.#T<$CLASS_NAME<*>>{ \"resolved endpoint: \$endpoint\" }", RuntimeTypes.KotlinCoroutines.coroutineContext, RuntimeTypes.Tracing.Core.debug)
             write("val reqBuilder = context.protocolRequest.#T()", RuntimeTypes.Http.Request.toBuilder)
             write("val req = #T(context.executionContext, reqBuilder)", RuntimeTypes.HttpClient.Operation.SdkHttpRequest)
-            write("#T(req, endpoint)", RuntimeTypes.HttpClient.Endpoints.setResolvedEndpoint)
+            write("#T(req, endpoint)", RuntimeTypes.HttpClient.Middleware.setResolvedEndpoint)
             renderPostResolution()
             write("return req.subject.build()")
         }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -366,7 +366,7 @@ class SymbolProviderTest {
         assertEquals("Document", documentSymbol.name)
         assertEquals("null", documentSymbol.defaultValue())
         assertEquals(true, documentSymbol.isBoxed)
-        assertEquals("${CORE.namespace}.smithy", documentSymbol.namespace)
+        assertEquals(RuntimeTypes.Core.Content.Document.namespace, documentSymbol.namespace)
         assertEquals(1, documentSymbol.dependencies.size)
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -155,7 +155,7 @@ class DeserializeStructGeneratorTest {
         val actual = codegenDeserializerForShape(model, "com.test#Foo")
 
         actual.shouldContainOnlyOnceWithDiff(expected)
-        actual.shouldContainOnlyOnceWithDiff("import aws.smithy.kotlin.runtime.smithy.Document")
+        actual.shouldContainOnlyOnceWithDiff("import aws.smithy.kotlin.runtime.content.Document")
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 # SDK
-sdkVersion=0.15.4-SNAPSHOT
+sdkVersion=0.16.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.8.10

--- a/runtime/auth/aws-credentials/build.gradle.kts
+++ b/runtime/auth/aws-credentials/build.gradle.kts
@@ -2,10 +2,25 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+buildscript {
+    val atomicFuVersion: String by project
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:$atomicFuVersion")
+    }
+}
 
 description = "Types for AWS credentials"
 extra["displayName"] = "Smithy :: Kotlin :: AWS Credentials"
 extra["moduleName"] = "aws.smithy.kotlin.runtime.auth.awscredentials"
+
+val coroutinesVersion: String by project
+val atomicFuVersion: String by project
+
+apply(plugin = "kotlinx-atomicfu")
 
 kotlin {
     sourceSets {
@@ -13,6 +28,13 @@ kotlin {
             dependencies {
                 // For Instant
                 api(project(":runtime:runtime-core"))
+                implementation(project(":runtime:tracing:tracing-core"))
+                implementation("org.jetbrains.kotlinx:atomicfu:$atomicFuVersion")
+            }
+        }
+        commonTest {
+            dependencies {
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
             }
         }
 

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awscredentials
+
+import aws.smithy.kotlin.runtime.io.closeIfCloseable
+import aws.smithy.kotlin.runtime.time.Clock
+import aws.smithy.kotlin.runtime.tracing.trace
+import aws.smithy.kotlin.runtime.util.CachedValue
+import aws.smithy.kotlin.runtime.util.ExpiringValue
+import kotlinx.atomicfu.atomic
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+private const val DEFAULT_CREDENTIALS_REFRESH_BUFFER_SECONDS = 10
+
+/**
+ * The amount of time credentials are valid for before being refreshed when an explicit value
+ * is not given to/from a provider
+ */
+public const val DEFAULT_CREDENTIALS_REFRESH_SECONDS: Int = 60 * 15
+
+/**
+ * Creates a provider that functions as a caching decorator of another provider.
+ *
+ * Credentials sourced through this provider will be cached within it until their expiration time.
+ * When the cached credentials expire, new credentials will be fetched when next queried.
+ *
+ * For example, the default chain is implemented as:
+ *
+ * CachedProvider -> ProviderChain(EnvironmentProvider -> ProfileProvider -> ECS/EC2IMD etc...)
+ *
+ * @param source the provider to cache credentials results from
+ * @param expireCredentialsAfter the default expiration time period for sourced credentials. For a given set of
+ * cached credentials, the refresh time period will be the minimum of this time and any expiration timestamp on
+ * the credentials themselves.
+ * @param refreshBufferWindow amount of time before the actual credential expiration time when credentials are
+ * considered expired. For example, if credentials are expiring in 15 minutes, and the buffer time is 10 seconds,
+ * then any requests made after 14 minutes and 50 seconds will load new credentials. Defaults to 10 seconds.
+ * @param clock the source of time for this provider
+ *
+ * @return the newly-constructed credentials provider
+ */
+public class CachedCredentialsProvider(
+    private val source: CredentialsProvider,
+    private val expireCredentialsAfter: Duration = DEFAULT_CREDENTIALS_REFRESH_SECONDS.seconds,
+    refreshBufferWindow: Duration = DEFAULT_CREDENTIALS_REFRESH_BUFFER_SECONDS.seconds,
+    private val clock: Clock = Clock.System,
+) : CloseableCredentialsProvider {
+
+    private val cachedCredentials = CachedValue<Credentials>(null, bufferTime = refreshBufferWindow, clock)
+    private val closed = atomic(false)
+
+    override suspend fun getCredentials(): Credentials {
+        check(!closed.value) { "Credentials provider is closed" }
+
+        return cachedCredentials.getOrLoad {
+            coroutineContext.trace<CachedCredentialsProvider> { "refreshing credentials cache" }
+            val providerCreds = source.getCredentials()
+            if (providerCreds.expiration != null) {
+                val expiration = minOf(providerCreds.expiration!!, (clock.now() + expireCredentialsAfter))
+                ExpiringValue(providerCreds, expiration)
+            } else {
+                val expiration = clock.now() + expireCredentialsAfter
+                val creds = providerCreds.copy(expiration = expiration)
+                ExpiringValue(creds, expiration)
+            }
+        }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        cachedCredentials.close()
+        source.closeIfCloseable()
+    }
+}

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -61,7 +61,7 @@ public class CachedCredentialsProvider(
             coroutineContext.trace<CachedCredentialsProvider> { "refreshing credentials cache" }
             val providerCreds = source.getCredentials()
             if (providerCreds.expiration != null) {
-                val expiration = minOf(providerCreds.expiration!!, (clock.now() + expireCredentialsAfter))
+                val expiration = minOf(providerCreds.expiration, (clock.now() + expireCredentialsAfter))
                 ExpiringValue(providerCreds, expiration)
             } else {
                 val expiration = clock.now() + expireCredentialsAfter

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awscredentials
+
+import aws.smithy.kotlin.runtime.io.Closeable
+import aws.smithy.kotlin.runtime.tracing.*
+import kotlin.coroutines.coroutineContext
+
+// TODO - support caching the provider that actually resolved credentials such that future calls don't involve going through the full chain
+
+/**
+ * Composite [CredentialsProvider] that delegates to a chain of providers. When asked for credentials [providers]
+ * are consulted in the order given until one succeeds. If none of the providers in the chain can provide credentials
+ * then this class will throw an exception. The exception will include the providers tried in the message. Each
+ * individual exception is available as a suppressed exception.
+ *
+ * @param providers the list of providers to delegate to
+ */
+public open class CredentialsProviderChain(
+    protected vararg val providers: CredentialsProvider,
+) : CloseableCredentialsProvider {
+    init {
+        require(providers.isNotEmpty()) { "at least one provider must be in the chain" }
+    }
+
+    override fun toString(): String =
+        (listOf(this) + providers).map { it::class.simpleName }.joinToString(" -> ")
+
+    override suspend fun getCredentials(): Credentials = coroutineContext.withChildTraceSpan("Credentials chain") {
+        val logger = coroutineContext.traceSpan.logger<CredentialsProviderChain>()
+        val chain = this@CredentialsProviderChain
+        val chainException = lazy { CredentialsProviderException("No credentials could be loaded from the chain: $chain") }
+        for (provider in providers) {
+            logger.trace { "Attempting to load credentials from $provider" }
+            try {
+                return@withChildTraceSpan provider.getCredentials()
+            } catch (ex: Exception) {
+                logger.debug { "unable to load credentials from $provider: ${ex.message}" }
+                chainException.value.addSuppressed(ex)
+            }
+        }
+
+        throw chainException.value
+    }
+
+    override fun close() {
+        val exceptions = providers.mapNotNull {
+            try {
+                (it as? Closeable)?.close()
+                null
+            } catch (ex: Exception) {
+                ex
+            }
+        }
+        if (exceptions.isNotEmpty()) {
+            val ex = exceptions.first()
+            exceptions.drop(1).forEach(ex::addSuppressed)
+            throw ex
+        }
+    }
+}

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderException.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderException.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awscredentials
+
+import aws.smithy.kotlin.runtime.ClientException
+
+/**
+ * The [CredentialsProvider] experienced an error during credentials resolution
+ */
+public class CredentialsProviderException(message: String, cause: Throwable? = null) : ClientException(message, cause)

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awscredentials
+
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ManualClock
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CachedCredentialsProviderTest {
+    private val epoch = Instant.fromIso8601("2020-10-16T03:56:00Z")
+    private val testExpiration = epoch + 30.minutes
+    private val testClock = ManualClock(epoch)
+
+    private class TestCredentialsProvider(
+        private val expiration: Instant? = null,
+    ) : CredentialsProvider {
+        var callCount = 0
+
+        override suspend fun getCredentials(): Credentials {
+            callCount++
+            return Credentials(
+                "AKID",
+                "secret",
+                expiration = this@TestCredentialsProvider.expiration,
+            )
+        }
+    }
+
+    @Test
+    fun testLoadFirstCall() = runTest {
+        // explicit expiration
+        val source = TestCredentialsProvider(expiration = testExpiration)
+        val provider = CachedCredentialsProvider(source, clock = testClock)
+        val creds = provider.getCredentials()
+        val expected = Credentials("AKID", "secret", expiration = testExpiration)
+        assertEquals(expected, creds)
+        assertEquals(1, source.callCount)
+
+        provider.getCredentials()
+        assertEquals(1, source.callCount)
+    }
+
+    @Test
+    fun testDefaultExpiration() = runTest {
+        // expiration should come from the cached provider
+        val source = TestCredentialsProvider()
+        val provider = CachedCredentialsProvider(source, clock = testClock)
+        val creds = provider.getCredentials()
+        val expectedExpiration = epoch + 15.minutes
+        val expected = Credentials("AKID", "secret", expiration = expectedExpiration)
+        assertEquals(expected, creds)
+        assertEquals(1, source.callCount)
+    }
+
+    @Test
+    fun testReloadExpiredCredentials() = runTest {
+        val source = TestCredentialsProvider(expiration = testExpiration)
+        val provider = CachedCredentialsProvider(source, clock = testClock)
+        val creds = provider.getCredentials()
+        val expected = Credentials("AKID", "secret", expiration = testExpiration)
+        assertEquals(expected, creds)
+        assertEquals(1, source.callCount)
+
+        // 1 min past expiration
+        testClock.advance(31.minutes)
+        provider.getCredentials()
+        assertEquals(2, source.callCount)
+    }
+
+    @Test
+    fun testRefreshBufferWindow() = runTest {
+        val source = TestCredentialsProvider(expiration = testExpiration)
+        val provider = CachedCredentialsProvider(source, clock = testClock, expireCredentialsAfter = 60.minutes)
+        val creds = provider.getCredentials()
+        val expected = Credentials("AKID", "secret", expiration = testExpiration)
+        assertEquals(expected, creds)
+        assertEquals(1, source.callCount)
+
+        // default buffer window is 10 seconds, advance 29 minutes, 49 seconds
+        testClock.advance((29 * 60 + 49).seconds)
+        provider.getCredentials()
+        // not within window yet
+        assertEquals(1, source.callCount)
+
+        // now we should be within 10 sec window
+        testClock.advance(1.seconds)
+        provider.getCredentials()
+        assertEquals(2, source.callCount)
+    }
+
+    @Test
+    fun testLoadFailed() = runTest {
+        val source = object : CredentialsProvider {
+            private var count = 0
+            override suspend fun getCredentials(): Credentials {
+                if (count <= 0) {
+                    count++
+                    throw RuntimeException("test error")
+                }
+                return Credentials("AKID", "secret")
+            }
+        }
+        val provider = CachedCredentialsProvider(source, clock = testClock)
+
+        assertFailsWith<RuntimeException> {
+            provider.getCredentials()
+        }.message.shouldContain("test error")
+
+        // future successful invocations should continue to work
+        provider.getCredentials()
+    }
+
+    @Test
+    fun testItThrowsOnGetCredentialsAfterClose() = runTest {
+        val source = TestCredentialsProvider(expiration = testExpiration)
+        val provider = CachedCredentialsProvider(source, clock = testClock)
+        val creds = provider.getCredentials()
+        val expected = Credentials("AKID", "secret", expiration = testExpiration)
+        assertEquals(expected, creds)
+        assertEquals(1, source.callCount)
+
+        provider.close()
+
+        assertFailsWith<IllegalStateException> {
+            provider.getCredentials()
+        }
+        assertEquals(1, source.callCount)
+    }
+}

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.auth.awscredentials
+
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CredentialsProviderChainTest {
+    @Test
+    fun testNoProviders() {
+        assertFails("at least one provider") {
+            CredentialsProviderChain()
+        }
+    }
+    data class TestProvider(val credentials: Credentials? = null) : CredentialsProvider {
+        override suspend fun getCredentials(): Credentials = credentials ?: throw IllegalStateException("no credentials available")
+    }
+
+    @Test
+    fun testChain() = runTest {
+        val chain = CredentialsProviderChain(
+            TestProvider(null),
+            TestProvider(Credentials("akid1", "secret1")),
+            TestProvider(Credentials("akid2", "secret2")),
+        )
+
+        assertEquals(Credentials("akid1", "secret1"), chain.getCredentials())
+    }
+
+    @Test
+    fun testChainNoCredentials() = runTest {
+        val chain = CredentialsProviderChain(
+            TestProvider(null),
+            TestProvider(null),
+        )
+
+        val ex = assertFailsWith<CredentialsProviderException> {
+            chain.getCredentials()
+        }
+        ex.message.shouldContain("No credentials could be loaded from the chain: CredentialsProviderChain -> TestProvider -> TestProvider")
+
+        assertEquals(2, ex.suppressedExceptions.size)
+    }
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -6,8 +6,8 @@ package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.net.QueryParameters
 import aws.smithy.kotlin.runtime.net.Scheme

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointTest.kt
@@ -5,12 +5,12 @@
 
 package aws.smithy.kotlin.runtime.http.middleware
 
+import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
+import aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.SdkHttpClient
-import aws.smithy.kotlin.runtime.http.endpoints.Endpoint
-import aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/Document.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/Document.kt
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.smithy.kotlin.runtime.smithy
+package aws.smithy.kotlin.runtime.content
 
 /**
  * A `Document` is used to store arbitrary or unstructured data.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/DocumentBuilder.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/DocumentBuilder.kt
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.smithy.kotlin.runtime.smithy
+package aws.smithy.kotlin.runtime.content
 
 import kotlin.jvm.JvmName
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/CachedValue.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/CachedValue.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.io.Closeable
+import aws.smithy.kotlin.runtime.time.Clock
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlin.time.Duration
+
+/**
+ * A value with an expiration
+ */
+@InternalApi
+public data class ExpiringValue<T> (val value: T, val expiresAt: Instant)
+
+/**
+ * Expiry aware value
+ *
+ * @param value The value that expires
+ * @param bufferTime The amount of time before the actual expiration time when the value is considered expired. By default
+ * the buffer time is zero meaning the value expires at the expiration time. A non-zero buffer time means the value will
+ * expire BEFORE the actual expiration.
+ * @param clock The clock to use for system time
+ */
+@InternalApi
+public class CachedValue<T> (
+    private var value: ExpiringValue<T>? = null,
+    private val bufferTime: Duration = Duration.ZERO,
+    private val clock: Clock = Clock.System,
+) : Closeable {
+    public constructor(value: T, expiresAt: Instant, bufferTime: Duration = Duration.ZERO, clock: Clock = Clock.System) : this(ExpiringValue(value, expiresAt), bufferTime, clock)
+
+    private val gate = Semaphore(1)
+    private val _ref: AtomicRef<ExpiringValue<T>?> = atomic(value)
+    private val ref: ExpiringValue<T>?
+        get() = _ref.value
+    private val closed = atomic(false)
+
+    /**
+     * Check if the value is expired or not as compared to the time now
+     */
+    public val isExpired: Boolean
+        get() {
+            check(!closed.value) { "value is closed" }
+            return ref?.let { isExpired(it) } ?: true
+        }
+
+    private fun isExpired(value: ExpiringValue<T>): Boolean = clock.now() >= (value.expiresAt - bufferTime)
+
+    /**
+     * Get the value if it has not expired yet. Returns null if the value has expired
+     */
+    public fun get(): T? {
+        check(!closed.value) { "value is closed" }
+        val curr = ref ?: return null
+
+        return if (isExpired(curr)) null else curr.value
+    }
+
+    /**
+     * Attempt to get the value or refresh it with [initializer] if it is expired
+     */
+    public suspend fun getOrLoad(initializer: suspend () -> ExpiringValue<T>): T = gate.withPermit {
+        check(!closed.value) { "value is closed" }
+
+        val curr = ref
+        if (curr != null && !isExpired(curr)) {
+            return curr.value
+        }
+
+        val next = initializer()
+
+        check(!closed.value) { "value is closed" }
+        check(_ref.compareAndSet(curr, next)) { "value changed during getOrLoad" }
+
+        return next.value
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) { return }
+        _ref.update { null }
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/DocumentBuilderTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/DocumentBuilderTest.kt
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package aws.smithy.kotlin.runtime
+package aws.smithy.kotlin.runtime.content
 
-import aws.smithy.kotlin.runtime.smithy.Document
-import aws.smithy.kotlin.runtime.smithy.buildDocument
 import kotlin.test.*
 
 class DocumentBuilderTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/CachedValueTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/CachedValueTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ManualClock
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CachedValueTest {
+    @Test
+    fun testNull() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val clock = ManualClock(epoch)
+        val value = CachedValue<String>(null, clock = clock)
+
+        assertTrue(value.isExpired)
+        assertNull(value.get())
+    }
+
+    @Test
+    fun testExpiration() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val expiresAt = epoch + 10.seconds
+        val clock = ManualClock(epoch)
+
+        val value = CachedValue("foo", expiresAt, clock = clock)
+
+        assertFalse(value.isExpired)
+        assertEquals("foo", value.get())
+
+        clock.advance(10.seconds)
+        assertTrue(value.isExpired)
+        assertNull(value.get())
+    }
+
+    @Test
+    fun testExpirationBuffer() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val expiresAt = epoch + 100.seconds
+        val clock = ManualClock(epoch)
+
+        val value = CachedValue("foo", expiresAt, bufferTime = 30.seconds, clock = clock)
+
+        assertFalse(value.isExpired)
+        assertEquals("foo", value.get())
+
+        clock.advance(70.seconds)
+        assertTrue(value.isExpired)
+        assertNull(value.get())
+    }
+
+    @Test
+    fun testGetOrLoad() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val expiresAt = epoch + 100.seconds
+        val clock = ManualClock(epoch)
+
+        val value = CachedValue("foo", expiresAt, bufferTime = 30.seconds, clock = clock)
+
+        var count = 0
+        val mu = Mutex()
+        val initializer = suspend {
+            mu.withLock { count++ }
+            ExpiringValue("bar", expiresAt + count.seconds * 100)
+        }
+
+        assertFalse(value.isExpired)
+        assertEquals("foo", value.getOrLoad(initializer))
+        assertEquals(0, count)
+
+        // t = 90
+        clock.advance(90.seconds)
+        assertEquals("bar", value.getOrLoad(initializer))
+        assertFalse(value.isExpired)
+        assertEquals(1, count)
+
+        // t = 180
+        clock.advance(90.seconds)
+        repeat(10) {
+            async {
+                value.getOrLoad(initializer)
+            }
+        }
+        yield()
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun testClose() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val expiresAt = epoch + 100.seconds
+
+        val clock = ManualClock(epoch)
+
+        val value = CachedValue("foo", expiresAt, bufferTime = 30.seconds, clock = clock)
+
+        assertNotNull(value.get())
+        value.close()
+        assertFailsWith<IllegalStateException> { value.get() }
+    }
+
+    @Test
+    fun throwsAfterCloseDuringGetOrLoad() = runTest {
+        val epoch = Instant.fromEpochSeconds(0)
+        val expiresAt = epoch + 100.seconds
+
+        val value: CachedValue<String> = CachedValue()
+
+        launch {
+            assertFailsWith<IllegalStateException> {
+                value.getOrLoad {
+                    delay(5000)
+                    ExpiringValue("bar", expiresAt)
+                }
+            }
+        }
+
+        delay(1000)
+        value.close()
+    }
+}

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Deserializer.kt
@@ -4,7 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.serde
 
-import aws.smithy.kotlin.runtime.smithy.Document
+import aws.smithy.kotlin.runtime.content.Document
 
 /**
  * Deserializer is a format agnostic deserialization interface. Specific formats (e.g. JSON, XML, etc) implement

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 package aws.smithy.kotlin.runtime.serde
-import aws.smithy.kotlin.runtime.smithy.Document
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
@@ -5,9 +5,9 @@
 
 package aws.smithy.kotlin.runtime.serde.formurl
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonDeserializer.kt
@@ -4,8 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.serde.json
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 
 /**
  * Provides a deserializer for JSON documents

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
@@ -4,8 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.serde.json
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -4,9 +4,9 @@
  */
 package aws.smithy.kotlin.runtime.serde.json
 
+import aws.smithy.kotlin.runtime.content.Document
+import aws.smithy.kotlin.runtime.content.buildDocument
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
-import aws.smithy.kotlin.runtime.smithy.buildDocument
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.math.abs

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
@@ -4,9 +4,9 @@
  */
 package aws.smithy.kotlin.runtime.serde.json
 
+import aws.smithy.kotlin.runtime.content.Document
+import aws.smithy.kotlin.runtime.content.buildDocument
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
-import aws.smithy.kotlin.runtime.smithy.buildDocument
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -5,8 +5,8 @@
 
 package aws.smithy.kotlin.runtime.serde.xml
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 
 // Represents aspects of SdkFieldDescriptor that are particular to the Xml format
 internal sealed class FieldLocation {

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlPrimitiveDeserializer.kt
@@ -5,8 +5,8 @@
 
 package aws.smithy.kotlin.runtime.serde.xml
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 
 /**
  * Deserialize primitive values for single values, lists, and maps

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
@@ -4,8 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.serde.xml
 
+import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.serde.*
-import aws.smithy.kotlin.runtime.smithy.Document
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 import aws.smithy.kotlin.runtime.util.*

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/EndpointProvider.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/EndpointProvider.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package aws.smithy.kotlin.runtime.http.endpoints
+package aws.smithy.kotlin.runtime.client.endpoints
 
 /**
  * Resolves endpoints for a given service client.

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/EndpointProviderException.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/EndpointProviderException.kt
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.smithy.kotlin.runtime.http.endpoints
+package aws.smithy.kotlin.runtime.client.endpoints
 
 import aws.smithy.kotlin.runtime.ClientException
 

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/functions/Functions.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/functions/Functions.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 // This package implements common standard library functions used by endpoint resolvers.
-package aws.smithy.kotlin.runtime.http.endpoints.functions
+package aws.smithy.kotlin.runtime.client.endpoints.functions
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.net.*

--- a/runtime/smithy-client/common/test/aws/smithy/kotlin/runtime/client/endpoints/functions/FunctionsTest.kt
+++ b/runtime/smithy-client/common/test/aws/smithy/kotlin/runtime/client/endpoints/functions/FunctionsTest.kt
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.smithy.kotlin.runtime.http.endpoints.functions
+package aws.smithy.kotlin.runtime.client.endpoints.functions
 
 import kotlin.test.*
 

--- a/tests/codegen/paginator-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
@@ -3,4 +3,4 @@ package com.test.endpoints
 /**
  * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
  */
-typealias EndpointProvider = aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider<Unit>
+typealias EndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<Unit>

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
@@ -3,4 +3,4 @@ package com.test.endpoints
 /**
  * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
  */
-typealias EndpointProvider = aws.smithy.kotlin.runtime.http.endpoints.EndpointProvider<Unit>
+typealias EndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<Unit>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* relocate endpoints from `http-client` to `smithy-client` removing any HTTP dependency on the `EndpointProvider`/`Endpoint` types
* move `Document` and friends to `content` package in `runtime-core
* relocate `CachedCredentialsProvider` and `CredentialsProviderChain` from `aws-sdk-kotlin` (also move dependent utility types `CachedValue`/`ExpiringValue`)
    * There are no changes to any of this code other than import changes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
