### PR TITLE
fix: correct waiters with broken subfield projections

### DIFF
--- a/.changes/3cf671d8-1ec4-4e2f-a4ae-0f1f08f73fd1.json
+++ b/.changes/3cf671d8-1ec4-4e2f-a4ae-0f1f08f73fd1.json
@@ -1,0 +1,5 @@
+{
+    "id": "3cf671d8-1ec4-4e2f-a4ae-0f1f08f73fd1",
+    "type": "bugfix",
+    "description": "Fix broken shape cursor when generating acceptor subfield projections."
+}

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -699,6 +699,36 @@ service WaitersTestService {
             }
         ]
     },
+
+    // subfield projection
+    HasStructWithStringByProjection: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[].primitives.string"
+                        expected: "foo",
+                        comparator: "anyStringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    HasStructWithSubstructWithStringByProjection: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[].subStructs[].subStructPrimitives.string"
+                        expected: "foo",
+                        comparator: "anyStringEquals"
+                    }
+                }
+            }
+        ]
+    },
 )
 @readonly
 @http(method: "GET", uri: "/entities/{name}", code: 200)
@@ -833,4 +863,13 @@ structure Struct {
     primitives: EntityPrimitives,
     strings: StringList,
     enums: EnumList,
+    subStructs: SubStructList,
+}
+
+list SubStructList {
+    member: SubStruct,
+}
+
+structure SubStruct {
+    subStructPrimitives: EntityPrimitives,
 }

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -681,4 +681,68 @@ class WaiterTest {
             }
         },
     )
+
+    // subfield projection
+    @Test fun testHasStructWithStringByProjection() = successTest(
+        WaitersTestClient::waitUntilHasStructWithStringByProjection,
+        GetEntityResponse { },
+        GetEntityResponse { lists = EntityLists { } },
+        GetEntityResponse {
+            lists = EntityLists { structs = listOf() }
+        },
+        GetEntityResponse {
+            lists = EntityLists { structs = listOf(Struct { }) }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct { primitives = EntityPrimitives { string = "bar" } },
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct { primitives = EntityPrimitives { string = "bar" } },
+                    Struct { primitives = EntityPrimitives { string = "foo" } },
+                )
+            }
+        },
+    )
+    @Test fun testHasStructWithSubstructWithStringByProjection() = successTest(
+        WaitersTestClient::waitUntilHasStructWithSubstructWithStringByProjection,
+        GetEntityResponse { },
+        GetEntityResponse { lists = EntityLists { } },
+        GetEntityResponse {
+            lists = EntityLists { structs = listOf() }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct { subStructs = listOf(SubStruct { }) },
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct { subStructs = listOf(SubStruct { subStructPrimitives = EntityPrimitives { string = "bar" } }) },
+                    Struct { subStructs = listOf(SubStruct { }) },
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct { subStructPrimitives = EntityPrimitives { string = "bar" } },
+                            SubStruct { subStructPrimitives = EntityPrimitives { string = "baz" } },
+                        )
+                    },
+                    Struct { subStructs = listOf(SubStruct { subStructPrimitives = EntityPrimitives { string = "foo" } }) },
+                )
+            }
+        },
+    )
 }


### PR DESCRIPTION
## Description of changes
Correct flat mapping codegen for waiters to correctly bubble up the inner visited expression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
