### PR TITLE
Added support for H2_PRIOR_KNOWLEDGE (HTTP2 without TLS)

### DIFF
--- a/.changes/01529a42-f6f9-49b7-8ee8-3888f319b332.json
+++ b/.changes/01529a42-f6f9-49b7-8ee8-3888f319b332.json
@@ -1,0 +1,5 @@
+{
+  "id": "01529a42-f6f9-49b7-8ee8-3888f319b332",
+  "type": "feature",
+  "description": "Add support for H2_PRIOR_KNOWLEDGE (HTTP2 without TLS)"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -102,6 +102,7 @@ private fun OkHttpEngineConfig.buildClient(): OkHttpClient {
                 when (it) {
                     AlpnId.HTTP1_1 -> Protocol.HTTP_1_1
                     AlpnId.HTTP2 -> Protocol.HTTP_2
+                    AlpnId.H2_PRIOR_KNOWLEDGE -> Protocol.H2_PRIOR_KNOWLEDGE
                     else -> null
                 }
             }

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -20,6 +20,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/config/HttpClient
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/AlpnId : java/lang/Enum {
+	public static final field H2_PRIOR_KNOWLEDGE Laws/smithy/kotlin/runtime/http/engine/AlpnId;
 	public static final field HTTP1_1 Laws/smithy/kotlin/runtime/http/engine/AlpnId;
 	public static final field HTTP2 Laws/smithy/kotlin/runtime/http/engine/AlpnId;
 	public static final field HTTP3 Laws/smithy/kotlin/runtime/http/engine/AlpnId;

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
@@ -164,6 +164,12 @@ public enum class AlpnId(public val protocolId: String) {
     HTTP2("h2"),
 
     /**
+     * Cleartext HTTP/2 with no "upgrade" round trip. This option requires the client to have prior knowledge that the
+     * server supports cleartext HTTP/2. See also rfc_7540_34.
+     */
+    H2_PRIOR_KNOWLEDGE("h2_prior_knowledge"),
+
+    /**
      * HTTP 3
      */
     HTTP3("h3"),


### PR DESCRIPTION
To be able to test a smithy client using a local server, it makes a lot of sense to support an option without TLS.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
The change is required to be able to test a locally generated smithy client with a locally generated smithy server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
