### PR TITLE
fix(rt): OkHttp request body retry failing due to Job completed

### DIFF
--- a/.changes/a9e3a074-33fa-41da-8322-c83adc2e3637.json
+++ b/.changes/a9e3a074-33fa-41da-8322-c83adc2e3637.json
@@ -1,0 +1,5 @@
+{
+    "id": "a9e3a074-33fa-41da-8322-c83adc2e3637",
+    "type": "bugfix",
+    "description": "Fix okhttp streaming body failing to retry"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
When OkHttp config has retry on connect failures enabled it will attempt to re-use the request body in some scenarios. The coroutine Job was setup to only be used once though and was completed when the original request fails. This causes the (internal okhttp) retry to fail with an obscure JobCompleted exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
