### PR TITLE
feat: enhance proxy exceptions

### DIFF
--- a/.changes/2c77890c-7867-41d2-b0c4-6e28525989d3.json
+++ b/.changes/2c77890c-7867-41d2-b0c4-6e28525989d3.json
@@ -1,0 +1,5 @@
+{
+    "id": "2c77890c-7867-41d2-b0c4-6e28525989d3",
+    "type": "feature",
+    "description": "Enhance exceptions thrown during proxy config parsing"
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
@@ -89,9 +89,13 @@ class EnvironmentProxySelectorTest {
     private val failCases = listOf(
         // Invalid ports specified
         FailCase(props = mapOf("http.proxyHost" to "test.proxy.aws", "http.proxyPort" to "0")),
+        FailCase(props = mapOf("http.proxyHost" to "test.proxy.aws", "http.proxyPort" to "x")),
         FailCase(props = mapOf("https.proxyHost" to "test.proxy.aws", "https.proxyPort" to "0")),
+        FailCase(props = mapOf("https.proxyHost" to "test.proxy.aws", "https.proxyPort" to "x")),
         FailCase(env = mapOf("http_proxy" to "http://test.proxy.aws:0")),
+        FailCase(env = mapOf("http_proxy" to "http://test.proxy.aws:x")),
         FailCase(env = mapOf("https_proxy" to "https://test.proxy.aws:0")),
+        FailCase(env = mapOf("https_proxy" to "https://test.proxy.aws:x")),
     )
 
     @Test

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/EnvironmentProxySelectorTest.kt
@@ -5,9 +5,12 @@
 
 package aws.smithy.kotlin.runtime.http.engine
 
+import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.util.PlatformEnvironProvider
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 data class TestPlatformEnvironmentProvider(
@@ -75,6 +78,37 @@ class EnvironmentProxySelectorTest {
             val url = Url.parse(testCase.url)
             val actual = selector.select(url)
             assertEquals(testCase.expected, actual, "[idx=$idx] expected $testCase resulted in proxy config: $actual")
+        }
+    }
+
+    private data class FailCase(
+        val env: Map<String, String> = emptyMap(),
+        val props: Map<String, String> = emptyMap(),
+    )
+
+    private val failCases = listOf(
+        // Invalid ports specified
+        FailCase(props = mapOf("http.proxyHost" to "test.proxy.aws", "http.proxyPort" to "0")),
+        FailCase(props = mapOf("https.proxyHost" to "test.proxy.aws", "https.proxyPort" to "0")),
+        FailCase(env = mapOf("http_proxy" to "http://test.proxy.aws:0")),
+        FailCase(env = mapOf("https_proxy" to "https://test.proxy.aws:0")),
+    )
+
+    @Test
+    fun testSelectFailures() {
+        failCases.forEachIndexed { idx, failCase ->
+            val testProvider = TestPlatformEnvironmentProvider(failCase.env, failCase.props)
+            val exception = assertThrows<ClientException>("[idx=$idx] expected ClientException") {
+                EnvironmentProxySelector(testProvider)
+            }
+
+            val expectedError = (failCase.env + failCase.props).map { (k, v) -> """$k="$v"""" }.joinToString(", ")
+
+            assertContains(
+                exception.message!!,
+                expectedError,
+                message = "[idx=$idx] unexpected error message ${exception.message}",
+            )
         }
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
@@ -35,7 +35,7 @@ public data class Url(
     public val encodeParameters: Boolean = true,
 ) {
     init {
-        require(port in 1..65535) { "port must be in range [1, 65535]" }
+        require(port in 1..65535) { "Given port $port is not in required range [1, 65535]" }
     }
 
     public companion object {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change enhances the exceptions thrown while parsing proxy configurations. Previously, specifying an invalid port via a system property (e.g., `https.proxyPort="0"`) would result in a generic exception thrown:

```
java.lang.IllegalArgumentException: port must be in range [1, 65535]
```

This change indicates which properties/variables were parsed and what their values were to aid in debugging proxy configuration:

```
aws.smithy.kotlin.runtime.ClientException: Could not parse http.proxyHost="test.proxy.aws", http.proxyPort="0" into a valid proxy URL
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.