### PR TITLE
chore: fix erronerous CHANGELOG entry for HTTP configuration change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.20.0] - 05/18/2023
 
 ### Features
-* **Breaking**: Make HTTP engines configurable in client config during initialization and during `withCopy`. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/new?category=announcements) for more information.
+* **Breaking**: Make HTTP engines configurable in client config during initialization and during `withCopy`. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/919) for more information.
 
 ## [0.19.0] - 05/12/2023
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The **CHANGELOG** entry for the HTTP engine configuration change erroneously linked to https://github.com/awslabs/aws-sdk-kotlin/discussions/new?category=announcements instead of https://github.com/awslabs/aws-sdk-kotlin/discussions/919.

The [GitHub release notes](https://github.com/awslabs/smithy-kotlin/releases/tag/v0.20.0) have already been updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
