### PR TITLE
feat(rt): retry HTTP exceptions (SRA)

### DIFF
--- a/.changes/389efd23-6868-4e0d-b392-fca03d358270.json
+++ b/.changes/389efd23-6868-4e0d-b392-fca03d358270.json
@@ -1,0 +1,5 @@
+{
+    "id": "389efd23-6868-4e0d-b392-fca03d358270",
+    "type": "feature",
+    "description": "Add support for retrying transient HTTP errors. `RetryErrorType.Timeout` was renamed to `RetryErrorType.Transient`."
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -118,8 +118,14 @@ internal inline fun <T> mapCrtException(block: () -> T): T =
     try {
         block()
     } catch (ex: CrtRuntimeException) {
-        throw HttpException(ex.message ?: ex.errorDescription, ex, errorCode = mapCrtErrorCode(ex.errorCode))
+        throw HttpException(fmtCrtErrorMessage(ex.errorCode), errorCode = mapCrtErrorCode(ex.errorCode))
     }
+
+internal fun fmtCrtErrorMessage(errorCode: Int): String {
+    val errorDescription = CRT.errorString(errorCode)
+    val errName = CRT.errorName(errorCode)
+    return "$errName: $errorDescription; crtErrorCode=$errorCode"
+}
 
 // do this by name rather than error code as it's difficult to map error codes on JVM side and would be prone to breaking
 // if new errors are added to the various aws-c-* lib enum blocks.

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.http.engine.crt
 
-import aws.sdk.kotlin.crt.CRT
 import aws.sdk.kotlin.crt.http.*
 import aws.sdk.kotlin.crt.io.Buffer
 import aws.smithy.kotlin.runtime.http.*
@@ -174,9 +173,7 @@ internal class SdkStreamResponseHandler(
 
         // close the body channel
         if (errorCode != 0) {
-            val errorDescription = CRT.errorString(errorCode)
-            val errName = CRT.errorName(errorCode)
-            val ex = HttpException("$errName: $errorDescription; ec=$errorCode", errorCode = mapCrtErrorCode(errorCode))
+            val ex = HttpException(fmtCrtErrorMessage(errorCode), errorCode = mapCrtErrorCode(errorCode))
             responseReady.close(ex)
             bodyChan.close(ex)
         } else {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -175,7 +175,7 @@ class SdkStreamResponseHandlerTest {
             respChan.readAll(SdkSink.blackhole())
         }
 
-        ex.message.shouldContain("socket is closed.; ec=$socketClosedEc")
+        ex.message.shouldContain("socket is closed.; crtErrorCode=$socketClosedEc")
         assertEquals(HttpErrorCode.CONNECTION_CLOSED, ex.errorCode)
     }
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -39,7 +39,7 @@ public class OkHttpEngine(
 
         val engineRequest = request.toOkHttpRequest(context, callContext)
         val engineCall = client.newCall(engineRequest)
-        val engineResponse = engineCall.executeAsync()
+        val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         callContext.job.invokeOnCompletion {
             engineResponse.body.close()
@@ -69,9 +69,9 @@ private fun OkHttpEngineConfig.buildClient(): OkHttpClient {
         followRedirects(false)
         followSslRedirects(false)
 
-        // see: https://github.com/ktorio/ktor/issues/1708#issuecomment-609988128
-        // TODO disable this once better transient exception handling is in place
-        retryOnConnectionFailure(true)
+        // Transient connection errors are handled by retry strategy (exceptions are wrapped and marked retryable
+        // appropriately internally). We don't want inner retry logic that inflates the number of retries.
+        retryOnConnectionFailure(false)
 
         connectTimeout(config.connectTimeout.toJavaDuration())
         readTimeout(config.socketReadTimeout.toJavaDuration())

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -195,7 +195,7 @@ internal inline fun<T> mapOkHttpExceptions(block: () -> T): T =
     try {
         block()
     } catch (ex: IOException) {
-        throw HttpException(ex.message, ex, ex.errCode(), ex.isRetryable())
+        throw HttpException(ex, ex.errCode(), ex.isRetryable())
     }
 
 private fun Exception.isRetryable(): Boolean = isCauseOrSuppressed<ConnectException>()

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http.engine.okhttp
+
+import aws.smithy.kotlin.runtime.http.HttpErrorCode
+import aws.smithy.kotlin.runtime.http.HttpException
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class OkHttpExceptionTest {
+    data class ExceptionTest(
+        val ex: Exception,
+        val expectedError: HttpErrorCode,
+        val expectedRetryable: Boolean = false,
+    )
+
+    @Test
+    fun testMapExceptions() {
+        val tests = listOf(
+            ExceptionTest(IOException("unknown"), expectedError = HttpErrorCode.SDK_UNKNOWN),
+            ExceptionTest(IOException(SocketTimeoutException("connect timeout")), expectedError = HttpErrorCode.CONNECT_TIMEOUT, true),
+            ExceptionTest(IOException().apply { addSuppressed(SocketTimeoutException("connect timeout")) }, expectedError = HttpErrorCode.CONNECT_TIMEOUT, true),
+            ExceptionTest(IOException(SocketTimeoutException("read timeout")), expectedError = HttpErrorCode.SOCKET_TIMEOUT),
+            ExceptionTest(IOException().apply { addSuppressed(SocketTimeoutException("read timeout")) }, expectedError = HttpErrorCode.SOCKET_TIMEOUT),
+            ExceptionTest(SocketTimeoutException("read timeout"), expectedError = HttpErrorCode.SOCKET_TIMEOUT),
+            ExceptionTest(IOException(SSLHandshakeException("negotiate error")), expectedError = HttpErrorCode.TLS_NEGOTIATION_ERROR),
+            ExceptionTest(ConnectException("test connect error"), expectedError = HttpErrorCode.SDK_UNKNOWN, true),
+        )
+
+        for (test in tests) {
+            val ex = assertFailsWith<HttpException> {
+                mapOkHttpExceptions {
+                    throw test.ex
+                }
+            }
+
+            assertEquals(test.expectedError, ex.errorCode, "ex=$ex; ${ex.suppressedExceptions}; cause=${ex.cause}; causeSuppressed=${ex.cause?.suppressedExceptions}")
+            assertEquals(test.expectedRetryable, ex.sdkErrorMetadata.isRetryable)
+        }
+    }
+}

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -142,9 +142,6 @@ public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseExcepti
 	public final fun setStatusCode (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)V
 }
 
-public final class aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointKt {
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {
 	public abstract fun deserialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/response/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -142,6 +142,9 @@ public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseExcepti
 	public final fun setStatusCode (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/middleware/ResolveEndpointKt {
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {
 	public abstract fun deserialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/response/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -103,9 +103,12 @@ public final class aws/smithy/kotlin/runtime/http/HttpErrorCode : java/lang/Enum
 }
 
 public final class aws/smithy/kotlin/runtime/http/HttpException : aws/smithy/kotlin/runtime/SdkBaseException {
-	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/http/HttpErrorCode;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/http/HttpErrorCode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;Z)V
+	public synthetic fun <init> (Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getErrorCode ()Laws/smithy/kotlin/runtime/http/HttpErrorCode;
 	public fun toString ()Ljava/lang/String;
 }

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -89,6 +89,27 @@ public final class aws/smithy/kotlin/runtime/http/HttpBodyKt {
 	public static final fun toHttpBody ([B)Laws/smithy/kotlin/runtime/http/HttpBody;
 }
 
+public final class aws/smithy/kotlin/runtime/http/HttpErrorCode : java/lang/Enum {
+	public static final field CONNECTION_ACQUIRE_TIMEOUT Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field CONNECTION_CLOSED Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field CONNECT_TIMEOUT Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field PROTOCOL_NEGOTIATION_ERROR Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field SDK_UNKNOWN Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field SOCKET_TIMEOUT Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field TLS_NEGOTIATION_ERROR Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static final field TLS_NEGOTIATION_TIMEOUT Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public static fun values ()[Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+}
+
+public final class aws/smithy/kotlin/runtime/http/HttpException : aws/smithy/kotlin/runtime/SdkBaseException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Laws/smithy/kotlin/runtime/http/HttpErrorCode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getErrorCode ()Laws/smithy/kotlin/runtime/http/HttpErrorCode;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/http/HttpMethod : java/lang/Enum {
 	public static final field Companion Laws/smithy/kotlin/runtime/http/HttpMethod$Companion;
 	public static final field DELETE Laws/smithy/kotlin/runtime/http/HttpMethod;

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpException.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpException.kt
@@ -11,14 +11,36 @@ import aws.smithy.kotlin.runtime.SdkBaseException
 /**
  * Base exception class for HTTP errors
  */
-public class HttpException(
-    message: String? = null,
-    cause: Throwable? = null,
-    public val errorCode: HttpErrorCode = HttpErrorCode.SDK_UNKNOWN,
-    retryable: Boolean = false,
-) : SdkBaseException(message ?: cause?.toString(), cause) {
+public class HttpException : SdkBaseException {
+    public val errorCode: HttpErrorCode
+    public constructor(
+        message: String?,
+        errorCode: HttpErrorCode = HttpErrorCode.SDK_UNKNOWN,
+        retryable: Boolean = false,
+    ) : super(message) {
+        this.errorCode = errorCode
+        setRetryable(retryable)
+    }
+    public constructor(
+        message: String?,
+        cause: Throwable?,
+        errorCode: HttpErrorCode = HttpErrorCode.SDK_UNKNOWN,
+        retryable: Boolean = false,
+    ) : super(message, cause) {
+        this.errorCode = errorCode
+        setRetryable(retryable)
+    }
 
-    init {
+    public constructor(
+        cause: Throwable?,
+        errorCode: HttpErrorCode = HttpErrorCode.SDK_UNKNOWN,
+        retryable: Boolean = false,
+    ) : super(cause) {
+        this.errorCode = errorCode
+        setRetryable(retryable)
+    }
+
+    private fun setRetryable(retryable: Boolean) {
         sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = retryable || when (errorCode) {
             HttpErrorCode.CONNECT_TIMEOUT, HttpErrorCode.TLS_NEGOTIATION_TIMEOUT -> true
             else -> false

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpException.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/HttpException.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http
+
+import aws.smithy.kotlin.runtime.ErrorMetadata
+import aws.smithy.kotlin.runtime.SdkBaseException
+
+/**
+ * Base exception class for HTTP errors
+ */
+public class HttpException(
+    message: String? = null,
+    cause: Throwable? = null,
+    public val errorCode: HttpErrorCode = HttpErrorCode.SDK_UNKNOWN,
+    retryable: Boolean = false,
+) : SdkBaseException(message ?: cause?.toString(), cause) {
+
+    init {
+        sdkErrorMetadata.attributes[ErrorMetadata.Retryable] = retryable || when (errorCode) {
+            HttpErrorCode.CONNECT_TIMEOUT, HttpErrorCode.TLS_NEGOTIATION_TIMEOUT -> true
+            else -> false
+        }
+    }
+
+    override fun toString(): String {
+        val orig = super.toString()
+        return when (errorCode) {
+            HttpErrorCode.SDK_UNKNOWN -> orig
+            else -> "$orig; HttpErrorCode($errorCode)"
+        }
+    }
+}
+
+public enum class HttpErrorCode {
+    /**
+     * A connection could not be established within the configured amount of time
+     */
+    CONNECT_TIMEOUT,
+
+    /**
+     * A connection could not be leased from the connection pool after the configured amount of time
+     */
+    CONNECTION_ACQUIRE_TIMEOUT,
+
+    /**
+     * TLS negotiation did not complete within the configure amount of time
+     */
+    TLS_NEGOTIATION_TIMEOUT,
+
+    /**
+     * TLS negotiation failed
+     */
+    TLS_NEGOTIATION_ERROR,
+
+    /**
+     * The connection was closed while the request was in-flight
+     */
+    CONNECTION_CLOSED,
+
+    /**
+     * A timeout has occurred on a socket read or write
+     */
+    SOCKET_TIMEOUT,
+
+    /**
+     * Failed to negotiate the HTTP protocol version with the service
+     */
+    PROTOCOL_NEGOTIATION_ERROR,
+
+    /**
+     * Unknown error
+     */
+    SDK_UNKNOWN,
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1176,7 +1176,7 @@ public final class aws/smithy/kotlin/runtime/retries/policy/RetryErrorType : jav
 	public static final field ClientSide Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static final field ServerSide Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static final field Throttling Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
-	public static final field Timeout Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
+	public static final field Transient Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static fun values ()[Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
@@ -19,12 +19,12 @@ public open class ErrorMetadata {
         /**
          * Set if an error is retryable
          */
-        public val Retryable: AttributeKey<Boolean> = AttributeKey("Retryable")
+        public val Retryable: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin#Retryable")
 
         /**
          * Set if an error represents a throttling condition
          */
-        public val ThrottlingError: AttributeKey<Boolean> = AttributeKey("ThrottlingError")
+        public val ThrottlingError: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin#ThrottlingError")
     }
 
     public val isRetryable: Boolean
@@ -76,11 +76,11 @@ private object EmptyProtocolResponse : ProtocolResponse
 
 public open class ServiceErrorMetadata : ErrorMetadata() {
     public companion object {
-        public val ErrorCode: AttributeKey<String> = AttributeKey("ErrorCode")
-        public val ErrorMessage: AttributeKey<String> = AttributeKey("ErrorMessage")
-        public val ErrorType: AttributeKey<ServiceException.ErrorType> = AttributeKey("ErrorType")
-        public val ProtocolResponse: AttributeKey<ProtocolResponse> = AttributeKey("ProtocolResponse")
-        public val RequestId: AttributeKey<String> = AttributeKey("RequestId")
+        public val ErrorCode: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#ErrorCode")
+        public val ErrorMessage: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#ErrorMessage")
+        public val ErrorType: AttributeKey<ServiceException.ErrorType> = AttributeKey("aws.smithy.kotlin#ErrorType")
+        public val ProtocolResponse: AttributeKey<ProtocolResponse> = AttributeKey("aws.smithy.kotlin#ProtocolResponse")
+        public val RequestId: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#RequestId")
     }
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -100,7 +100,7 @@ public class StandardRetryTokenBucket constructor(
          */
         override suspend fun scheduleRetry(reason: RetryErrorType): RetryToken {
             val size = when (reason) {
-                RetryErrorType.Timeout, RetryErrorType.Throttling -> options.timeoutRetryCost
+                RetryErrorType.Transient, RetryErrorType.Throttling -> options.timeoutRetryCost
                 else -> options.retryCost
             }
             checkoutCapacity(size)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
@@ -25,7 +25,9 @@ public enum class RetryErrorType {
     Throttling,
 
     /**
-     * A timeout condition such as a socket error or server-indicated request timeout.
+     * A connection level error such as a socket timeout, connect error, TLS negotiation timeout, etc. Typically, these
+     * should not be retried for non-idempotent requests as it's impossible to know whether the operation had a side
+     * effect on the server
      */
-    Timeout,
+    Transient,
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/StandardRetryStrategyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/StandardRetryStrategyTest.kt
@@ -49,7 +49,7 @@ class StandardRetryStrategyTest {
                 delayer,
                 "client-error",
                 "server-error",
-                "timeout",
+                "transient",
                 "throttled",
                 "success",
             ),
@@ -147,14 +147,14 @@ class StandardRetryStrategyTest {
                     delayer,
                     "client-error",
                     "server-error",
-                    "timeout",
+                    "transient",
                 ),
             )
         }
 
         val ex = assertIs<TooManyAttemptsException>(result.exceptionOrNull(), "Unexpected ${result.exceptionOrNull()}")
         assertEquals(3, ex.attempts)
-        assertEquals("timeout", ex.lastResponse)
+        assertEquals("transient", ex.lastResponse)
 
         val token = bucket.lastTokenAcquired!!
         assertTrue(token.nextToken!!.nextToken!!.isFailure)
@@ -252,7 +252,7 @@ class StringRetryPolicy : RetryPolicy<String> {
         "fail" -> RetryDirective.TerminateAndFail
         "client-error" -> RetryDirective.RetryError(RetryErrorType.ClientSide)
         "server-error" -> RetryDirective.RetryError(RetryErrorType.ServerSide)
-        "timeout" -> RetryDirective.RetryError(RetryErrorType.Timeout)
+        "transient" -> RetryDirective.RetryError(RetryErrorType.Transient)
         "throttled" -> RetryDirective.RetryError(RetryErrorType.Throttling)
         null -> {
             assertNotNull(result.exceptionOrNull()) // If the value is null, this must be an exception

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -71,7 +71,7 @@ class StandardRetryTokenBucketTest {
     fun testRetryCapacityAdjustments() = runTest {
         mapOf(
             RetryErrorType.Throttling to DefaultOptions.timeoutRetryCost,
-            RetryErrorType.Timeout to DefaultOptions.timeoutRetryCost,
+            RetryErrorType.Transient to DefaultOptions.timeoutRetryCost,
             RetryErrorType.ClientSide to DefaultOptions.retryCost,
             RetryErrorType.ServerSide to DefaultOptions.retryCost,
         ).forEach { (errorType, cost) ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Adds a new `HttpException` and associated error code
* Updates retry policy to evaluate retry metadata from `SdkBaseException` and moves base exception evaluation after more specific exception types
* Removes `retryOnConnect` failures from OkHttp configuration. This avoids an inner retry loop that could exasperate connect storms. 
    * The downside is that OkHttp internally can be smarter about retrying because they know more about the state of the request (e.g. has body been sent) and can likely retry under a few additional scenarios that we can't detect or do safely.
* Map OkHttp and CRT engine exceptions to `HttpException` and attempt to map the underlying cause to a specific `HttpErrorCode`
* Rename `RetryErrorType.Timeout` to `RetryErrorType.Transient` which maps directly to SRA error types for retries

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
