### PR TITLE
feat: add code support for awsQuery-compatible error responses

### DIFF
--- a/.changes/2d229b1e-7d3c-4d89-8e5c-030d3baf5dae.json
+++ b/.changes/2d229b1e-7d3c-4d89-8e5c-030d3baf5dae.json
@@ -1,0 +1,5 @@
+{
+    "id": "2d229b1e-7d3c-4d89-8e5c-030d3baf5dae",
+    "type": "feature",
+    "description": "Add code support for awsQuery-compatible error responses."
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -304,6 +304,9 @@ object RuntimeTypes {
     object AwsProtocolCore: RuntimeTypePackage(KotlinDependency.AWS_PROTOCOL_CORE) {
         val withPayload = symbol("withPayload")
         val setAseErrorMetadata = symbol("setAseErrorMetadata")
+        val AwsQueryCompatibleErrorDetails = symbol("AwsQueryCompatibleErrorDetails")
+        val setAwsQueryCompatibleErrorMetadata = symbol("setAwsQueryCompatibleErrorMetadata")
+        val XAmznQueryErrorHeader = symbol("X_AMZN_QUERY_ERROR_HEADER")
     }
 
     object AwsJsonProtocols: RuntimeTypePackage(KotlinDependency.AWS_JSON_PROTOCOLS) {

--- a/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
+++ b/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
@@ -4,6 +4,13 @@ public abstract interface class aws/smithy/kotlin/runtime/awsprotocol/AwsErrorDe
 	public abstract fun getRequestId ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails$Companion {
+	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetailsKt {
+}
+
 public final class aws/smithy/kotlin/runtime/awsprotocol/ProtocolErrorsKt {
 }
 

--- a/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails.kt
+++ b/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.awsprotocol
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.ServiceErrorMetadata
+import aws.smithy.kotlin.runtime.ServiceException
+
+/**
+ * Header name for awsQuery-compatible error values.
+ */
+@InternalApi
+public const val X_AMZN_QUERY_ERROR_HEADER: String = "x-amzn-query-error"
+
+/**
+ * Error details presented for backwards-compatibility by services that have migrated from awsQuery.
+ */
+@InternalApi
+public data class AwsQueryCompatibleErrorDetails(
+    public val code: String,
+    public val type: ServiceException.ErrorType,
+) {
+    public companion object {
+        public fun parse(value: String): AwsQueryCompatibleErrorDetails = parseImpl(value)
+    }
+}
+
+/**
+ * Set awsQuery error details on a [ServiceException]
+ */
+@InternalApi
+public fun setAwsQueryCompatibleErrorMetadata(exception: Any, error: AwsQueryCompatibleErrorDetails) {
+    if (exception is ServiceException) {
+        exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = error.code
+        exception.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorType] = error.type
+    }
+}
+
+// parse an awsQuery error from its string representation
+// the value is formatted as `code;type` e.g. `AWS.SimpleQueueService.NonExistentQueue;Sender`.
+private fun parseImpl(error: String): AwsQueryCompatibleErrorDetails {
+    val segments = error.split(";", limit = 2)
+    require(segments.size == 2) { "value is malformed" }
+    require(segments[0].isNotEmpty()) { "code is empty" }
+
+    val code = segments[0]
+    val type = when (segments[1]) { // can be empty
+        "Sender" -> ServiceException.ErrorType.Client
+        "Receiver" -> ServiceException.ErrorType.Server
+        else -> ServiceException.ErrorType.Unknown
+    }
+    return AwsQueryCompatibleErrorDetails(code, type)
+}

--- a/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails.kt
+++ b/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails.kt
@@ -44,6 +44,7 @@ private fun parseImpl(error: String): AwsQueryCompatibleErrorDetails {
     val segments = error.split(";", limit = 2)
     require(segments.size == 2) { "value is malformed" }
     require(segments[0].isNotEmpty()) { "code is empty" }
+    require(segments[1].isNotEmpty()) { "type is empty" }
 
     val code = segments[0]
     val type = when (segments[1]) { // can be empty

--- a/runtime/protocol/aws-protocol-core/common/test/AwsQueryCompatibleErrorDetailsTest.kt
+++ b/runtime/protocol/aws-protocol-core/common/test/AwsQueryCompatibleErrorDetailsTest.kt
@@ -21,6 +21,12 @@ class AwsQueryCompatibleErrorDetailsTest {
     }
 
     @Test
+    fun testParseEmptyType() {
+        val ex = assertFailsWith<IllegalArgumentException> { AwsQueryCompatibleErrorDetails.parse("code;") }
+        assertEquals("type is empty", ex.message)
+    }
+
+    @Test
     fun testParseErrorClient() {
         val expected = AwsQueryCompatibleErrorDetails(
             "com.test.ErrorCode",
@@ -46,7 +52,7 @@ class AwsQueryCompatibleErrorDetailsTest {
             "com.test.ErrorCode",
             ServiceException.ErrorType.Unknown,
         )
-        val actual = AwsQueryCompatibleErrorDetails.parse("com.test.ErrorCode;")
+        val actual = AwsQueryCompatibleErrorDetails.parse("com.test.ErrorCode;idk")
         assertEquals(expected, actual)
     }
 }

--- a/runtime/protocol/aws-protocol-core/common/test/AwsQueryCompatibleErrorDetailsTest.kt
+++ b/runtime/protocol/aws-protocol-core/common/test/AwsQueryCompatibleErrorDetailsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.awsprotocol
+
+import aws.smithy.kotlin.runtime.ServiceException
+import kotlin.test.*
+
+class AwsQueryCompatibleErrorDetailsTest {
+    @Test
+    fun testParseMalformed() {
+        val ex = assertFailsWith<IllegalArgumentException> { AwsQueryCompatibleErrorDetails.parse("malformed") }
+        assertEquals("value is malformed", ex.message)
+    }
+
+    @Test
+    fun testParseEmptyCode() {
+        val ex = assertFailsWith<IllegalArgumentException> { AwsQueryCompatibleErrorDetails.parse(";type") }
+        assertEquals("code is empty", ex.message)
+    }
+
+    @Test
+    fun testParseErrorClient() {
+        val expected = AwsQueryCompatibleErrorDetails(
+            "com.test.ErrorCode",
+            ServiceException.ErrorType.Client,
+        )
+        val actual = AwsQueryCompatibleErrorDetails.parse("com.test.ErrorCode;Sender")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testParseErrorServer() {
+        val expected = AwsQueryCompatibleErrorDetails(
+            "com.test.ErrorCode",
+            ServiceException.ErrorType.Server,
+        )
+        val actual = AwsQueryCompatibleErrorDetails.parse("com.test.ErrorCode;Receiver")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testParseErrorUnknown() {
+        val expected = AwsQueryCompatibleErrorDetails(
+            "com.test.ErrorCode",
+            ServiceException.ErrorType.Unknown,
+        )
+        val actual = AwsQueryCompatibleErrorDetails.parse("com.test.ErrorCode;")
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
Add `aws-protocol-core` support for parsing aws-Query compatible errors.

Consumed by https://github.com/awslabs/aws-sdk-kotlin/pull/880.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
