### PR TITLE
feat: add intEnum support

### DIFF
--- a/.changes/ef39e9b0-b8e5-4885-93c9-15ddca89343e.json
+++ b/.changes/ef39e9b0-b8e5-4885-93c9-15ddca89343e.json
@@ -1,0 +1,8 @@
+{
+    "id": "ef39e9b0-b8e5-4885-93c9-15ddca89343e",
+    "type": "feature",
+    "description": "Add intEnum support.",
+    "issues": [
+        "awslabs/smithy-kotlin#752"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/CodegenVisitor.kt
@@ -156,9 +156,14 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Unit>() {
     }
 
     override fun stringShape(shape: StringShape) {
+        // smithy will present both strings with legacy enum trait AND explicit (non-int) enum shapes in this manner
         if (shape.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()) {
             writers.useShapeWriter(shape) { EnumGenerator(shape, symbolProvider.toSymbol(shape), it).render() }
         }
+    }
+
+    override fun intEnumShape(shape: IntEnumShape) {
+        writers.useShapeWriter(shape) { EnumGenerator(shape, symbolProvider.toSymbol(shape), it).render() }
     }
 
     override fun unionShape(shape: UnionShape) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -69,6 +69,8 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
 
     override fun integerShape(shape: IntegerShape): Symbol = numberShape(shape, "Int")
 
+    override fun intEnumShape(shape: IntEnumShape): Symbol = createEnumSymbol(shape)
+
     override fun shortShape(shape: ShortShape): Symbol = numberShape(shape, "Short")
 
     override fun longShape(shape: LongShape): Symbol = numberShape(shape, "Long", "0L")
@@ -95,7 +97,7 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         createSymbolBuilder(shape, "String", boxed = true, namespace = "kotlin").build()
     }
 
-    private fun createEnumSymbol(shape: StringShape): Symbol {
+    private fun createEnumSymbol(shape: Shape): Symbol {
         val namespace = "$rootNamespace.model"
         return createSymbolBuilder(shape, shape.defaultName(service), namespace, boxed = true)
             .definitionFile("${shape.defaultName(service)}.kt")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
@@ -59,17 +59,12 @@ private fun String.sanitizeClientName(): String =
 fun clientName(raw: String): String = raw.sanitizeClientName().toPascalCase()
 
 /**
- * Get the (un-validated) name of an enum variant from the trait definition
+ * Get the (un-validated) name of an enum variant.
+ *
+ * This value can come from an enum definition trait, or it could be a member name from an explicit enum shape.
  */
-fun EnumDefinition.variantName(): String {
-    val identifier = name.orElseGet {
-        // we don't want to be doing this...name your enums people
-        Logger.getLogger("NamingUtils").also {
-            it.warning("Using EnumDefinition.value to derive generated identifier name: $value")
-        }
-        value
-    }
-        .splitOnWordBoundaries()
+fun String.enumVariantName(): String {
+    val identifier = splitOnWordBoundaries()
         .fold(StringBuilder()) { acc, x ->
             val curr = x.lowercase().replaceFirstChar { c -> c.uppercaseChar() }
             if (acc.isNotEmpty() && acc.last().isDigit() && x.first().isDigit()) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/Naming.kt
@@ -14,10 +14,8 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
-import software.amazon.smithy.model.traits.EnumDefinition
 import java.security.MessageDigest
 import java.util.*
-import java.util.logging.Logger
 
 // (somewhat) centralized naming rules
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -91,6 +91,7 @@ object RuntimeTypes {
         val ErrorMetadata = symbol("ErrorMetadata")
         val ServiceErrorMetadata = symbol("ServiceErrorMetadata")
         val Instant = symbol("Instant", "time")
+        val fromEpochMilliseconds = symbol("fromEpochMilliseconds", "time")
         val TimestampFormat = symbol("TimestampFormat", "time")
         val ClientException = symbol("ClientException")
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -156,14 +156,18 @@ val Shape.isDeprecated: Boolean
     get() = hasTrait<DeprecatedTrait>()
 
 /**
- * Test if a shape represents an enumeration
- * https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait
+ * Test if a shape represents either kind of enumeration
  */
 val Shape.isEnum: Boolean
-    get() =
-        isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() ||
-            isEnumShape ||
-            isIntEnumShape
+    get() = isStringEnumShape || isIntEnumShape
+
+/**
+ * Test if a shape is a string-based enum, which will present either as:
+ * 1. The explicit enum shape (NOT intEnum)
+ * 2. The [legacy enum trait](https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait) applied to a string shape
+ */
+val Shape.isStringEnumShape: Boolean
+    get() = isEnumShape || isStringShape && hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
 
 /**
  * Test if a shape is an error.
@@ -172,7 +176,7 @@ val Shape.isError: Boolean
     get() = hasTrait<ErrorTrait>()
 
 /**
- * Test if a shape represents an Kotlin number type
+ * Test if a shape represents a Kotlin number type
  */
 val Shape.isNumberShape: Boolean
     get() = this is NumberShape

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGenerator.kt
@@ -10,9 +10,14 @@ import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.lang.isValidKotlinIdentifier
 import software.amazon.smithy.kotlin.codegen.model.expectTrait
+import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.kotlin.codegen.model.hasTrait
-import software.amazon.smithy.model.shapes.StringShape
-import software.amazon.smithy.model.traits.EnumDefinition
+import software.amazon.smithy.kotlin.codegen.utils.doubleQuote
+import software.amazon.smithy.kotlin.codegen.utils.getOrNull
+import software.amazon.smithy.model.shapes.IntEnumShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.traits.DocumentationTrait
+import java.util.logging.Logger
 
 /**
  * Generates a Kotlin sealed class from a Smithy enum string
@@ -89,102 +94,141 @@ import software.amazon.smithy.model.traits.EnumDefinition
  * }
  * ```
  */
-class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: KotlinWriter) {
+class EnumGenerator(val shape: Shape, val symbol: Symbol, val writer: KotlinWriter) {
+    private val ktEnum = shape.asKotlinEnum()
 
     // generated enum names must be unique, keep track of what we generate to ensure this.
     // Necessary due to prefixing and other name manipulation to create either valid identifiers
     // and idiomatic names
     private val generatedNames = mutableSetOf<String>()
 
-    init {
-        assert(shape.hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>())
-    }
-
-    @Suppress("DEPRECATION")
-    val enumTrait: software.amazon.smithy.model.traits.EnumTrait by lazy {
-        shape.expectTrait()
-    }
-
     fun render() {
         writer.renderDocumentation(shape)
         writer.renderAnnotations(shape)
-        // NOTE: The smithy spec only allows string shapes to apply to a string shape at the moment
-        writer.withBlock("public sealed class ${symbol.name} {", "}") {
-            write("\npublic abstract val value: #Q\n", KotlinTypes.String)
+        writer.withBlock("public sealed class #L {", "}", symbol.name) {
+            write("public abstract val value: #Q", ktEnum.symbol)
+            write("")
 
-            val sortedDefinitions = enumTrait
-                .values
-                .sortedBy { it.name.orElse(it.value) }
-
-            sortedDefinitions.forEach {
-                generateSealedClassVariant(it)
+            ktEnum.variants.forEach {
+                renderVariant(it)
                 write("")
             }
 
-            if (generatedNames.contains("SdkUnknown")) throw CodegenException("generating SdkUnknown would cause duplicate variant for enum shape: $shape")
-
-            // generate the unknown which will always be last
-            writer.withBlock("public data class SdkUnknown(override val value: #Q) : #Q() {", "}", KotlinTypes.String, symbol) {
-                renderToStringOverride()
-            }
-
+            renderSdkUnknown()
             write("")
 
-            // generate the fromValue() static method
-            withBlock("public companion object {", "}") {
-                writer.dokka("Convert a raw value to one of the sealed variants or [SdkUnknown]")
-                openBlock("public fun fromValue(str: #Q): #Q = when(str) {", KotlinTypes.String, symbol)
-                    .call {
-                        sortedDefinitions.forEach { definition ->
-                            val variantName = getVariantName(definition)
-                            write("\"${definition.value}\" -> $variantName")
-                        }
-                    }
-                    .write("else -> SdkUnknown(str)")
-                    .closeBlock("}")
-                    .write("")
+            renderCompanionObject()
+        }
+    }
 
-                writer.dokka("Get a list of all possible variants")
-                openBlock("public fun values(): #Q<#Q> = listOf(", KotlinTypes.Collections.List, symbol)
-                    .call {
-                        sortedDefinitions.forEachIndexed { idx, definition ->
-                            val variantName = getVariantName(definition)
-                            val suffix = if (idx < sortedDefinitions.size - 1) "," else ""
-                            write("${variantName}$suffix")
-                        }
-                    }
-                    .closeBlock(")")
+    private fun renderVariant(variant: KotlinEnum.Variant) {
+        variant.documentation?.let { writer.dokka(it) }
+        if (!generatedNames.add(variant.name)) {
+            throw CodegenException("prefixing invalid enum value to form a valid Kotlin identifier causes generated sealed class names to not be unique: ${variant.name}; shape=$shape")
+        }
+
+        writer.withBlock("public object #L : #Q() {", "}", variant.name, symbol) {
+            write("override val value: #Q = #L", ktEnum.symbol, variant.valueLiteral)
+            renderToStringOverride()
+        }
+    }
+
+    private fun renderSdkUnknown() {
+        if (generatedNames.contains("SdkUnknown")) {
+            throw CodegenException("generating SdkUnknown would cause duplicate variant for enum shape: $shape")
+        }
+
+        writer.withBlock("public data class SdkUnknown(override val value: #Q) : #Q() {", "}", ktEnum.symbol, symbol) {
+            renderToStringOverride()
+        }
+    }
+
+    private fun renderCompanionObject() {
+        writer.withBlock("public companion object {", "}") {
+            writer.dokka("Convert a raw value to one of the sealed variants or [SdkUnknown]")
+            withBlock("public fun fromValue(v: #Q): #Q = when (v) {", "}", ktEnum.symbol, symbol) {
+                ktEnum.variants.forEach { write("#L -> #L", it.valueLiteral, it.name) }
+                write("else -> SdkUnknown(v)")
+            }
+            write("")
+
+            dokka("Get a list of all possible variants")
+            withBlock("public fun values(): #Q<#Q> = listOf(", ")", KotlinTypes.Collections.List, symbol) {
+                ktEnum.variants.forEach { write("#L,", it.name) }
             }
         }
     }
 
     private fun renderToStringOverride() {
         // override to string to use the enum constant value
-        writer.write("override fun toString(): #Q = value", KotlinTypes.String)
+        writer.write("override fun toString(): #Q = value#L", KotlinTypes.String, ktEnum.toStringExpr)
+    }
+}
+
+private fun Shape.asKotlinEnum(): KotlinEnum = when {
+    this is IntEnumShape -> {
+        val variants = members()
+            .map { it to enumValues[it.memberName] }
+            .sortedBy { (_, value) -> value }
+            .map { (member, value) ->
+                KotlinEnum.Variant(
+                    member.memberName.getVariantName(),
+                    value.toString(),
+                    member.getTrait<DocumentationTrait>()?.value,
+                )
+            }
+        KotlinEnum(KotlinTypes.Int, variants)
+    }
+    hasTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>() -> {
+        val variants = expectTrait<@Suppress("DEPRECATION") software.amazon.smithy.model.traits.EnumTrait>()
+            .values
+            .sortedBy { it.name.orElse(it.value) }
+            .map {
+                val name = it.name.orElseGet {
+                    // we don't want to be doing this... name your enums, people
+                    Logger.getLogger("NamingUtils").also { logger ->
+                        logger.warning("Using enum value to derive generated identifier name: ${it.value}")
+                    }
+                    it.value
+                }
+
+                KotlinEnum.Variant(
+                    name.getVariantName(),
+                    it.value.doubleQuote(),
+                    it.documentation.getOrNull(),
+                )
+            }
+        KotlinEnum(KotlinTypes.String, variants)
+    }
+    else -> throw CodegenException("shape $this is not an enum")
+}
+
+// adaptor struct to handle different enum types
+private data class KotlinEnum(
+    val symbol: Symbol,
+    val variants: List<Variant>,
+) {
+    data class Variant(
+        val name: String,
+        val valueLiteral: String,
+        val documentation: String? = null,
+    )
+}
+
+private val KotlinEnum.toStringExpr: String
+    get() = when (symbol) {
+        KotlinTypes.Int -> ".toString()"
+        KotlinTypes.String -> ""
+        else -> throw IllegalArgumentException("unexpected symbol $symbol")
     }
 
-    private fun generateSealedClassVariant(definition: EnumDefinition) {
-        writer.renderEnumDefinitionDocumentation(definition)
-        val variantName = getVariantName(definition)
-        if (!generatedNames.add(variantName)) {
-            throw CodegenException("prefixing invalid enum value to form a valid Kotlin identifier causes generated sealed class names to not be unique: $variantName; shape=$shape")
-        }
-
-        writer.openBlock("public object $variantName : #Q() {", symbol)
-            .write("override val value: #Q = #S", KotlinTypes.String, definition.value)
-            .call { renderToStringOverride() }
-            .closeBlock("}")
+private fun String.getVariantName(): String {
+    val identifierName = enumVariantName()
+    if (!isValidKotlinIdentifier(identifierName)) {
+        // prefixing didn't fix it, this must be a value since EnumDefinition.name MUST be a valid identifier
+        // already, see: https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait
+        throw CodegenException("$identifierName is not a valid Kotlin identifier and cannot be automatically fixed with a prefix. Fix by customizing the model or giving the enum definition a name.")
     }
 
-    private fun getVariantName(definition: EnumDefinition): String {
-        val identifierName = definition.variantName()
-
-        if (!isValidKotlinIdentifier(identifierName)) {
-            // prefixing didn't fix it, this must be a value since EnumDefinition.name MUST be a valid identifier
-            // already, see: https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait
-            throw CodegenException("$identifierName is not a valid Kotlin identifier and cannot be automatically fixed with a prefix. Fix by customizing the model for $shape or giving the enum definition a name.")
-        }
-
-        return identifierName
-    }
+    return identifierName
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpStringValuesMapSerializer.kt
@@ -73,6 +73,8 @@ class HttpStringValuesMapSerializer(
                     )
                 }
                 is StringShape -> renderStringShape(it, memberTarget, writer)
+                is IntEnumShape ->
+                    writer.write("if (input.#1L != null) { append(#2S, \"\${input.#1L.value}\") }", memberName, paramName)
                 else -> {
                     // encode to string
                     val encodedValue = "\"\${input.$memberName}\""
@@ -118,6 +120,7 @@ class HttpStringValuesMapSerializer(
                     }
                 }
             }
+            ShapeType.INT_ENUM -> "\"\${it.value}\""
             // default to "toString"
             else -> "\"\$it\""
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeStructGenerator.kt
@@ -104,9 +104,8 @@ open class DeserializeStructGenerator(
             ShapeType.BIG_DECIMAL,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderShapeDeserializer(memberShape)
-
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unexpected shape type: ${targetShape.type}")
         }
@@ -187,6 +186,7 @@ open class DeserializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.TIMESTAMP,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderEntry(elementShape, nestingLevel, isSparse, parentMemberName)
 
             ShapeType.SET,
@@ -197,8 +197,6 @@ open class DeserializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureEntry(elementShape, nestingLevel, isSparse, parentMemberName)
-
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }
@@ -413,6 +411,7 @@ open class DeserializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.TIMESTAMP,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderElement(elementShape, nestingLevel, isSparse, parentMemberName)
 
             ShapeType.LIST,
@@ -423,8 +422,6 @@ open class DeserializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureElement(elementShape, nestingLevel, isSparse, parentMemberName)
-
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }
@@ -583,10 +580,15 @@ open class DeserializeStructGenerator(
                 }
             }
 
-            target.isEnum -> {
+            target.isStringEnumShape -> {
                 val enumSymbol = ctx.symbolProvider.toSymbol(target)
                 writer.addImport(enumSymbol)
                 "deserializeString().let { ${enumSymbol.name}.fromValue(it) }"
+            }
+            target.isIntEnumShape -> {
+                val enumSymbol = ctx.symbolProvider.toSymbol(target)
+                writer.addImport(enumSymbol)
+                "deserializeInt().let { ${enumSymbol.name}.fromValue(it) }"
             }
 
             target.type == ShapeType.STRING -> "deserializeString()"

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerializeStructGenerator.kt
@@ -109,9 +109,9 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveShapeSerializer(memberShape, ::serializerForPrimitiveShape)
 
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unexpected shape type: ${targetShape.type}")
         }
@@ -181,6 +181,7 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveEntry(elementShape, nestingLevel, parentMemberName)
 
             ShapeType.BLOB -> renderBlobEntry(nestingLevel, parentMemberName)
@@ -193,8 +194,6 @@ open class SerializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureEntry(elementShape, nestingLevel, parentMemberName, isSparse)
-
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }
@@ -220,6 +219,7 @@ open class SerializeStructGenerator(
             ShapeType.DOCUMENT,
             ShapeType.BIG_INTEGER,
             ShapeType.ENUM,
+            ShapeType.INT_ENUM,
             -> renderPrimitiveElement(elementShape, nestingLevel, parentMemberName, isSparse)
 
             ShapeType.BLOB -> renderBlobElement(nestingLevel, parentMemberName)
@@ -232,8 +232,6 @@ open class SerializeStructGenerator(
             ShapeType.UNION,
             ShapeType.STRUCTURE,
             -> renderNestedStructureElement(elementShape, nestingLevel, parentMemberName)
-
-            ShapeType.INT_ENUM -> error("IntEnum is not supported until Smithy 2.0")
 
             else -> error("Unhandled type ${elementShape.type}")
         }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.kotlin.codegen.core
 import io.kotest.matchers.string.shouldNotContain
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.integration.SectionKey
+import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/NamingTest.kt
@@ -121,8 +121,7 @@ class NamingTest {
             // NOTE: a lot of these are not valid names according to the Smithy spec but since
             // we still allow deriving a name from the enum value we want to verify what _would_ happen
             // should we encounter these inputs
-            val definition = EnumDefinition.builder().name(input).value(input).build()
-            val actual = definition.variantName()
+            val actual = input.enumVariantName()
             assertEquals(expected, actual, "input: $input")
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -315,6 +315,26 @@ class SymbolProviderTest {
     }
 
     @Test
+    fun `creates int enums`() {
+        val model = """
+            intEnum Baz {
+                FOO = 1
+                BAR = 2
+            }
+        """.prependNamespaceAndService(version = "2", namespace = "foo.bar").toSmithyModel()
+
+        val provider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
+        val shape = model.expectShape<IntEnumShape>("foo.bar#Baz")
+        val symbol = provider.toSymbol(shape)
+
+        assertEquals("foo.bar.model", symbol.namespace)
+        assertEquals("null", symbol.defaultValue())
+        assertEquals(true, symbol.isBoxed)
+        assertEquals("Baz", symbol.name)
+        assertEquals("Baz.kt", symbol.definitionFile)
+    }
+
+    @Test
     fun `creates unions`() {
         val model = """
             union MyUnion {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/EnumGeneratorTest.kt
@@ -54,32 +54,34 @@ public sealed class Baz {
      */
     public object Bar : test.model.Baz() {
         override val value: kotlin.String = "BAR"
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "Bar"
     }
 
     public object Foo : test.model.Baz() {
         override val value: kotlin.String = "FOO"
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "Foo"
     }
 
     public data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "SdkUnknown(${'$'}value)"
     }
 
     public companion object {
         /**
          * Convert a raw value to one of the sealed variants or [SdkUnknown]
          */
-        public fun fromValue(v: kotlin.String): test.model.Baz = when (v) {
+        public fun fromValue(value: kotlin.String): test.model.Baz = when (value) {
             "BAR" -> Bar
             "FOO" -> Foo
-            else -> SdkUnknown(v)
+            else -> SdkUnknown(value)
         }
 
         /**
          * Get a list of all possible variants
          */
-        public fun values(): kotlin.collections.List<test.model.Baz> = listOf(
+        public fun values(): kotlin.collections.List<test.model.Baz> = values
+
+        private val values: kotlin.collections.List<test.model.Baz> = listOf(
             Bar,
             Foo,
         )
@@ -136,32 +138,34 @@ public sealed class Baz {
      */
     public object T2Micro : test.model.Baz() {
         override val value: kotlin.String = "t2.micro"
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "T2Micro"
     }
 
     public object T2Nano : test.model.Baz() {
         override val value: kotlin.String = "t2.nano"
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "T2Nano"
     }
 
     public data class SdkUnknown(override val value: kotlin.String) : test.model.Baz() {
-        override fun toString(): kotlin.String = value
+        override fun toString(): kotlin.String = "SdkUnknown(${'$'}value)"
     }
 
     public companion object {
         /**
          * Convert a raw value to one of the sealed variants or [SdkUnknown]
          */
-        public fun fromValue(v: kotlin.String): test.model.Baz = when (v) {
+        public fun fromValue(value: kotlin.String): test.model.Baz = when (value) {
             "t2.micro" -> T2Micro
             "t2.nano" -> T2Nano
-            else -> SdkUnknown(v)
+            else -> SdkUnknown(value)
         }
 
         /**
          * Get a list of all possible variants
          */
-        public fun values(): kotlin.collections.List<test.model.Baz> = listOf(
+        public fun values(): kotlin.collections.List<test.model.Baz> = values
+
+        private val values: kotlin.collections.List<test.model.Baz> = listOf(
             T2Micro,
             T2Nano,
         )
@@ -205,38 +209,40 @@ public sealed class Baz {
      */
     public object T2Micro : test.model.Baz() {
         override val value: kotlin.Int = 1
-        override fun toString(): kotlin.String = value.toString()
+        override fun toString(): kotlin.String = "T2Micro"
     }
 
     public object T2Nano : test.model.Baz() {
         override val value: kotlin.Int = 2
-        override fun toString(): kotlin.String = value.toString()
+        override fun toString(): kotlin.String = "T2Nano"
     }
 
     public object X9Omega : test.model.Baz() {
         override val value: kotlin.Int = 9999
-        override fun toString(): kotlin.String = value.toString()
+        override fun toString(): kotlin.String = "X9Omega"
     }
 
     public data class SdkUnknown(override val value: kotlin.Int) : test.model.Baz() {
-        override fun toString(): kotlin.String = value.toString()
+        override fun toString(): kotlin.String = "SdkUnknown(${'$'}value)"
     }
 
     public companion object {
         /**
          * Convert a raw value to one of the sealed variants or [SdkUnknown]
          */
-        public fun fromValue(v: kotlin.Int): test.model.Baz = when (v) {
+        public fun fromValue(value: kotlin.Int): test.model.Baz = when (value) {
             1 -> T2Micro
             2 -> T2Nano
             9999 -> X9Omega
-            else -> SdkUnknown(v)
+            else -> SdkUnknown(value)
         }
 
         /**
          * Get a list of all possible variants
          */
-        public fun values(): kotlin.collections.List<test.model.Baz> = listOf(
+        public fun values(): kotlin.collections.List<test.model.Baz> = values
+
+        private val values: kotlin.collections.List<test.model.Baz> = listOf(
             T2Micro,
             T2Nano,
             X9Omega,

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -44,6 +44,12 @@ class DefaultEndpointProviderGeneratorTest {
                             "type": "endpoint",
                             "conditions": [
                                 {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {"ref": "BazName"}
+                                    ]
+                                },
+                                {
                                     "fn": "stringEquals",
                                     "argv": [
                                         {"ref": "BazName"},
@@ -68,7 +74,7 @@ class DefaultEndpointProviderGeneratorTest {
                                     "fn": "stringEquals",
                                     "argv": [
                                         {"ref": "resourceIdPrefix"},
-                                        "gov.{BazName}"
+                                        "gov.{ResourceId}"
                                     ]
                                 }
                             ],
@@ -80,6 +86,12 @@ class DefaultEndpointProviderGeneratorTest {
                             "documentation": "throw exception if bad value",
                             "type": "error",
                             "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {"ref": "BazName"}
+                                    ]
+                                },
                                 {
                                     "fn": "stringEquals",
                                     "argv": [
@@ -142,6 +154,7 @@ class DefaultEndpointProviderGeneratorTest {
     fun testBasicCondition() {
         val expected = """
             if (
+                params.bazName != null &&
                 params.bazName == "gov"
             ) {
                 return Endpoint(
@@ -159,7 +172,7 @@ class DefaultEndpointProviderGeneratorTest {
                 val resourceIdPrefix = substring(params.resourceId, 0, 4, false)
                 if (
                     resourceIdPrefix != null &&
-                    resourceIdPrefix == "gov.${'$'}{params.bazName}"
+                    resourceIdPrefix == "gov.${'$'}{params.resourceId}"
                 ) {
                     return Endpoint(
                         Url.parse("https://assignment.condition"),
@@ -174,6 +187,7 @@ class DefaultEndpointProviderGeneratorTest {
     fun testException() {
         val expected = """
             if (
+                params.bazName != null &&
                 params.bazName == "invalid"
             ) {
                 throw EndpointProviderException("invalid BazName value")

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ okHttpVersion=5.0.0-alpha.11
 okioVersion=3.3.0
 
 # codegen
-smithyVersion=1.26.1
+smithyVersion=1.29.0
 smithyGradleVersion=0.6.0
 
 # testing/utility


### PR DESCRIPTION
## Issue \#
Closes #752

## Description of changes
* Add smithy `intEnum` support (codegen + all serde/binding points)
* Modernize `EnumGenerator` codegen
* Upgrade smithy to pull in new protocol tests, which triggered a few incidental changes:
  * update test endpoint ruleset to pass new, more-strict validation
  * `ShapeValueGenerator` (protocol tests)
    * handle fractional values in timestamps
    * ensure list member symbols are imported


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
