### PR TITLE
fix: only take contentLength if >= 0

### DIFF
--- a/.changes/09d06759-1400-4cda-a67c-103605d087ca.json
+++ b/.changes/09d06759-1400-4cda-a67c-103605d087ca.json
@@ -1,0 +1,5 @@
+{
+    "id": "09d06759-1400-4cda-a67c-103605d087ca",
+    "type": "bugfix",
+    "description": "Only take contentLength if it's >= 0 in CRT HTTP engine"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -60,7 +60,7 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
         headers.forEach { key, values -> appendAll(key, values) }
     }
 
-    val contentLength = body.contentLength?.toString() ?: headers[CONTENT_LENGTH_HEADER]
+    val contentLength = body.contentLength?.takeIf { it >= 0 }?.toString() ?: headers[CONTENT_LENGTH_HEADER]
     contentLength?.let { crtHeaders.append(CONTENT_LENGTH_HEADER, it) }
 
     return aws.sdk.kotlin.crt.http.HttpRequest(method.name, url.encodedPath, crtHeaders.build(), bodyStream)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a bug introduced in a [previous PR](https://github.com/awslabs/smithy-kotlin/pull/819) which unintentionally enabled sending contentLength of -1.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR makes the CRT HTTP request only use the input body's contentLength if it's greater than -1. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
