### PR TITLE
feat: add reader-friendly client name to SDK config

### DIFF
--- a/.changes/2d4548fd-a1ed-4a4e-8798-18d5726aee0c.json
+++ b/.changes/2d4548fd-a1ed-4a4e-8798-18d5726aee0c.json
@@ -1,0 +1,5 @@
+{
+    "id": "2d4548fd-a1ed-4a4e-8798-18d5726aee0c",
+    "type": "feature",
+    "description": "Add configurable reader-friendly name to generated SDK clients."
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -40,6 +40,7 @@ class ServiceClientConfigGenerator(
      * Attempt to detect configuration properties automatically based on the model
      */
     private fun detectDefaultProps(context: CodegenContext, shape: ServiceShape): List<ConfigProperty> = buildList {
+        add(RuntimeConfigProperty.ClientName)
         add(RuntimeConfigProperty.SdkLogMode)
         if (context.protocolGenerator?.applicationProtocol?.isHttpProtocol == true) {
             add(RuntimeConfigProperty.HttpClientEngine)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -73,7 +73,6 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.renderDocumentation(service)
         writer.renderAnnotations(service)
         writer.openBlock("public interface ${serviceSymbol.name} : #T {", RuntimeTypes.SmithyClient.SdkClient)
-            .call { overrideServiceName() }
             .call {
                 // allow access to client's Config
                 writer.dokka("${serviceSymbol.name}'s configuration")
@@ -159,14 +158,6 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
             write("@#T", KotlinTypes.Jvm.JvmStatic)
             write("override fun builder(): Builder = Builder()")
         }
-    }
-
-    private fun overrideServiceName() {
-        writer.write("")
-            .write("override val serviceName: String")
-            .indent()
-            .write("get() = #service.name:S")
-            .dedent()
     }
 
     private fun renderOperation(opIndex: OperationIndex, op: OperationShape) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -169,7 +169,6 @@ abstract class HttpProtocolClientGenerator(
             writer.openBlock("context {", "}") {
                 writer.write("expectedHttpStatus = ${httpTrait.code}")
                 // property from implementing SdkClient
-                writer.write("service = serviceName")
                 writer.write("operationName = #S", op.id.name)
 
                 // optional endpoint trait

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -47,6 +47,7 @@ public class Config private constructor(builder: Builder) : HttpClientConfig, Id
         contents.shouldContainWithDiff(expectedCtor)
 
         val expectedProps = """
+    override val clientName: String = builder.clientName
     override val httpClientEngine: HttpClientEngine = builder.httpClientEngine ?: DefaultHttpEngine().manage()
     public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
@@ -54,12 +55,17 @@ public class Config private constructor(builder: Builder) : HttpClientConfig, Id
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val sdkLogMode: SdkLogMode = builder.sdkLogMode
-    override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, "${TestModelDefault.SERVICE_NAME}")
+    override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, clientName)
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilder = """
     public class Builder : HttpClientConfig.Builder, IdempotencyTokenConfig.Builder, SdkClientConfig.Builder<Config>, TracingClientConfig.Builder {
+        /**
+         * A reader-friendly name for the client.
+         */
+        override var clientName: String = "Test"
+
         /**
          * Override the default HTTP client engine used to make SDK requests (e.g. configure proxy behavior, timeouts, concurrency, etc).
          * NOTE: The caller is responsible for managing the lifetime of the engine when set. The SDK

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
@@ -35,15 +35,6 @@ class ServiceClientGeneratorTest {
     }
 
     @Test
-    fun `it overrides SdkClient serviceName`() {
-        val expected = """
-            override val serviceName: String
-                get() = "Test"
-        """.formatForTest()
-        commonTestContents.shouldContainOnlyOnce(expected)
-    }
-
-    @Test
     fun `it renders signatures correctly`() {
         val expectedSignatures = listOf(
             "public suspend fun getFoo(input: GetFooRequest): GetFooResponse",

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -81,7 +81,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFoo"
             }
         }
@@ -101,7 +100,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooNoInputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooNoInput"
             }
         }
@@ -121,7 +119,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooNoOutputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooNoOutput"
             }
         }
@@ -141,7 +138,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooStreamingInputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooStreamingInput"
             }
         }
@@ -161,7 +157,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooStreamingOutputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooStreamingOutput"
             }
         }
@@ -181,7 +176,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooStreamingOutputNoInputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooStreamingOutputNoInput"
             }
         }
@@ -201,7 +195,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooStreamingInputNoOutputOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooStreamingInputNoOutput"
             }
         }
@@ -221,7 +214,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooNoRequiredOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooNoRequired"
             }
         }
@@ -241,7 +233,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetFooSomeRequiredOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetFooSomeRequired"
             }
         }
@@ -317,7 +308,6 @@ class HttpProtocolClientGeneratorTest {
             deserializer = GetStatusOperationDeserializer()
             context {
                 expectedHttpStatus = 200
-                service = serviceName
                 operationName = "GetStatus"
                 hostPrefix = "$prefix"
             }

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/MiddlewareSigningTestBase.kt
@@ -62,7 +62,6 @@ public abstract class MiddlewareSigningTestBase : HasSigner {
 
             context {
                 operationName = "testSigningOperation"
-                service = "TestService"
                 set(AwsSigningAttributes.SigningRegion, "us-east-1")
                 set(AwsSigningAttributes.SigningDate, Instant.fromIso8601("2020-10-16T19:56:00Z"))
                 set(AwsSigningAttributes.SigningService, "demo")

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -450,7 +450,6 @@ private fun buildOperation(
 
         context {
             operationName = "testSigningOperation"
-            service = config.service
             set(AwsSigningAttributes.SigningRegion, config.region)
             config.signingDate.let {
                 set(AwsSigningAttributes.SigningDate, it)

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
@@ -38,7 +38,6 @@ class AwsJsonProtocolTest {
             serializer = UnitSerializer
             deserializer = IdentityDeserializer
             context {
-                service = "FooService"
                 operationName = "Bar"
             }
         }
@@ -69,7 +68,6 @@ class AwsJsonProtocolTest {
             serializer = UnitSerializer
             deserializer = IdentityDeserializer
             context {
-                service = "FooService"
                 operationName = "Bar"
             }
         }
@@ -103,7 +101,6 @@ class AwsJsonProtocolTest {
             }
             deserializer = IdentityDeserializer
             context {
-                service = "FooService"
                 operationName = "Bar"
             }
         }

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -153,11 +153,9 @@ public class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Build
 	public final fun getExpectedHttpStatus ()Ljava/lang/Integer;
 	public final fun getHostPrefix ()Ljava/lang/String;
 	public final fun getOperationName ()Ljava/lang/String;
-	public final fun getService ()Ljava/lang/String;
 	public final fun setExpectedHttpStatus (Ljava/lang/Integer;)V
 	public final fun setHostPrefix (Ljava/lang/String;)V
 	public final fun setOperationName (Ljava/lang/String;)V
-	public final fun setService (Ljava/lang/String;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Companion {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -58,11 +58,6 @@ public open class HttpOperationContext {
     public open class Builder : ClientOptionsBuilder() {
 
         /**
-         * The service name
-         */
-        public var service: String? by requiredOption(SdkClientOption.ServiceName)
-
-        /**
          * The name of the operation
          */
         public var operationName: String? by requiredOption(SdkClientOption.OperationName)

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
@@ -38,7 +38,6 @@ inline fun <reified I> newTestOperation(serialized: HttpRequestBuilder): SdkHttp
         context {
             // required operation context
             operationName = "TestOperation"
-            service = "TestService"
         }
     }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
@@ -14,12 +14,10 @@ class HttpOperationContextTest {
     @Test
     fun testBuilder() {
         val op = HttpOperationContext.build {
-            service = "test"
             operationName = "operation"
             expectedHttpStatus = 418
         }
 
-        assertEquals("test", op[(SdkClientOption.ServiceName)])
         assertEquals("operation", op[SdkClientOption.OperationName])
         assertEquals(418, op[HttpOperationContext.ExpectedHttpStatus])
     }
@@ -28,7 +26,6 @@ class HttpOperationContextTest {
     fun testMissingRequiredProperties() {
         val ex = assertFailsWith<IllegalArgumentException> {
             HttpOperationContext.build {
-                service = "test"
             }
         }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/TestOperation.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/TestOperation.kt
@@ -29,7 +29,6 @@ inline fun <reified I, reified O> newTestOperation(serialized: HttpRequestBuilde
         context {
             // required operation context
             operationName = "TestOperation"
-            service = "TestService"
         }
     }
 

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -107,7 +107,6 @@ public abstract interface class aws/smithy/kotlin/runtime/client/ResponseInterce
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient : java/io/Closeable {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/client/SdkClientConfig;
-	public abstract fun getServiceName ()Ljava/lang/String;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient$Builder : aws/smithy/kotlin/runtime/util/Buildable {
@@ -147,11 +146,11 @@ public final class aws/smithy/kotlin/runtime/client/SdkClientFactory$DefaultImpl
 
 public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/client/SdkClientOption;
+	public final fun getClientName ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getEndpointDiscoveryEnabled ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getLogMode ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getOperationName ()Laws/smithy/kotlin/runtime/util/AttributeKey;
-	public final fun getServiceName ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
 
 public final class aws/smithy/kotlin/runtime/client/SdkClientOptionKt {

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -115,15 +115,18 @@ public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient$Build
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig {
+	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
 	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 	public abstract fun getSdkLogMode ()Laws/smithy/kotlin/runtime/client/SdkLogMode;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig$Builder : aws/smithy/kotlin/runtime/util/Buildable {
+	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
 	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 	public abstract fun getSdkLogMode ()Laws/smithy/kotlin/runtime/client/SdkLogMode;
+	public abstract fun setClientName (Ljava/lang/String;)V
 	public abstract fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
 	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
 	public abstract fun setSdkLogMode (Laws/smithy/kotlin/runtime/client/SdkLogMode;)V

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClient.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClient.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.util.Buildable
  */
 public interface SdkClient : Closeable {
     /**
-     * The name of the service client
+     * The name of the service
      */
     public val serviceName: String
 

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClient.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClient.kt
@@ -12,11 +12,6 @@ import aws.smithy.kotlin.runtime.util.Buildable
  */
 public interface SdkClient : Closeable {
     /**
-     * The name of the service
-     */
-    public val serviceName: String
-
-    /**
      * The client's configuration
      */
     public val config: SdkClientConfig

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
@@ -13,6 +13,11 @@ import aws.smithy.kotlin.runtime.util.Buildable
  */
 public interface SdkClientConfig {
     /**
+     * A reader-friendly name for the client.
+     */
+    public val clientName: String
+
+    /**
      * Configure events that will be logged. By default, clients will not output
      * raw requests or responses. Use this setting to opt in to additional debug logging.
      *
@@ -41,6 +46,11 @@ public interface SdkClientConfig {
      * @param TConfig the type of configuration built by this builder
      */
     public interface Builder<TConfig : SdkClientConfig> : Buildable<TConfig> {
+        /**
+         * A reader-friendly name for the client.
+         */
+        public var clientName: String
+
         /**
          * Configure events that will be logged. By default, clients will not output
          * raw requests or responses. Use this setting to opt in to additional debug logging.

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -21,7 +21,7 @@ public object SdkClientOption {
     /**
      * The service name the operation is executed against
      */
-    public val ClientName: ClientOption<String> = ClientOption("ClientName")
+    public val ClientName: ClientOption<String> = ClientOption("aws.smithy.kotlin#ClientName")
 
     /**
      * A token generator for idempotency tokens

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -21,7 +21,7 @@ public object SdkClientOption {
     /**
      * The service name the operation is executed against
      */
-    public val ServiceName: ClientOption<String> = ClientOption("ServiceName")
+    public val ClientName: ClientOption<String> = ClientOption("ClientName")
 
     /**
      * A token generator for idempotency tokens


### PR DESCRIPTION
## Description of changes
Add configurable client name that is passed to the tracer by default.
Supports https://github.com/awslabs/aws-sdk-kotlin/pull/854

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
