### PR TITLE
fix: usage of pre-calculated checksum values

### DIFF
--- a/.changes/47b592af-ba43-43ad-b38b-534845549cfd.json
+++ b/.changes/47b592af-ba43-43ad-b38b-534845549cfd.json
@@ -1,0 +1,5 @@
+{
+    "id": "47b592af-ba43-43ad-b38b-534845549cfd",
+    "type": "bugfix",
+    "description": "Fix usage of precalculated checksum values"
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
@@ -56,7 +56,7 @@ public class FlexibleChecksumsRequestInterceptor<I>(
             "Can't calculate the checksum of an empty body"
         }
 
-        val headerName = "x-amz-checksum-$checksumAlgorithmName"
+        val headerName = "x-amz-checksum-$checksumAlgorithmName".lowercase()
         logger.debug { "Resolved checksum header name: $headerName" }
 
         // remove all checksum headers except for $headerName

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
@@ -42,7 +42,6 @@ public class FlexibleChecksumsRequestInterceptor<I>(
         checksumAlgorithmName = checksumAlgorithmNameInitializer(input)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun modifyBeforeRetryLoop(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
         val logger = coroutineContext.getLogger<FlexibleChecksumsRequestInterceptor<I>>()
 
@@ -140,7 +139,7 @@ public class FlexibleChecksumsRequestInterceptor<I>(
      * Convert an [HttpBody] with an underlying [HashingSource] or [HashingByteReadChannel]
      * to a [CompletingSource] or [CompletingByteReadChannel], respectively.
      */
-    internal fun HttpBody.toCompletingBody(deferred: CompletableDeferred<String>) = when (this) {
+    private fun HttpBody.toCompletingBody(deferred: CompletableDeferred<String>) = when (this) {
         is HttpBody.SourceContent -> CompletingSource(deferred, (readFrom() as HashingSource)).toHttpBody(contentLength)
         is HttpBody.ChannelContent -> CompletingByteReadChannel(deferred, (readFrom() as HashingByteReadChannel)).toHttpBody(contentLength)
         else -> throw ClientException("HttpBody type is not supported")

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -186,7 +186,7 @@ class FlexibleChecksumsRequestInterceptorTest {
         val req = HttpRequestBuilder().apply {
             body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
         }
-        val checksumAlgorithmName = "SHA256"
+        val checksumAlgorithmName = "sha256"
         val precalculatedChecksumValue = "sha256-checksum-value"
         req.headers { append("x-amz-checksum-$checksumAlgorithmName", precalculatedChecksumValue) }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -181,6 +181,30 @@ class FlexibleChecksumsRequestInterceptorTest {
         assertEquals(expectedHash.digest().encodeBase64String(), completableDeferred.getCompleted())
     }
 
+    @Test
+    fun itUsesPrecalculatedChecksum() = runTest {
+        val req = HttpRequestBuilder().apply {
+            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+        }
+        val checksumAlgorithmName = "SHA256"
+        val precalculatedChecksumValue = "sha256-checksum-value"
+        req.headers { append("x-amz-checksum-$checksumAlgorithmName", precalculatedChecksumValue) }
+
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+
+        op.interceptors.add(
+            FlexibleChecksumsRequestInterceptor<Unit> {
+                checksumAlgorithmName
+            },
+        )
+
+        op.roundTrip(client, Unit)
+        val call = op.context.attributes[HttpOperationContext.HttpCallList].first()
+
+        assertEquals(1, call.request.headers.getNumChecksumHeaders())
+        assertEquals(precalculatedChecksumValue, call.request.headers["x-amz-checksum-sha256"])
+    }
+
     private fun Headers.getNumChecksumHeaders(): Long = entries().stream()
         .filter { (name, _) -> name.startsWith("x-amz-checksum-") }
         .count()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Pre-calculated checksums were being ignored in all cases because the checksum algorithm name was not being lowercased properly. This results in the SDK expecting a checksum header value in `x-amz-checksum-SHA256` rather than `x-amz-checksum-sha256` where it's actually set. 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR ensures `lowercase()` is called on the expected header name (turning `x-amz-checksum-SHA256` into `x-amz-checksum-sha256`) before it's used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
