### PR TITLE
fix: correct token bucket delays when experiencing system time jumps

### DIFF
--- a/.changes/9e04fd2c-136d-490b-9ecf-d6072a6f34c1.json
+++ b/.changes/9e04fd2c-136d-490b-9ecf-d6072a6f34c1.json
@@ -1,0 +1,8 @@
+{
+    "id": "9e04fd2c-136d-490b-9ecf-d6072a6f34c1",
+    "type": "bugfix",
+    "description": "Fix a bug where system time jumps could cause unexpected retry behavior",
+    "issues": [
+        "awslabs/smithy-kotlin#805"
+    ]
+}


### PR DESCRIPTION
## Issue \#

Closes #805 

## Description of changes

As noted in #805 the retry token bucket calculation is susceptible to changes in system time. Replace the `Clock` implementation with a Kotlin `TimeSource.Monotonic`, which offers intra-moment comparison capable of withstanding system time changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
