### PR TITLE
fix: don't sign Expect header in SigV4

### DIFF
--- a/.changes/d4ba7f85-24f3-4925-8bb4-25020f294b9a.json
+++ b/.changes/d4ba7f85-24f3-4925-8bb4-25020f294b9a.json
@@ -1,0 +1,8 @@
+{
+    "id": "d4ba7f85-24f3-4925-8bb4-25020f294b9a",
+    "type": "bugfix",
+    "description": "Skip signing the `Expect` header in SigV4",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#862"
+    ]
+}

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
@@ -59,9 +59,10 @@ internal interface Canonicalizer {
     ): CanonicalRequest
 }
 
-// Taken from https://github.com/awslabs/aws-c-auth/blob/31d573c0dd328db5775f7a55650d27b8c08311ba/source/aws_signing.c#L118-L151
+// Taken from https://github.com/awslabs/aws-c-auth/blob/dd505b55fd46222834f35c6e54165d8cbebbfaaa/source/aws_signing.c#L118-L156
 private val skipHeaders = setOf(
     "connection",
+    "expect", // https://github.com/awslabs/aws-sdk-kotlin/issues/862
     "sec-websocket-key",
     "sec-websocket-protocol",
     "sec-websocket-version",


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#862](https://github.com/awslabs/aws-sdk-kotlin/issues/862)

## Description of changes

Recent changes #802 and [aws-sdk-kotlin#845](https://github.com/awslabs/aws-sdk-kotlin/pull/845) enabled sending the `Expect: 100-continue` header on S3 PUT requests over 2MB (by default). The `Expect` header is not meant to be signed and causes a problem when using S3 with Transfer Acceleration enabled. (It is unknown why this doesn't also cause a problem when using the default S3 configuration.)

This change exempts the `Expect` header from signature calculation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
