### PR TITLE
chore: refactor environment settings and retry settings out of aws-sdk-kotlin into smithy-kotlin

### DIFF
--- a/.changes/c0bae93d-f508-4b1e-a810-a528285f599f.json
+++ b/.changes/c0bae93d-f508-4b1e-a810-a528285f599f.json
@@ -1,0 +1,5 @@
+{
+    "id": "c0bae93d-f508-4b1e-a810-a528285f599f",
+    "type": "misc",
+    "description": "Refactor environment settings and retry modes out of aws-sdk-kotlin"
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -66,6 +66,9 @@ public final class aws/smithy/kotlin/runtime/ServiceException$ErrorType : java/l
 	public static fun values ()[Laws/smithy/kotlin/runtime/ServiceException$ErrorType;
 }
 
+public final class aws/smithy/kotlin/runtime/config/EnvironmentSettingKt {
+}
+
 public final class aws/smithy/kotlin/runtime/content/ByteArrayContent : aws/smithy/kotlin/runtime/content/ByteStream$Buffer {
 	public fun <init> ([B)V
 	public fun bytes ()[B

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/EnvironmentSetting.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/EnvironmentSetting.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.config
 
 import aws.smithy.kotlin.runtime.ClientException
@@ -8,25 +12,25 @@ import aws.smithy.kotlin.runtime.util.PlatformEnvironProvider
 public typealias EnvSettingFactory<T> = (String, String) -> EnvironmentSetting<T>
 
 /**
- * Describes a setting whose value may be retrieved from the local environment, usually via an environment variable or
- * a JVM system property.
+ * Describes a setting whose value may be retrieved from the local environment, usually via a JVM system property or an
+ * environment variable.
  * @param T The type of values for this property
  * @param parse A function that maps string values into the type of this setting
- * @param envVar The name of the environment variable where this setting may be configured
  * @param sysProp The name of the JVM system property where this setting may be configured
+ * @param envVar The name of the environment variable where this setting may be configured
  * @param defaultValue The default value (if one exists)
  */
 @InternalApi
 public data class EnvironmentSetting<T>(
     public val parse: (String) -> T,
-    public val envVar: String,
     public val sysProp: String,
+    public val envVar: String,
     public val defaultValue: T? = null,
 ) {
     @InternalApi
     public companion object {
         public operator fun <T> invoke(asTyped: (String) -> T): EnvSettingFactory<T> =
-            { envVar: String, sysProp: String -> EnvironmentSetting(asTyped, envVar, sysProp) }
+            { sysProp: String, envVar: String -> EnvironmentSetting(asTyped, sysProp, envVar) }
     }
 
     public fun orElse(defaultValue: T): EnvironmentSetting<T> = copy(defaultValue = defaultValue)
@@ -44,22 +48,20 @@ public fun <T> EnvironmentSetting<T>.resolve(platform: PlatformEnvironProvider):
     return stringValue?.let(parse) ?: defaultValue
 }
 
-@InternalApi
-public val boolEnvSetting: EnvSettingFactory<Boolean> = EnvironmentSetting(String::toBoolean)
-@InternalApi
-public val intEnvSetting: EnvSettingFactory<Int> = EnvironmentSetting(String::toInt)
-@InternalApi
-public val longEnvSetting: EnvSettingFactory<Long> = EnvironmentSetting(String::toLong)
-@InternalApi
-public val strEnvSetting: EnvSettingFactory<String> = EnvironmentSetting { it }
+/* ktlint-disable spacing-between-declarations-with-annotations */
+@InternalApi public val boolEnvSetting: EnvSettingFactory<Boolean> = EnvironmentSetting(String::toBoolean)
+@InternalApi public val intEnvSetting: EnvSettingFactory<Int> = EnvironmentSetting(String::toInt)
+@InternalApi public val longEnvSetting: EnvSettingFactory<Long> = EnvironmentSetting(String::toLong)
+@InternalApi public val strEnvSetting: EnvSettingFactory<String> = EnvironmentSetting { it }
+/* ktlint-enable spacing-between-declarations-with-annotations */
 
 @InternalApi
-public inline fun <reified T : Enum<T>> enumEnvSetting(envVar: String, sysProp: String): EnvironmentSetting<T> {
+public inline fun <reified T : Enum<T>> enumEnvSetting(sysProp: String, envVar: String): EnvironmentSetting<T> {
     val parse = { strValue: String ->
         val allValues = enumValues<T>()
         allValues
             .firstOrNull { it.name.equals(strValue, ignoreCase = true) }
             ?: throw ClientException("Value $strValue is not supported, should be one of ${allValues.joinToString(", ")}")
     }
-    return EnvironmentSetting(parse, envVar, sysProp)
+    return EnvironmentSetting(parse, sysProp, envVar)
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/EnvironmentSetting.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/config/EnvironmentSetting.kt
@@ -1,0 +1,65 @@
+package aws.smithy.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.util.PlatformEnvironProvider
+
+@InternalApi
+public typealias EnvSettingFactory<T> = (String, String) -> EnvironmentSetting<T>
+
+/**
+ * Describes a setting whose value may be retrieved from the local environment, usually via an environment variable or
+ * a JVM system property.
+ * @param T The type of values for this property
+ * @param parse A function that maps string values into the type of this setting
+ * @param envVar The name of the environment variable where this setting may be configured
+ * @param sysProp The name of the JVM system property where this setting may be configured
+ * @param defaultValue The default value (if one exists)
+ */
+@InternalApi
+public data class EnvironmentSetting<T>(
+    public val parse: (String) -> T,
+    public val envVar: String,
+    public val sysProp: String,
+    public val defaultValue: T? = null,
+) {
+    @InternalApi
+    public companion object {
+        public operator fun <T> invoke(asTyped: (String) -> T): EnvSettingFactory<T> =
+            { envVar: String, sysProp: String -> EnvironmentSetting(asTyped, envVar, sysProp) }
+    }
+
+    public fun orElse(defaultValue: T): EnvironmentSetting<T> = copy(defaultValue = defaultValue)
+}
+
+/**
+ * Resolves an environment setting from the environment. This method attempts to resolve the setting via the system
+ * property first, falling back to the environment variable if necessary. If neither is set, it returns the setting's
+ * default value.
+ * @param platform The [PlatformEnvironProvider] to use for reading system properties and environment variables.
+ */
+@InternalApi
+public fun <T> EnvironmentSetting<T>.resolve(platform: PlatformEnvironProvider): T? {
+    val stringValue = platform.getProperty(sysProp) ?: platform.getenv(envVar)
+    return stringValue?.let(parse) ?: defaultValue
+}
+
+@InternalApi
+public val boolEnvSetting: EnvSettingFactory<Boolean> = EnvironmentSetting(String::toBoolean)
+@InternalApi
+public val intEnvSetting: EnvSettingFactory<Int> = EnvironmentSetting(String::toInt)
+@InternalApi
+public val longEnvSetting: EnvSettingFactory<Long> = EnvironmentSetting(String::toLong)
+@InternalApi
+public val strEnvSetting: EnvSettingFactory<String> = EnvironmentSetting { it }
+
+@InternalApi
+public inline fun <reified T : Enum<T>> enumEnvSetting(envVar: String, sysProp: String): EnvironmentSetting<T> {
+    val parse = { strValue: String ->
+        val allValues = enumValues<T>()
+        allValues
+            .firstOrNull { it.name.equals(strValue, ignoreCase = true) }
+            ?: throw ClientException("Value $strValue is not supported, should be one of ${allValues.joinToString(", ")}")
+    }
+    return EnvironmentSetting(parse, envVar, sysProp)
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/config/EnvironmentSettingTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/config/EnvironmentSettingTest.kt
@@ -1,7 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.config
 
 import aws.smithy.kotlin.runtime.util.PlatformEnvironProvider
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -9,8 +12,8 @@ import kotlin.test.assertNull
 class EnvironmentSettingTest {
     @Test
     fun itResolvesSysPropSettingFirst() {
-        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("error")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "error"), mapOf("foo.bar" to "success"))
+        val setting = strEnvSetting("foo.bar", "FOO_BAR").orElse("error")
+        val testPlatform = mockPlatform(mapOf("foo.bar" to "success"), mapOf("FOO_BAR" to "error"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals("success", actual)
@@ -18,8 +21,8 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesEnvVarSettingSecond() {
-        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("error")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "success"))
+        val setting = strEnvSetting("foo.bar", "FOO_BAR").orElse("error")
+        val testPlatform = mockPlatform(envVars = mapOf("FOO_BAR" to "success"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals("success", actual)
@@ -27,7 +30,7 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesDefaultSettingThird() {
-        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("success")
+        val setting = strEnvSetting("foo.bar", "FOO_BAR").orElse("success")
         val testPlatform = mockPlatform()
 
         val actual = setting.resolve(testPlatform)
@@ -36,7 +39,7 @@ class EnvironmentSettingTest {
 
     @Test
     fun itReturnsNullWithNoValue() {
-        val setting = strEnvSetting("FOO_BAR", "foo.bar")
+        val setting = strEnvSetting("foo.bar", "FOO_BAR")
         val testPlatform = mockPlatform()
 
         assertNull(setting.resolve(testPlatform))
@@ -44,8 +47,8 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesBooleans() {
-        val setting = boolEnvSetting("FOO_BAR", "foo.bar")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "TRUE"))
+        val setting = boolEnvSetting("foo.bar", "FOO_BAR")
+        val testPlatform = mockPlatform(mapOf("foo.bar" to "TRUE"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals(true, actual)
@@ -53,8 +56,8 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesIntegers() {
-        val setting = intEnvSetting("FOO_BAR", "foo.bar")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "42"))
+        val setting = intEnvSetting("foo.bar", "FOO_BAR")
+        val testPlatform = mockPlatform(mapOf("foo.bar" to "42"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals(42, actual)
@@ -62,8 +65,8 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesLongs() {
-        val setting = longEnvSetting("FOO_BAR", "foo.bar")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "-4294967296"))
+        val setting = longEnvSetting("foo.bar", "FOO_BAR")
+        val testPlatform = mockPlatform(mapOf("foo.bar" to "-4294967296"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals(-4294967296L, actual)
@@ -71,15 +74,15 @@ class EnvironmentSettingTest {
 
     @Test
     fun itResolvesEnums() {
-        val setting = enumEnvSetting<Suit>("FOO_BAR", "foo.bar")
-        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "spades"))
+        val setting = enumEnvSetting<Suit>("foo.bar", "FOO_BAR")
+        val testPlatform = mockPlatform(mapOf("foo.bar" to "spades"))
 
         val actual = setting.resolve(testPlatform)
         assertEquals(Suit.Spades, actual)
     }
 }
 
-private fun mockPlatform(envVars: Map<String, String> = mapOf(), sysProps: Map<String, String> = mapOf()) =
+private fun mockPlatform(sysProps: Map<String, String> = mapOf(), envVars: Map<String, String> = mapOf()) =
     object : PlatformEnvironProvider {
         override fun getAllEnvVars(): Map<String, String> = envVars
         override fun getenv(key: String): String? = envVars[key]

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/config/EnvironmentSettingTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/config/EnvironmentSettingTest.kt
@@ -1,0 +1,95 @@
+package aws.smithy.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.util.PlatformEnvironProvider
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EnvironmentSettingTest {
+    @Test
+    fun itResolvesSysPropSettingFirst() {
+        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("error")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "error"), mapOf("foo.bar" to "success"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals("success", actual)
+    }
+
+    @Test
+    fun itResolvesEnvVarSettingSecond() {
+        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("error")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "success"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals("success", actual)
+    }
+
+    @Test
+    fun itResolvesDefaultSettingThird() {
+        val setting = strEnvSetting("FOO_BAR", "foo.bar").orElse("success")
+        val testPlatform = mockPlatform()
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals("success", actual)
+    }
+
+    @Test
+    fun itReturnsNullWithNoValue() {
+        val setting = strEnvSetting("FOO_BAR", "foo.bar")
+        val testPlatform = mockPlatform()
+
+        assertNull(setting.resolve(testPlatform))
+    }
+
+    @Test
+    fun itResolvesBooleans() {
+        val setting = boolEnvSetting("FOO_BAR", "foo.bar")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "TRUE"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals(true, actual)
+    }
+
+    @Test
+    fun itResolvesIntegers() {
+        val setting = intEnvSetting("FOO_BAR", "foo.bar")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "42"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals(42, actual)
+    }
+
+    @Test
+    fun itResolvesLongs() {
+        val setting = longEnvSetting("FOO_BAR", "foo.bar")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "-4294967296"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals(-4294967296L, actual)
+    }
+
+    @Test
+    fun itResolvesEnums() {
+        val setting = enumEnvSetting<Suit>("FOO_BAR", "foo.bar")
+        val testPlatform = mockPlatform(mapOf("FOO_BAR" to "spades"))
+
+        val actual = setting.resolve(testPlatform)
+        assertEquals(Suit.Spades, actual)
+    }
+}
+
+private fun mockPlatform(envVars: Map<String, String> = mapOf(), sysProps: Map<String, String> = mapOf()) =
+    object : PlatformEnvironProvider {
+        override fun getAllEnvVars(): Map<String, String> = envVars
+        override fun getenv(key: String): String? = envVars[key]
+        override fun getAllProperties(): Map<String, String> = sysProps
+        override fun getProperty(key: String): String? = sysProps[key]
+    }
+
+enum class Suit {
+    Hearts,
+    Diamonds,
+    Clubs,
+    Spades,
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.client.config
 
 import aws.smithy.kotlin.runtime.InternalApi
@@ -11,10 +15,10 @@ public object ClientSettings {
      * The maximum number of request attempts to perform. This is one more than the number of retries, so
      * maxAttempts = 1 will have 0 retries.
      */
-    public val MaxAttempts: EnvironmentSetting<Int> = intEnvSetting("SDK_MAX_ATTEMPTS", "sdk.maxAttempts")
+    public val MaxAttempts: EnvironmentSetting<Int> = intEnvSetting("sdk.maxAttempts", "SDK_MAX_ATTEMPTS")
 
     /**
      * Which RetryMode to use for the default RetryPolicy, when one is not specified at the client level.
      */
-    public val RetryMode: EnvironmentSetting<RetryMode> = enumEnvSetting<RetryMode>("SDK_RETRY_MODE", "sdk.retryMode")
+    public val RetryMode: EnvironmentSetting<RetryMode> = enumEnvSetting<RetryMode>("sdk.retryMode", "SDK_RETRY_MODE")
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
@@ -1,0 +1,20 @@
+package aws.smithy.kotlin.runtime.client.config
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.config.EnvironmentSetting
+import aws.smithy.kotlin.runtime.config.enumEnvSetting
+import aws.smithy.kotlin.runtime.config.intEnvSetting
+
+@InternalApi
+public object ClientSettings {
+    /**
+     * The maximum number of request attempts to perform. This is one more than the number of retries, so
+     * maxAttempts = 1 will have 0 retries.
+     */
+    public val MaxAttempts: EnvironmentSetting<Int> = intEnvSetting("SDK_MAX_ATTEMPTS", "sdk.maxAttempts")
+
+    /**
+     * Which RetryMode to use for the default RetryPolicy, when one is not specified at the client level.
+     */
+    public val RetryMode: EnvironmentSetting<RetryMode> = enumEnvSetting<RetryMode>("SDK_RETRY_MODE", "sdk.retryMode")
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.client.config
 
 import aws.smithy.kotlin.runtime.InternalApi

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -1,0 +1,25 @@
+package aws.smithy.kotlin.runtime.client.config
+
+import aws.smithy.kotlin.runtime.InternalApi
+
+/**
+ * The retry mode to be used for the client's retry strategy.
+ */
+@InternalApi
+public enum class RetryMode {
+    /**
+     * The legacy retry mode is supported for compatibility with other SDKs and existing configurations for them,
+     * but it works exactly the same as the standard retry mode for this SDK.
+     */
+    LEGACY,
+
+    /**
+     * The standard retry mode. With this, the client will use the [StandardRetryStrategy][aws.smithy.kotlin.runtime.retries.StandardRetryStrategy]
+     */
+    STANDARD,
+
+    /**
+     * Not implemented yet. https://github.com/awslabs/aws-sdk-kotlin/issues/701
+     */
+    ADAPTIVE,
+}


### PR DESCRIPTION
## Issue \#

Pre-requisite for #661 

## Description of changes

This change refactors environmental settings and moves the core logic from **aws-sdk-kotlin**'s `AwsSdkSetting` into a new **smithy-kotlin** `EnvironmentSetting`. It also moves retry configuration settings down to **smithy-kotlin** in a new `ClientSettings` namespace.

**Companion PR**: [aws-sdk-kotlin#904](https://github.com/awslabs/aws-sdk-kotlin/pull/904)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
