### PR TITLE
fix: use service's `signingName` instead of `serviceId` for presigning

### DIFF
--- a/.changes/f3d93638-bc80-4e52-88fa-4c73a093f9bc.json
+++ b/.changes/f3d93638-bc80-4e52-88fa-4c73a093f9bc.json
@@ -1,0 +1,8 @@
+{
+    "id": "f3d93638-bc80-4e52-88fa-4c73a093f9bc",
+    "type": "bugfix",
+    "description": "Fix a bug in presigned URL generation when using a ServicePresignConfig object",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/868"
+    ]
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -115,6 +115,7 @@ public suspend fun createPresignedRequest(
     serviceConfig: ServicePresignConfig,
     requestConfig: PresignedRequestConfig,
 ): HttpRequest {
+    // TODO re-evaluate whether SigningContext is a necessary concept: https://github.com/awslabs/smithy-kotlin/issues/755
     val givenSigningContext = SigningContext(serviceConfig.signingName, serviceConfig.region)
     val endpoint = serviceConfig.endpointProvider(givenSigningContext)
     val signatureType = when (requestConfig.presigningLocation) {

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -115,7 +115,7 @@ public suspend fun createPresignedRequest(
     serviceConfig: ServicePresignConfig,
     requestConfig: PresignedRequestConfig,
 ): HttpRequest {
-    val givenSigningContext = SigningContext(serviceConfig.serviceId, serviceConfig.region)
+    val givenSigningContext = SigningContext(serviceConfig.signingName, serviceConfig.region)
     val endpoint = serviceConfig.endpointProvider(givenSigningContext)
     val signatureType = when (requestConfig.presigningLocation) {
         PresigningLocation.HEADER -> AwsSignatureType.HTTP_REQUEST_VIA_HEADERS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Presigned URLs are being incorrectly signed with `serviceId` instead of `signingName` 

## Issue \#
https://github.com/awslabs/aws-sdk-kotlin/issues/868

## Description of changes
We are currently using the service's `serviceId` for the signing context, but this should actually be the `signingName`. For example, S3's `serviceId` is "S3" but the `signingName` is "s3". 

This leads to a signature mismatch / other errors depending on how signature mismatch is handled on the service-side.

Currently the issue only affects presigned URLs generated from a [presigned config object](https://github.com/awslabs/aws-sdk-kotlin/blob/main/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/PresignerGenerator.kt#L360), not [a client config](https://github.com/awslabs/aws-sdk-kotlin/blob/main/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/PresignerGenerator.kt#L312). 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.