### PR TITLE
fix: allow `Content-Length=0` headers in the CRT HTTP engine

### DIFF
--- a/.changes/85c91e25-fbc9-4416-a8bc-54991580a802.json
+++ b/.changes/85c91e25-fbc9-4416-a8bc-54991580a802.json
@@ -1,0 +1,8 @@
+{
+    "id": "85c91e25-fbc9-4416-a8bc-54991580a802",
+    "type": "bugfix",
+    "description": "Allow requests with zero content length in the CRT HTTP engine",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/818"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -60,11 +60,7 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
         headers.forEach { key, values -> appendAll(key, values) }
     }
 
-    val bodyLen = body.contentLength
-    val contentLength = when {
-        bodyLen != null -> if (bodyLen > 0) bodyLen.toString() else null
-        else -> headers[CONTENT_LENGTH_HEADER]
-    }
+    val contentLength = body.contentLength?.toString() ?: headers[CONTENT_LENGTH_HEADER]
     contentLength?.let { crtHeaders.append(CONTENT_LENGTH_HEADER, it) }
 
     return aws.sdk.kotlin.crt.http.HttpRequest(method.name, url.encodedPath, crtHeaders.build(), bodyStream)

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -92,6 +92,20 @@ class RequestConversionTest {
     }
 
     @Test
+    fun testEngineAddsContentLengthHeaderForEmptyBody() {
+        val request = HttpRequest(
+            HttpMethod.POST,
+            Url.parse("https://test.aws.com?foo=bar"),
+            Headers.Empty,
+            HttpBody.Empty,
+        )
+
+        val testContext = EmptyCoroutineContext + Job()
+        val crtRequest = request.toCrtRequest(testContext)
+        assertEquals("0", crtRequest.headers["Content-Length"])
+    }
+
+    @Test
     fun testEngineSetsNullBodyForChannelContentChunkedRequests() {
         val testData = ByteArray(1024) { 0 }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -92,20 +92,6 @@ class RequestConversionTest {
     }
 
     @Test
-    fun testEngineDoesNotAddContentLengthHeaderForEmptyBody() {
-        val request = HttpRequest(
-            HttpMethod.POST,
-            Url.parse("https://test.aws.com?foo=bar"),
-            Headers.Empty,
-            HttpBody.Empty,
-        )
-
-        val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
-        assertFalse(crtRequest.headers.contains("Content-Length"))
-    }
-
-    @Test
     fun testEngineSetsNullBodyForChannelContentChunkedRequests() {
         val testData = ByteArray(1024) { 0 }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -58,7 +58,7 @@ internal fun HttpRequest.toOkHttpRequest(
             is HttpBody.Empty -> ByteArray(0).toRequestBody(null, 0, 0)
             is HttpBody.Bytes -> body.bytes().let { it.toRequestBody(null, 0, it.size) }
             is HttpBody.SourceContent, is HttpBody.ChannelContent -> {
-                val body: HttpBody = headers["Content-Length"]?.let {
+                val updatedBody: HttpBody = headers["Content-Length"]?.let {
                     if (body.contentLength == null || body.contentLength == -1L) {
                         when (body) {
                             is HttpBody.SourceContent -> body.readFrom().toHttpBody(it.toLong())
@@ -67,7 +67,7 @@ internal fun HttpRequest.toOkHttpRequest(
                         }
                     } else { null }
                 } ?: body
-                StreamingRequestBody(body, callContext)
+                StreamingRequestBody(updatedBody, callContext)
             }
         }
     } else {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
@@ -188,5 +188,4 @@ class OkHttpRequestTest {
         actualBody.writeTo(buffer)
         assertEquals(content, buffer.readUtf8())
     }
-
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
@@ -135,4 +135,58 @@ class OkHttpRequestTest {
         actualBody.writeTo(buffer)
         assertEquals(content, buffer.readUtf8())
     }
+
+    @Test
+    fun itUsesContentLengthHeaderWhenContentLengthIsUnknown() {
+        val url = Url.parse("https://aws.amazon.com")
+        val content = "Hello OkHttp from HttpBody.Streaming".repeat(1024)
+        val contentBytes = content.encodeToByteArray()
+        val chan = SdkByteReadChannel(contentBytes)
+        val body = object : HttpBody.ChannelContent() {
+            override val contentLength: Long = -1
+            override fun readFrom(): SdkByteReadChannel = chan
+        }
+        val expectedContentLength = "5"
+        val headers = HeadersBuilder().apply {
+            append("Content-Length", expectedContentLength)
+        }.build()
+
+        val request = HttpRequest(HttpMethod.POST, url, headers, body)
+        val execContext = ExecutionContext()
+        val actual = request.toOkHttpRequest(execContext, EmptyCoroutineContext)
+
+        val actualBody = assertNotNull(actual.body)
+        assertEquals(expectedContentLength.toLong(), actualBody.contentLength())
+
+        val buffer = Buffer()
+        actualBody.writeTo(buffer)
+        assertEquals(content, buffer.readUtf8())
+    }
+
+    @Test
+    fun itDoesNotUseContentLengthHeaderWhenContentLengthIsDefined() {
+        val url = Url.parse("https://aws.amazon.com")
+        val content = "Hello OkHttp from HttpBody.Streaming".repeat(1024)
+        val contentBytes = content.encodeToByteArray()
+        val chan = SdkByteReadChannel(contentBytes)
+        val body = object : HttpBody.ChannelContent() {
+            override val contentLength: Long = contentBytes.size.toLong()
+            override fun readFrom(): SdkByteReadChannel = chan
+        }
+        val headers = HeadersBuilder().apply {
+            append("Content-Length", "9")
+        }.build()
+
+        val request = HttpRequest(HttpMethod.POST, url, headers, body)
+        val execContext = ExecutionContext()
+        val actual = request.toOkHttpRequest(execContext, EmptyCoroutineContext)
+
+        val actualBody = assertNotNull(actual.body)
+        assertEquals(request.body.contentLength, actualBody.contentLength())
+
+        val buffer = Buffer()
+        actualBody.writeTo(buffer)
+        assertEquals(content, buffer.readUtf8())
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Reverts [a previous commit](https://github.com/awslabs/smithy-kotlin/commit/ed4324590d37f19ffebab06eade776ea2ab61c72) which disallowed sending requests with zero `Content-Length` in the CRT HTTP engine. 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
#818 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required to allow sending `Content-Length=0` headers in the CRT engine, as it's done in the OkHttp engine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.