### PR TITLE
fix: update runtime-core API manifest after API-incompatible change that wasn't caught by CI

### DIFF
--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1076,8 +1076,8 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTok
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
 	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Laws/smithy/kotlin/runtime/time/Clock;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Laws/smithy/kotlin/runtime/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getOptions ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

#810 changed the API signature for the public constructor `StandardRetryTokenBucket`. It was introduced on a separate branch from the change that added API compatibility verification, #808, and so did not fail compatibility checks in PR. The push to **main** occurred after API compatibility verification was enabled and wasn't blocked on merging because no overlapping files were touched.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
