### PR TITLE
chore: configure SonarCloud scanning exclusions

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions = runtime/auth/aws-signing-tests/common/resources/aws-signing-test-suite/**


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Fixes false positives detected by SonarCloud's automated code scanning, namely fake secrets embedded in the Sigv4 test suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
