### PR TITLE
IdentityProvider input parameter; refactor Attributes

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -84,6 +84,11 @@ class KotlinWriter(
 
         addDepsRecursively(symbol)
 
+        // object references should import the containing object rather than the member referenced
+        if (symbol.isObjectRef) {
+            return addImport(symbol.objectRef!!)
+        }
+
         // only add imports for symbols in a different namespace
         if (symbol.namespace.isNotEmpty() && symbol.namespace != fullPackageName) {
             // Check to see if another symbol with the same name but different namespace

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -311,7 +311,11 @@ object RuntimeTypes {
         val coroutineContext = "kotlin.coroutines.coroutineContext".toSymbol()
     }
 
-    object KotlinxCoroutines {
+    object KotlinxCoroutines{
+
+        val CompletableDeferred = "kotlinx.coroutines.CompletableDeferred".toSymbol()
+        val job = "kotlinx.coroutines.job".toSymbol()
+
         object Flow {
             // NOTE: smithy-kotlin core has an API dependency on this already
             val Flow = "kotlinx.coroutines.flow.Flow".toSymbol()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -145,6 +145,8 @@ object RuntimeTypes {
         }
         object Utils : RuntimeTypePackage(KotlinDependency.CORE, "util") {
             val Attributes = symbol("Attributes")
+            val MutableAttributes = symbol("MutableAttributes")
+            val attributesOf = symbol("attributesOf")
             val AttributeKey = symbol("AttributeKey")
             val flattenIfPossible = symbol("flattenIfPossible")
             val length = symbol("length")
@@ -288,6 +290,7 @@ object RuntimeTypes {
         object HttpAuthAws : RuntimeTypePackage(KotlinDependency.HTTP_AUTH_AWS){
             val AwsHttpSigner = symbol("AwsHttpSigner")
             val SigV4AuthScheme = symbol("SigV4AuthScheme")
+            val sigv4 = symbol("sigv4")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -285,6 +285,7 @@ object RuntimeTypes {
         object HttpAuth: RuntimeTypePackage(KotlinDependency.HTTP_AUTH) {
             val AnonymousAuthScheme  = symbol("AnonymousAuthScheme")
             val AnonymousIdentityProvider = symbol("AnonymousIdentityProvider")
+            val HttpAuthScheme = symbol("HttpAuthScheme")
         }
 
         object HttpAuthAws : RuntimeTypePackage(KotlinDependency.HTTP_AUTH_AWS){

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/AuthSchemeHandler.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/AuthSchemeHandler.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.kotlin.codegen.integration
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.OperationShape
@@ -18,6 +19,12 @@ interface AuthSchemeHandler {
      * The auth scheme ID
      */
     val authSchemeId: ShapeId
+
+    /**
+     * Optional symbol in the runtime that this scheme ID is mapped to (e.g. `AuthSchemeId.Sigv4`)
+     */
+    val authSchemeIdSymbol: Symbol?
+        get() = null
 
     /**
      * Render the expression mapping auth scheme ID to the SDK client config. This is used to render the
@@ -50,4 +57,3 @@ interface AuthSchemeHandler {
      */
     fun instantiateAuthSchemeExpr(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter)
 }
-

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/lang/KotlinTypes.kt
@@ -36,11 +36,12 @@ object KotlinTypes {
 
     object Collections {
         val List: Symbol = builtInSymbol("List", "kotlin.collections")
+        val listOf: Symbol = builtInSymbol("listOf", "kotlin.collections")
         val MutableList: Symbol = builtInSymbol("MutableList", "kotlin.collections")
-        val Set: Symbol = builtInSymbol("Set", "kotlin.collections")
         val Map: Symbol = builtInSymbol("Map", "kotlin.collections")
         val mutableListOf: Symbol = builtInSymbol("mutableListOf", "kotlin.collections")
         val mutableMapOf: Symbol = builtInSymbol("mutableMapOf", "kotlin.collections")
+        val Set: Symbol = builtInSymbol("Set", "kotlin.collections")
 
         private fun listType(
             listType: Symbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilder.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolBuilder.kt
@@ -23,6 +23,7 @@ open class SymbolBuilder {
     var name: String? = null
     var nullable: Boolean = true
     var isExtension: Boolean = false
+    var objectRef: Symbol? = null
     var namespace: String? = null
 
     var definitionFile: String? = null
@@ -80,6 +81,9 @@ open class SymbolBuilder {
             builder.boxed()
         }
         builder.putProperty(SymbolProperty.IS_EXTENSION, isExtension)
+        if (objectRef != null) {
+            builder.putProperty(SymbolProperty.OBJECT_REF, objectRef)
+        }
 
         namespace?.let { builder.namespace(namespace, ".") }
         declarationFile?.let { builder.declarationFile(it) }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
@@ -41,6 +41,9 @@ object SymbolProperty {
 
     // Denotes whether a symbol represents an extension function
     const val IS_EXTENSION: String = "isExtension"
+
+    // Denotes the symbol is a reference to a static member of an object (e.g. of an object or companion object)
+    const val OBJECT_REF: String = "objectRef"
 }
 
 /**
@@ -181,3 +184,15 @@ fun Symbol.asNullable(): Symbol = toBuilder().boxed().build()
  */
 val Symbol.isExtension: Boolean
     get() = getProperty(SymbolProperty.IS_EXTENSION).getOrNull() == true
+
+/**
+ * Check whether a symbol represents a static reference (member of object/companion object)
+ */
+val Symbol.isObjectRef: Boolean
+    get() = getProperty(SymbolProperty.OBJECT_REF).getOrNull() != null
+
+/**
+ * Get the parent object/companion object symbol
+ */
+val Symbol.objectRef: Symbol?
+    get() = getProperty(SymbolProperty.OBJECT_REF, Symbol::class.java).getOrNull()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -44,6 +44,7 @@ class ServiceClientConfigGenerator(
         if (context.protocolGenerator?.applicationProtocol?.isHttpProtocol == true) {
             add(RuntimeConfigProperty.HttpClientEngine)
             add(RuntimeConfigProperty.HttpInterceptors)
+            add(RuntimeConfigProperty.HttpAuthSchemes)
         }
         if (shape.hasIdempotentTokenMember(context.model)) {
             add(RuntimeConfigProperty.IdempotencyTokenProvider)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
@@ -5,10 +5,13 @@
 
 package software.amazon.smithy.kotlin.codegen.rendering.auth
 
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.integration.AuthSchemeHandler
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
@@ -25,6 +28,14 @@ class AnonymousAuthSchemeIntegration : KotlinIntegration {
 
 class AnonymousAuthSchemeHandler : AuthSchemeHandler {
     override val authSchemeId: ShapeId = OptionalAuthTrait.ID
+    override val authSchemeIdSymbol: Symbol = buildSymbol {
+        name = "AuthSchemeId.Anonymous"
+        val ref = RuntimeTypes.Auth.Identity.AuthSchemeId
+        objectRef = ref
+        namespace = ref.namespace
+        reference(ref, SymbolReference.ContextOption.USE)
+    }
+
     override fun identityProviderAdapterExpression(writer: KotlinWriter) {
         writer.write("#T", RuntimeTypes.Auth.HttpAuth.AnonymousIdentityProvider)
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
@@ -6,13 +6,15 @@ package software.amazon.smithy.kotlin.codegen.rendering.auth
 
 import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
-import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.AuthSchemeHandler
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
 import software.amazon.smithy.kotlin.codegen.model.knowledge.AwsSignatureVersion4
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
@@ -54,6 +56,14 @@ class Sigv4AuthSchemeIntegration : KotlinIntegration {
 
 open class SigV4AuthSchemeHandler : AuthSchemeHandler {
     override val authSchemeId: ShapeId = SigV4Trait.ID
+
+    override val authSchemeIdSymbol: Symbol = buildSymbol {
+        name = "AuthSchemeId.AwsSigV4"
+        val ref = RuntimeTypes.Auth.Identity.AuthSchemeId
+        objectRef = ref
+        namespace = ref.namespace
+        reference(ref, SymbolReference.ContextOption.USE)
+    }
 
     override fun identityProviderAdapterExpression(writer: KotlinWriter) {
         writer.write("config.credentialsProvider")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
@@ -65,29 +65,11 @@ open class SigV4AuthSchemeHandler : AuthSchemeHandler {
         writer: KotlinWriter
     ) {
         val expr = if (op?.hasTrait<UnsignedPayloadTrait>() == true) {
-            "sigv4(unsignedPayload = true)"
+            "#T(unsignedPayload = true)"
         }else {
-            "sigv4()"
+            "#T()"
         }
-        writer.write(expr)
-    }
-
-    // FIXME: Move to runtime?
-    override fun authSchemeProviderRenderAdditionalMethods(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
-        super.authSchemeProviderRenderAdditionalMethods(ctx, writer)
-        writer.withBlock(
-            "private fun sigv4(unsignedPayload: Boolean = false): #T {",
-            "}",
-            RuntimeTypes.Auth.Identity.AuthSchemeOption
-        ) {
-            writer.write("val opt = #T(#T.AwsSigV4)", RuntimeTypes.Auth.Identity.AuthSchemeOption, RuntimeTypes.Auth.Identity.AuthSchemeId)
-            writer.write(
-                "if (unsignedPayload) opt.attributes[#T.HashSpecification] = #T.UnsignedPayload",
-                RuntimeTypes.Auth.Signing.AwsSigningCommon.AwsSigningAttributes,
-                RuntimeTypes.Auth.Signing.AwsSigningCommon.HashSpecification
-            )
-            writer.write("return opt")
-        }
+        writer.write(expr, RuntimeTypes.Auth.HttpAuthAws.sigv4)
     }
 
     override fun instantiateAuthSchemeExpr(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -163,7 +163,7 @@ class DefaultEndpointProviderGenerator(
                 }
 
                 if (rule.endpoint.properties.isNotEmpty()) {
-                    withBlock("attributes = #T().apply {", "},", RuntimeTypes.Core.Utils.Attributes) {
+                    withBlock("attributes = #T {", "},", RuntimeTypes.Core.Utils.attributesOf) {
                         rule.endpoint.properties.entries.forEach { (k, v) ->
                             val kStr = k.asString()
 
@@ -175,11 +175,8 @@ class DefaultEndpointProviderGenerator(
 
                             // otherwise, we just traverse the value like any other rules expression, object values will
                             // be rendered as Documents
-                            withBlock("set(", ")") {
-                                write("#T(#S),", RuntimeTypes.Core.Utils.AttributeKey, kStr)
-                                renderExpression(v)
-                                write(",")
-                            }
+                            writeInline("#T(#S) to ", RuntimeTypes.Core.Utils.AttributeKey, kStr)
+                            renderExpression(v)
                         }
                     }
                 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -177,6 +177,7 @@ class DefaultEndpointProviderGenerator(
                             // be rendered as Documents
                             writeInline("#T(#S) to ", RuntimeTypes.Core.Utils.AttributeKey, kStr)
                             renderExpression(v)
+                            ensureNewline()
                         }
                     }
                 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -119,18 +119,16 @@ class DefaultEndpointProviderTestGenerator(
             }
 
             if (endpoint.properties.isNotEmpty()) {
-                withBlock("attributes = #T().apply {", "},", RuntimeTypes.Core.Utils.Attributes) {
+                withBlock("attributes = #T {", "},", RuntimeTypes.Core.Utils.attributesOf) {
                     endpoint.properties.entries.forEach { (k, v) ->
                         if (k in expectedPropertyRenderers) {
                             expectedPropertyRenderers[k]!!(writer, Expression.fromNode(v), this@DefaultEndpointProviderTestGenerator)
                             return@forEach
                         }
 
-                        withBlock("set(", ")") {
-                            write("#T(#S),", RuntimeTypes.Core.Utils.AttributeKey, k)
-                            renderExpression(Expression.fromNode(v))
-                            write(",")
-                        }
+                        writeInline("#T(#S) to ", RuntimeTypes.Core.Utils.AttributeKey, k)
+                        renderExpression(Expression.fromNode(v))
+                        ensureNewline()
                     }
                 }
             }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -101,7 +101,7 @@ abstract class HttpProtocolClientGenerator(
                 }
 
                 withBlock(
-                    "computeIfAbsent($format){",
+                    "getOrPut($format){",
                     "}",
                     *args
                 ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -6,7 +6,6 @@ package software.amazon.smithy.kotlin.codegen.rendering.protocol
 
 import software.amazon.smithy.aws.traits.HttpChecksumTrait
 import software.amazon.smithy.kotlin.codegen.core.*
-import software.amazon.smithy.kotlin.codegen.integration.AuthSchemeHandler
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.integration.SectionKey
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
@@ -18,12 +17,10 @@ import software.amazon.smithy.kotlin.codegen.rendering.serde.deserializerName
 import software.amazon.smithy.kotlin.codegen.rendering.serde.serializerName
 import software.amazon.smithy.kotlin.codegen.utils.getOrNull
 import software.amazon.smithy.model.knowledge.OperationIndex
-import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.traits.EndpointTrait
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait
-import java.util.logging.Logger
 
 /**
  * Renders an implementation of a service interface for HTTP protocol
@@ -89,20 +86,31 @@ abstract class HttpProtocolClientGenerator(
         writer.write("private val identityProviderConfig = #T(config)", IdentityProviderConfigGenerator.getSymbol(ctx.settings))
 
         writer.withBlock(
-            "private val configuredAuthSchemes = listOf(",
-            ")",
+            "private val configuredAuthSchemes = with(config.authSchemes.associateBy(#T::schemeId).toMutableMap()){",
+            "}",
+            RuntimeTypes.Auth.HttpAuth.HttpAuthScheme
         ){
-            // FIXME - generate reconciliation with customer overrides from config
             val authIndex = AuthIndex()
             val allAuthHandlers = authIndex.authHandlersForService(ctx)
 
             allAuthHandlers.forEach {
-                // use inline writer to deal with list formatting
-                val inlineWriter: InlineKotlinWriter = { it.instantiateAuthSchemeExpr(ctx, this) }
-                writer.write("#W,", inlineWriter)
-            }
-        }
+                val (format, args) = if (it.authSchemeIdSymbol != null) {
+                    "#T" to arrayOf(it.authSchemeIdSymbol!!)
+                }else {
+                    "#T(#S)" to arrayOf(RuntimeTypes.Auth.Identity.AuthSchemeId, it.authSchemeId)
+                }
 
+                withBlock(
+                    "computeIfAbsent($format){",
+                    "}",
+                    *args
+                ) {
+                    it.instantiateAuthSchemeExpr(ctx, this)
+                }
+            }
+
+            write("toMap()")
+        }
     }
 
     protected open fun importSymbols(writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -169,7 +169,7 @@ object RuntimeConfigProperty {
         name = "authSchemes"
         symbol = KotlinTypes.Collections.list(RuntimeTypes.Auth.HttpAuth.HttpAuthScheme, default = "emptyList()")
         documentation = """
-            Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+            Register new or override default [HttpAuthScheme]s configured for this client. By default, the set
             of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
             precedence over the defaults and can be used to customize identity resolution and signing for specific
             authentication schemes.

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -164,4 +164,15 @@ object RuntimeConfigProperty {
             later than any added automatically by the SDK.
         """.trimIndent()
     }
+
+    val HttpAuthSchemes = ConfigProperty {
+        name = "authSchemes"
+        symbol = KotlinTypes.Collections.list(RuntimeTypes.Auth.HttpAuth.HttpAuthScheme, default = "emptyList()")
+        documentation = """
+            Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+            of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
+            precedence over the defaults and can be used to customize identity resolution and signing for specific
+            authentication schemes.
+        """.trimIndent()
+    }
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -69,7 +69,7 @@ public class Config private constructor(builder: Builder) : HttpClientConfig, Id
         override var httpClientEngine: HttpClientEngine? = null
 
         /**
-         * Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+         * Register new or override default [HttpAuthScheme]s configured for this client. By default, the set
          * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
          * precedence over the defaults and can be used to customize identity resolution and signing for specific
          * authentication schemes.
@@ -253,7 +253,7 @@ public class Config private constructor(builder: Builder) {
         override var httpClientEngine: HttpClientEngine? = null
 
         /**
-         * Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+         * Register new or override default [HttpAuthScheme]s configured for this client. By default, the set
          * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
          * precedence over the defaults and can be used to customize identity resolution and signing for specific
          * authentication schemes.

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -48,6 +48,7 @@ public class Config private constructor(builder: Builder) : HttpClientConfig, Id
 
         val expectedProps = """
     override val httpClientEngine: HttpClientEngine = builder.httpClientEngine ?: DefaultHttpEngine().manage()
+    public val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = builder.authSchemes
     public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
@@ -66,6 +67,14 @@ public class Config private constructor(builder: Builder) : HttpClientConfig, Id
          * client will not close it when the client is closed.
          */
         override var httpClientEngine: HttpClientEngine? = null
+
+        /**
+         * Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+         * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
+         * precedence over the defaults and can be used to customize identity resolution and signing for specific
+         * authentication schemes.
+         */
+        public var authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = emptyList()
 
         /**
          * The endpoint provider used to determine where to make service requests.
@@ -242,6 +251,14 @@ public class Config private constructor(builder: Builder) {
          * client will not close it when the client is closed.
          */
         override var httpClientEngine: HttpClientEngine? = null
+
+        /**
+         * Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+         * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
+         * precedence over the defaults and can be used to customize identity resolution and signing for specific
+         * authentication schemes.
+         */
+        public var authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = emptyList()
 
         public var customProp: Int? = null
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -190,30 +190,15 @@ class DefaultEndpointProviderGeneratorTest {
                 headers = Headers {
                     append("fooheader", "barheader")
                 },
-                attributes = Attributes().apply {
-                    set(
-                        AttributeKey("foo"),
-                        "bar",
-                    )
-                    set(
-                        AttributeKey("fooInt"),
-                        7,
-                    )
-                    set(
-                        AttributeKey("fooBoolean"),
-                        true,
-                    )
-                    set(
-                        AttributeKey("fooObject"),
-                        buildDocument {
-                            "fooObjectFoo" to "bar"
-                        },
-                    )
-                    set(
-                        AttributeKey("fooArray"),
-                        listOf(
-                            "\"fooArrayBar\"",
-                        ),
+                attributes = attributesOf {
+                    AttributeKey("foo") to "bar"
+                    AttributeKey("fooInt") to 7
+                    AttributeKey("fooBoolean") to true
+                    AttributeKey("fooObject") to buildDocument {
+                        "fooObjectFoo" to "bar"
+                    }
+                    AttributeKey("fooArray") to listOf(
+                        "\"fooArrayBar\"",
                     )
                 },
             )

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 import aws.smithy.kotlin.runtime.io.closeIfCloseable
 import aws.smithy.kotlin.runtime.time.Clock
 import aws.smithy.kotlin.runtime.tracing.trace
+import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.CachedValue
 import aws.smithy.kotlin.runtime.util.ExpiringValue
 import kotlinx.atomicfu.atomic
@@ -54,7 +55,7 @@ public class CachedCredentialsProvider(
     private val cachedCredentials = CachedValue<Credentials>(null, bufferTime = refreshBufferWindow, clock)
     private val closed = atomic(false)
 
-    override suspend fun resolve(): Credentials {
+    override suspend fun resolve(attributes: Attributes): Credentials {
         check(!closed.value) { "Credentials provider is closed" }
 
         return cachedCredentials.getOrLoad {

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
@@ -7,7 +7,8 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 import aws.smithy.kotlin.runtime.identity.Identity
 import aws.smithy.kotlin.runtime.identity.IdentityAttributes
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.MutableAttributes
+import aws.smithy.kotlin.runtime.util.mutableAttributes
 
 /**
  * Represents a set of AWS credentials
@@ -21,7 +22,7 @@ public data class Credentials(
     override val expiration: Instant? = null,
     val providerName: String? = null,
 ) : Identity {
-    override val attributes: Attributes by lazy { Attributes() }
+    override val attributes: MutableAttributes = mutableAttributes()
     init {
         providerName?.let {
             attributes[IdentityAttributes.ProviderName] = it

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 
 import aws.smithy.kotlin.runtime.identity.IdentityProvider
 import aws.smithy.kotlin.runtime.io.Closeable
+import aws.smithy.kotlin.runtime.util.Attributes
 
 /**
  * Represents a producer/source of AWS credentials
@@ -14,7 +15,7 @@ public interface CredentialsProvider : IdentityProvider {
     /**
      * Request credentials from the provider
      */
-    public override suspend fun resolve(): Credentials
+    public override suspend fun resolve(attributes: Attributes): Credentials
 }
 
 /**

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 
 import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.tracing.*
+import aws.smithy.kotlin.runtime.util.Attributes
 import kotlin.coroutines.coroutineContext
 
 // TODO - support caching the provider that actually resolved credentials such that future calls don't involve going through the full chain
@@ -29,14 +30,14 @@ public open class CredentialsProviderChain(
     override fun toString(): String =
         (listOf(this) + providers).map { it::class.simpleName }.joinToString(" -> ")
 
-    override suspend fun resolve(): Credentials = coroutineContext.withChildTraceSpan("Credentials chain") {
+    override suspend fun resolve(attributes: Attributes): Credentials = coroutineContext.withChildTraceSpan("Credentials chain") {
         val logger = coroutineContext.traceSpan.logger<CredentialsProviderChain>()
         val chain = this@CredentialsProviderChain
         val chainException = lazy { CredentialsProviderException("No credentials could be loaded from the chain: $chain") }
         for (provider in providers) {
             logger.trace { "Attempting to load credentials from $provider" }
             try {
-                return@withChildTraceSpan provider.resolve()
+                return@withChildTraceSpan provider.resolve(attributes)
             } catch (ex: Exception) {
                 logger.debug { "unable to load credentials from $provider: ${ex.message}" }
                 chainException.value.addSuppressed(ex)

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.ManualClock
+import aws.smithy.kotlin.runtime.util.Attributes
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -27,7 +28,7 @@ class CachedCredentialsProviderTest {
     ) : CredentialsProvider {
         var callCount = 0
 
-        override suspend fun resolve(): Credentials {
+        override suspend fun resolve(attributes: Attributes): Credentials {
             callCount++
             return Credentials(
                 "AKID",
@@ -103,7 +104,7 @@ class CachedCredentialsProviderTest {
     fun testLoadFailed() = runTest {
         val source = object : CredentialsProvider {
             private var count = 0
-            override suspend fun resolve(): Credentials {
+            override suspend fun resolve(attributes: Attributes): Credentials {
                 if (count <= 0) {
                     count++
                     throw RuntimeException("test error")

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.auth.awscredentials
 
+import aws.smithy.kotlin.runtime.util.Attributes
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -22,7 +23,7 @@ class CredentialsProviderChainTest {
         }
     }
     data class TestProvider(val credentials: Credentials? = null) : CredentialsProvider {
-        override suspend fun resolve(): Credentials = credentials ?: throw IllegalStateException("no credentials available")
+        override suspend fun resolve(attributes: Attributes): Credentials = credentials ?: throw IllegalStateException("no credentials available")
     }
 
     @Test

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -5,36 +5,36 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import aws.smithy.kotlin.runtime.client.ClientOption
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.AttributeKey
+import kotlinx.coroutines.CompletableDeferred
 
 /**
- *  [ClientOption] instances related to signing.
+ *  [AttributeKey] instances related to signing.
  */
 public object AwsSigningAttributes {
     /**
      * The signer implementation to use
      */
-    public val Signer: ClientOption<AwsSigner> = ClientOption("Signer")
+    public val Signer: AttributeKey<AwsSigner> = AttributeKey("aws.smithy.kotlin#Signer")
 
     /**
      * AWS region to be used for signing the request
      */
-    public val SigningRegion: ClientOption<String> = ClientOption("AwsSigningRegion")
+    public val SigningRegion: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#AwsSigningRegion")
 
     /**
      * The signature version 4 service signing name to use in the credential scope when signing requests.
      * See: https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html
      */
-    public val SigningService: ClientOption<String> = ClientOption("AwsSigningService")
+    public val SigningService: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#AwsSigningService")
 
     /**
      * Override the date to complete the signing process with. Defaults to current time when not specified.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val SigningDate: ClientOption<Instant> = ClientOption("SigningDate")
+    public val SigningDate: AttributeKey<Instant> = AttributeKey("aws.smithy.kotlin#SigningDate")
 
     /**
      * The [CredentialsProvider] to complete the signing process with. Defaults to the provider configured
@@ -42,24 +42,25 @@ public object AwsSigningAttributes {
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val CredentialsProvider: ClientOption<CredentialsProvider> = ClientOption("CredentialsProvider")
+    public val CredentialsProvider: AttributeKey<CredentialsProvider> = AttributeKey("aws.smithy.kotlin#CredentialsProvider")
 
     /**
      * The specification for determining the hash value for the request.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val HashSpecification: ClientOption<HashSpecification> = ClientOption("HashSpecification")
+    public val HashSpecification: AttributeKey<HashSpecification> = AttributeKey("aws.smithy.kotlin#HashSpecification")
 
     /**
      * The signed body header type.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val SignedBodyHeader: ClientOption<AwsSignedBodyHeader> = ClientOption("SignedBodyHeader")
+    public val SignedBodyHeader: AttributeKey<AwsSignedBodyHeader> = AttributeKey("aws.smithy.kotlin#SignedBodyHeader")
 
     /**
-     * The signature of the HTTP request. This will only exist after the request has been signed.
+     * The signature of the HTTP request. The signer will complete this once the request has been signed.
+     * Operation middleware is responsible for resetting the completable deferred value.
      */
-    public val RequestSignature: AttributeKey<ByteArray> = AttributeKey("AWS_HTTP_SIGNATURE")
+    public val RequestSignature: AttributeKey<CompletableDeferred<ByteArray>> = AttributeKey("aws.smithy.kotlin#RequestSignature")
 }

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningTestUtil.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningTestUtil.kt
@@ -7,10 +7,11 @@ package aws.smithy.kotlin.runtime.auth.awssigning.tests
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import aws.smithy.kotlin.runtime.util.Attributes
 
 public val DEFAULT_TEST_CREDENTIALS: Credentials = Credentials("AKID", "SECRET", "SESSION")
 public val DEFAULT_TEST_CREDENTIALS_PROVIDER: CredentialsProvider = DEFAULT_TEST_CREDENTIALS.asStaticProvider()
 
 public fun Credentials.asStaticProvider(): CredentialsProvider = object : CredentialsProvider {
-    override suspend fun resolve(): Credentials = this@asStaticProvider
+    override suspend fun resolve(attributes: Attributes): Credentials = this@asStaticProvider
 }

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -22,6 +22,7 @@ import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 import aws.smithy.kotlin.runtime.net.fullUriToQueryParameters
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.ValuesMap
 import aws.smithy.kotlin.runtime.util.get
 import io.ktor.http.cio.*
@@ -460,7 +461,7 @@ private fun buildOperation(
     }
 
     val idp = object : CredentialsProvider {
-        override suspend fun resolve(): Credentials = config.credentials
+        override suspend fun resolve(attributes: Attributes): Credentials = config.credentials
     }
 
     val signerConfig = AwsHttpSigner.Config().apply {

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -145,9 +145,8 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
         val signingResult = checkNotNull(config.signer).sign(request.build(), signingConfig)
         val signedRequest = signingResult.output
 
-        // FIXME - need a better way of propagating this back for event streams
         // Add the signature to the request context
-        // attributes[AwsSigningAttributes.RequestSignature] = signingResult.signature
+        attributes.getOrNull(AwsSigningAttributes.RequestSignature)?.complete(signingResult.signature)
 
         request.update(signedRequest)
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -145,8 +145,9 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
         val signingResult = checkNotNull(config.signer).sign(request.build(), signingConfig)
         val signedRequest = signingResult.output
 
+        // FIXME - need a better way of propagating this back for event streams
         // Add the signature to the request context
-        attributes[AwsSigningAttributes.RequestSignature] = signingResult.signature
+        // attributes[AwsSigningAttributes.RequestSignature] = signingResult.signature
 
         request.update(signedRequest)
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -5,8 +5,14 @@
 
 package aws.smithy.kotlin.runtime.http.auth
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
+import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
+import aws.smithy.kotlin.runtime.auth.awssigning.HashSpecification
+import aws.smithy.kotlin.runtime.util.attributesOf
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 
 // TODO - is AwsHttpSigner.Config what we want to use to configure this scheme?
 /**
@@ -24,4 +30,21 @@ public class SigV4AuthScheme(
 
     override val schemeId: AuthSchemeId = AuthSchemeId.AwsSigV4
     override val signer: AwsHttpSigner = AwsHttpSigner(config)
+}
+
+/**
+ * Create a new [AuthSchemeOption] for the [SigV4AuthScheme]
+ * @param unsignedPayload set the signing attribute to indicate the signer should use unsigned payload.
+ * @return auth scheme option representing the [SigV4AuthScheme]
+ */
+@InternalApi
+public fun sigv4(unsignedPayload: Boolean = false): AuthSchemeOption {
+    val attrs = if (unsignedPayload) {
+        attributesOf {
+            AwsSigningAttributes.HashSpecification to HashSpecification.UnsignedPayload
+        }
+    } else {
+        emptyAttributes()
+    }
+    return AuthSchemeOption(AuthSchemeId.AwsSigV4, attrs)
 }

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -25,6 +25,7 @@ import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.get
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
@@ -87,7 +88,7 @@ public abstract class AwsHttpSignerTestBase(
         }
 
         val idp = object : CredentialsProvider {
-            override suspend fun resolve(): Credentials = testCredentials
+            override suspend fun resolve(attributes: Attributes): Credentials = testCredentials
         }
 
         val signerConfig = AwsHttpSigner.Config().apply {

--- a/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
+++ b/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
@@ -29,7 +29,7 @@ public object AnonymousIdentity : Identity {
 }
 
 public object AnonymousIdentityProvider : IdentityProvider {
-    override suspend fun resolve(): Identity = AnonymousIdentity
+    override suspend fun resolve(attributes: Attributes): Identity = AnonymousIdentity
 }
 
 /**

--- a/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
+++ b/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
@@ -11,6 +11,7 @@ import aws.smithy.kotlin.runtime.identity.IdentityProvider
 import aws.smithy.kotlin.runtime.identity.IdentityProviderConfig
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 
 /**
  * A no-op signer that does nothing with the request
@@ -24,7 +25,7 @@ public object AnonymousHttpSigner : HttpSigner {
  */
 public object AnonymousIdentity : Identity {
     override val expiration: Instant? = null
-    override val attributes: Attributes = Attributes()
+    override val attributes: Attributes = emptyAttributes()
 }
 
 public object AnonymousIdentityProvider : IdentityProvider {

--- a/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeOption.kt
+++ b/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeOption.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.auth
 
 import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 
 /**
  * A tuple of [AuthSchemeId] and typed properties. AuthSchemeOption represents a candidate
@@ -20,5 +21,5 @@ public data class AuthSchemeOption(
     /**
      * Identity or signer attributes to use with this resolved authentication scheme
      */
-    public val attributes: Attributes = Attributes(),
+    public val attributes: Attributes = emptyAttributes(),
 )

--- a/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/identity/IdentityProvider.kt
+++ b/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/identity/IdentityProvider.kt
@@ -5,13 +5,18 @@
 
 package aws.smithy.kotlin.runtime.identity
 
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+
 /**
  * Resolves identities for a service client
  */
 public interface IdentityProvider {
     /**
      * Resolve the identity to authenticate requests with
-     * @return an [Identity] that can be used to connect to the service
+     * @param attributes Additional attributes to feed into identity resolution. Typically, metadata from
+     * selecting the authentication scheme.
+     * @return An [Identity] that can be used to connect to the service
      */
-    public suspend fun resolve(): Identity
+    public suspend fun resolve(attributes: Attributes = emptyAttributes()): Identity
 }

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
@@ -13,6 +13,7 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.ManualClock
+import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.encodeToHex
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -25,7 +26,7 @@ import kotlin.test.assertEquals
 class EventStreamSigningTest {
     private val testCredentials = Credentials("fake access key", "fake secret key")
     private val testCredentialsProvider = object : CredentialsProvider {
-        override suspend fun resolve() = testCredentials
+        override suspend fun resolve(attributes: Attributes) = testCredentials
     }
 
     @Test

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
@@ -15,6 +15,7 @@ import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.ManualClock
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.encodeToHex
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -76,7 +77,7 @@ class EventStreamSigningTest {
 
         val context = ExecutionContext()
         context[AwsSigningAttributes.Signer] = DefaultAwsSigner
-        context[AwsSigningAttributes.RequestSignature] = HashSpecification.EmptyBody.hash.encodeToByteArray()
+        context[AwsSigningAttributes.RequestSignature] = CompletableDeferred(HashSpecification.EmptyBody.hash.encodeToByteArray())
         context[AwsSigningAttributes.SigningRegion] = "us-east-2"
         context[AwsSigningAttributes.SigningService] = "test"
         context[AwsSigningAttributes.CredentialsProvider] = testCredentialsProvider

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
@@ -13,11 +13,11 @@ import aws.smithy.kotlin.runtime.http.auth.AnonymousAuthScheme
 import aws.smithy.kotlin.runtime.http.auth.AnonymousIdentityProvider
 import aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme
 import aws.smithy.kotlin.runtime.identity.IdentityProviderConfig
+import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 
-private val AnonymousAuthConfig = OperationAuthConfig(
-    { listOf(AuthSchemeOption(AuthSchemeId.Anonymous)) },
-    configuredAuthSchemes = listOf(AnonymousAuthScheme),
-    { AnonymousIdentityProvider },
+private val AnonymousAuthConfig = OperationAuthConfig.from(
+    AnonymousIdentityProvider.asIdentityProviderConfig(),
+    AnonymousAuthScheme,
 )
 
 /**
@@ -29,7 +29,7 @@ private val AnonymousAuthConfig = OperationAuthConfig(
 @InternalApi
 public data class OperationAuthConfig(
     val authSchemeResolver: AuthSchemeResolver,
-    val configuredAuthSchemes: List<HttpAuthScheme>,
+    val configuredAuthSchemes: Map<AuthSchemeId, HttpAuthScheme>,
     val identityProviderConfig: IdentityProviderConfig,
 ) {
     public companion object {
@@ -44,7 +44,7 @@ public data class OperationAuthConfig(
             vararg authSchemes: HttpAuthScheme,
         ): OperationAuthConfig {
             val resolver = AuthSchemeResolver { authSchemes.map { AuthSchemeOption(it.schemeId) } }
-            return OperationAuthConfig(resolver, authSchemes.toList(), identityProviderConfig)
+            return OperationAuthConfig(resolver, authSchemes.associateBy(HttpAuthScheme::schemeId), identityProviderConfig)
         }
     }
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -253,9 +253,8 @@ internal class HttpAuthHandler<Input, Output>(
         // select an auth scheme by reconciling the (priority) list of candidates returned from the resolver
         // with the ones actually configured/available for the SDK
         val candidateAuthSchemes = authConfig.authSchemeResolver.resolve(request)
-        val configuredAuthSchemes = authConfig.configuredAuthSchemes.associateBy { it.schemeId }
-        val authOption = candidateAuthSchemes.firstOrNull { it.schemeId in configuredAuthSchemes } ?: error("no auth scheme found for operation; candidates: $candidateAuthSchemes")
-        val authScheme = configuredAuthSchemes[authOption.schemeId] ?: error("auth scheme ${authOption.schemeId} not configured")
+        val authOption = candidateAuthSchemes.firstOrNull { it.schemeId in authConfig.configuredAuthSchemes } ?: error("no auth scheme found for operation; candidates: $candidateAuthSchemes")
+        val authScheme = authConfig.configuredAuthSchemes[authOption.schemeId] ?: error("auth scheme ${authOption.schemeId} not configured")
 
         // resolve identity from the selected auth scheme
         val identityProvider = authScheme.identityProvider(authConfig.identityProviderConfig)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -259,7 +259,7 @@ internal class HttpAuthHandler<Input, Output>(
 
         // resolve identity from the selected auth scheme
         val identityProvider = authScheme.identityProvider(authConfig.identityProviderConfig)
-        val identity = identityProvider.resolve()
+        val identity = identityProvider.resolve(authOption.attributes)
 
         // FIXME - endpoint resolution should happen here, either we make it explicit or we change implementation to use modifyBeforeSigning and have to stuff identity into the context
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
@@ -14,7 +14,7 @@ import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 import aws.smithy.kotlin.runtime.io.Handler
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.AttributeKey
-import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.attributesOf
 import aws.smithy.kotlin.runtime.util.get
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -47,8 +47,9 @@ class HttpAuthHandlerTest {
         }
 
         val resolver = AuthSchemeResolver {
-            val attrs = Attributes()
-            attrs[testAttrKey] = "testing"
+            val attrs = attributesOf {
+                testAttrKey to "testing"
+            }
             listOf(AuthSchemeOption(AuthSchemeId.Anonymous, attrs))
         }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
@@ -64,7 +64,8 @@ class HttpAuthHandlerTest {
             listOf(AuthSchemeOption(AuthSchemeId.Anonymous, attrs))
         }
 
-        val authConfig = OperationAuthConfig(resolver, listOf(scheme), idpConfig)
+        val schemes = listOf(scheme).associateBy(HttpAuthScheme::schemeId)
+        val authConfig = OperationAuthConfig(resolver, schemes, idpConfig)
         val op = HttpAuthHandler<Unit, Unit>(inner, interceptorExec, authConfig)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())
         op.call(request)

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpAuthHandlerTest.kt
@@ -20,11 +20,13 @@ import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.attributesOf
 import aws.smithy.kotlin.runtime.util.get
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HttpAuthHandlerTest {
     private val testAttrKey = AttributeKey<String>("HttpAuthHandlerTest")
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
@@ -5,14 +5,15 @@
 package aws.smithy.kotlin.runtime
 
 import aws.smithy.kotlin.runtime.util.AttributeKey
-import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.MutableAttributes
+import aws.smithy.kotlin.runtime.util.mutableAttributes
 
 /**
  * Additional metadata about an error
  */
 public open class ErrorMetadata {
     @InternalApi
-    public val attributes: Attributes = Attributes()
+    public val attributes: MutableAttributes = mutableAttributes()
 
     public companion object {
         /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/operation/ExecutionContext.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/operation/ExecutionContext.kt
@@ -4,7 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.operation
 
-import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.MutableAttributes
+import aws.smithy.kotlin.runtime.util.mutableAttributes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlin.coroutines.CoroutineContext
@@ -12,7 +13,7 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Per operation metadata a service client uses to drive the execution of a single request/response
  */
-public class ExecutionContext private constructor(builder: ExecutionContextBuilder) : Attributes by builder.attributes, CoroutineScope {
+public class ExecutionContext private constructor(builder: ExecutionContextBuilder) : MutableAttributes by builder.attributes, CoroutineScope {
     /**
      * Default construct an [ExecutionContext]. Note: this is not usually useful without configuring the call attributes
      */
@@ -23,14 +24,14 @@ public class ExecutionContext private constructor(builder: ExecutionContextBuild
     /**
      * Attributes associated with this particular execution/call
      */
-    public val attributes: Attributes = builder.attributes
+    public val attributes: MutableAttributes = builder.attributes
 
     public companion object {
         public fun build(block: ExecutionContextBuilder.() -> Unit): ExecutionContext = ExecutionContextBuilder().apply(block).build()
     }
 
     public class ExecutionContextBuilder {
-        public var attributes: Attributes = Attributes()
+        public var attributes: MutableAttributes = mutableAttributes()
 
         public fun build(): ExecutionContext = ExecutionContext(this)
     }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -16,7 +16,7 @@ public data class AttributeKey<T>(public val name: String) {
 }
 
 /**
- * Generic type safe property bag
+ * Immutable type safe property bag
  */
 public interface Attributes {
     /**
@@ -29,6 +29,16 @@ public interface Attributes {
      */
     public operator fun contains(key: AttributeKey<*>): Boolean
 
+    /**
+     * Get a set of all the keys
+     */
+    public val keys: Set<AttributeKey<*>>
+}
+
+/**
+ * Mutable type safe property bag
+ */
+public interface MutableAttributes : Attributes {
     /**
      * Creates or changes an attribute with the specified [key] using [value]
      */
@@ -43,18 +53,6 @@ public interface Attributes {
      * Gets a value of the attribute for the specified [key], or calls supplied [block] to compute its value
      */
     public fun <T : Any> computeIfAbsent(key: AttributeKey<T>, block: () -> T): T
-
-    /**
-     * Get a set of all the keys
-     */
-    public val keys: Set<AttributeKey<*>>
-
-    public companion object {
-        /**
-         * Create an attributes instance
-         */
-        public operator fun invoke(): Attributes = AttributesImpl()
-    }
 }
 
 /**
@@ -65,39 +63,44 @@ public operator fun <T : Any> Attributes.get(key: AttributeKey<T>): T = getOrNul
 /**
  * Removes an attribute with the specified [key] and returns its current value, throws an exception if an attribute doesn't exist
  */
-public fun <T : Any> Attributes.take(key: AttributeKey<T>): T = get(key).also { remove(key) }
+public fun <T : Any> MutableAttributes.take(key: AttributeKey<T>): T = get(key).also { remove(key) }
 
 /**
  * Set a value for [key] only if it is not already set
  */
-public fun <T : Any> Attributes.putIfAbsent(key: AttributeKey<T>, value: T) {
+public fun <T : Any> MutableAttributes.putIfAbsent(key: AttributeKey<T>, value: T) {
     if (!contains(key)) set(key, value)
 }
 
 /**
  * Set a value for [key] only if [value] is not null
  */
-public fun <T : Any> Attributes.setIfValueNotNull(key: AttributeKey<T>, value: T?) {
+public fun <T : Any> MutableAttributes.setIfValueNotNull(key: AttributeKey<T>, value: T?) {
     if (value != null) set(key, value)
 }
 
 /**
  * Removes an attribute with the specified [key] and returns its current value, returns `null` if an attribute doesn't exist
  */
-public fun <T : Any> Attributes.takeOrNull(key: AttributeKey<T>): T? = getOrNull(key).also { remove(key) }
+public fun <T : Any> MutableAttributes.takeOrNull(key: AttributeKey<T>): T? = getOrNull(key).also { remove(key) }
 
 /**
  * Merge another attributes instance into this set of attributes favoring [other]
  */
-public fun Attributes.merge(other: Attributes) {
+public fun MutableAttributes.merge(other: Attributes) {
     other.keys.forEach {
         @Suppress("UNCHECKED_CAST")
         set(it as AttributeKey<Any>, other[it])
     }
 }
 
-private class AttributesImpl : Attributes {
+private class AttributesImpl constructor(seed: Attributes) : MutableAttributes {
     private val map: MutableMap<AttributeKey<*>, Any> = mutableMapOf()
+    constructor() : this(emptyAttributes())
+
+    init {
+        merge(seed)
+    }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> getOrNull(key: AttributeKey<T>): T? = map[key] as T?
@@ -124,3 +127,70 @@ private class AttributesImpl : Attributes {
     override val keys: Set<AttributeKey<*>>
         get() = map.keys
 }
+
+private object EmptyAttributes : Attributes {
+    override val keys: Set<AttributeKey<*>> = emptySet()
+    override fun contains(key: AttributeKey<*>): Boolean = false
+    override fun <T : Any> getOrNull(key: AttributeKey<T>): T? = null
+}
+
+/**
+ * Returns an empty read-only set of attributes
+ */
+public fun emptyAttributes(): Attributes = EmptyAttributes
+
+/**
+ * Returns an empty new mutable set of attributes
+ */
+public fun mutableAttributes(): MutableAttributes = AttributesImpl()
+
+public class AttributesBuilder {
+    @PublishedApi
+    internal val attributes: MutableAttributes = mutableAttributes()
+    public infix fun <T : Any> AttributeKey<T>.to(value: T) {
+        attributes[this] = value
+    }
+
+    public infix fun <T : Any> String.to(value: T) {
+        attributes[AttributeKey<T>(this)] = value
+    }
+}
+
+/**
+ * Return a new set of mutable attributes using [AttributesBuilder].
+ *
+ * Example
+ * ```kotlin
+ * val attr1 = AttributeKey<String>("attribute 1")
+ * val attr1 = AttributeKey<Int>("attribute 2")
+ *
+ * val attrs = mutableAttributesOf {
+ *     attr1 to "value 1"
+ *     attr2 to 57
+ * }
+ * ```
+ */
+public inline fun mutableAttributesOf(block: AttributesBuilder.() -> Unit): MutableAttributes =
+    AttributesBuilder().apply(block).attributes
+
+/**
+ * Return a new set of attributes using [AttributesBuilder].
+ *
+ * Example
+ * ```kotlin
+ * val attr1 = AttributeKey<String>("attribute 1")
+ * val attr1 = AttributeKey<Int>("attribute 2")
+ *
+ * val attrs = attributesOf {
+ *     attr1 to "value 1"
+ *     attr2 to 57
+ * }
+ * ```
+ */
+public inline fun attributesOf(block: AttributesBuilder.() -> Unit): Attributes =
+    mutableAttributesOf(block)
+
+/**
+ * Returns a new [MutableAttributes] instance with elements from this set of attributes.
+ */
+public fun Attributes.toMutableAttributes(): MutableAttributes = AttributesImpl(this)

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/AttributesTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/AttributesTest.kt
@@ -12,7 +12,7 @@ class AttributesTest {
     fun testPropertyBag() {
         val strKey = AttributeKey<String>("string")
         val intKey = AttributeKey<Int>("int")
-        val attributes = Attributes()
+        val attributes = mutableAttributes()
 
         attributes[strKey] = "foo"
         assertTrue(attributes.contains(strKey))
@@ -29,7 +29,7 @@ class AttributesTest {
 
     @Test
     fun testPutIfAbsent() {
-        val attributes = Attributes()
+        val attributes = mutableAttributes()
         val strKey = AttributeKey<String>("string")
         attributes[strKey] = "foo"
         attributes.putIfAbsent(strKey, "bar")
@@ -41,7 +41,7 @@ class AttributesTest {
 
     @Test
     fun testMerge() {
-        val attr1 = Attributes()
+        val attr1 = mutableAttributes()
         val key1 = AttributeKey<String>("k1")
         val key2 = AttributeKey<String>("k2")
         val key3 = AttributeKey<String>("k3")
@@ -49,7 +49,7 @@ class AttributesTest {
         attr1[key1] = "Foo"
         attr1[key2] = "Bar"
 
-        val attr2 = Attributes()
+        val attr2 = mutableAttributes()
         attr2[key2] = "Baz"
         attr2[key3] = "Quux"
 
@@ -62,12 +62,46 @@ class AttributesTest {
 
     @Test
     fun testSetIfNotNull() {
-        val attributes = Attributes()
+        val attributes = mutableAttributes()
         val strKey = AttributeKey<String>("string")
         attributes.setIfValueNotNull(strKey, null)
         assertFalse(attributes.contains(strKey))
 
         attributes.setIfValueNotNull(strKey, "foo")
         assertEquals("foo", attributes[strKey])
+    }
+
+    @Test
+    fun testMutableAttributesOf() {
+        val attr1 = AttributeKey<String>("string")
+        val attr2 = AttributeKey<Int>("int")
+        val attributes = mutableAttributesOf {
+            attr1 to "foo"
+            attr2 to 57
+        }
+
+        assertEquals("foo", attributes[attr1])
+        assertEquals(57, attributes[attr2])
+    }
+
+    @Test
+    fun testToMutableAttributes() {
+        val attr1 = AttributeKey<String>("string")
+        val attr2 = AttributeKey<Int>("int")
+        val attrs = attributesOf {
+            attr1 to "foo"
+            attr2 to 57
+        }
+
+        val mutAttrs = attrs.toMutableAttributes()
+
+        assertEquals("foo", mutAttrs[attr1])
+        assertEquals(57, mutAttrs[attr2])
+
+        mutAttrs.remove(attr2)
+        assertFalse(attr2 in mutAttrs)
+
+        assertEquals("foo", attrs[attr1])
+        assertEquals(57, attrs[attr2])
     }
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/ClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/ClientOption.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.client
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.MutableAttributes
 
 /**
  * A (service) client option that influences how the client behaves when executing requests
@@ -38,7 +39,7 @@ public interface ClientOptions {
  * Wrapper around [Attributes] that provides a [ClientOptions] implementation
  */
 @InternalApi
-public class ClientOptionsImpl(private val attributes: Attributes) : ClientOptions {
+public class ClientOptionsImpl(private val attributes: MutableAttributes) : ClientOptions {
     override fun <T : Any> set(option: ClientOption<T>, value: T) {
         attributes[option] = value
     }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/ClientOptionsBuilder.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/ClientOptionsBuilder.kt
@@ -7,14 +7,15 @@ package aws.smithy.kotlin.runtime.client
 
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.AttributeKey
-import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.MutableAttributes
+import aws.smithy.kotlin.runtime.util.mutableAttributes
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 /**
  * Base class for building client options
  */
-public abstract class ClientOptionsBuilder(protected val options: Attributes = Attributes()) : Attributes by options {
+public abstract class ClientOptionsBuilder(protected val options: MutableAttributes = mutableAttributes()) : MutableAttributes by options {
     private val requiredKeys = mutableSetOf<AttributeKey<*>>()
 
     // TODO - currently can only have nullable (T?) values delegated. Look at providing either a default/initial value
@@ -58,7 +59,7 @@ public abstract class ClientOptionsBuilder(protected val options: Attributes = A
  */
 public class DelegatedClientOption<T : Any>(
     private val key: AttributeKey<T>,
-    private val into: Attributes,
+    private val into: MutableAttributes,
 ) : ReadWriteProperty<Any?, T?> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T? =

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/Endpoint.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/Endpoint.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.ValuesMap
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 
 /**
  * Represents the endpoint a service client should make API operation calls to.
@@ -38,14 +39,14 @@ public data class Endpoint @InternalApi constructor(
     public val uri: Url,
     public val headers: ValuesMap<String>? = null,
     @InternalApi
-    public val attributes: Attributes = Attributes(),
+    public val attributes: Attributes = emptyAttributes(),
 ) {
     public constructor(uri: String) : this(Url.parse(uri))
 
     public constructor(
         uri: Url,
         headers: ValuesMap<String>? = null,
-    ) : this(uri, headers, Attributes())
+    ) : this(uri, headers, emptyAttributes())
 
     override fun equals(other: Any?): Boolean =
         other is Endpoint &&
@@ -59,4 +60,11 @@ public data class Endpoint @InternalApi constructor(
                 @Suppress("UNCHECKED_CAST")
                 attributes.contains(it) && attributes.getOrNull(it as AttributeKey<Any>) == other.attributes.getOrNull(it)
             }
+
+    override fun hashCode(): Int {
+        var result = uri.hashCode()
+        result = 31 * result + (headers?.hashCode() ?: 0)
+        result = 31 * result + attributes.hashCode()
+        return result
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR was originally meant to be split in two but I messed that up somewhere along the way and it's not too big as to be cumbersome to review together.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Refactor `IdentityProvider` (and subsequently `CredentialsProvider`) to take a parameter to allow for future extension (SRA requirement). 
* Refactor `Attributes` into immutable and mutable versions (`MutableAttributes`). Most existing uses of `Attributes` were updated to be `MutableAttributes` without worry or care if we could do better yet (most of our usage is from `ExecutionContext` which will be hard to make immutable). 
    * Fix endpoint generation to make use of new APIs
* Generate `authSchemes` parameter for service client configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
