### PR TITLE
fix: validate modeled HTTP status codes

### DIFF
--- a/.changes/2fda4a38-9ab6-4f22-8142-b8b269c52451.json
+++ b/.changes/2fda4a38-9ab6-4f22-8142-b8b269c52451.json
@@ -1,0 +1,5 @@
+{
+    "id": "2fda4a38-9ab6-4f22-8142-b8b269c52451",
+    "type": "misc",
+    "description": "Remove `expectedHttpStatus` from HTTP operation context"
+}

--- a/.changes/93d5f1da-5d48-4a24-926e-6df432969e39.json
+++ b/.changes/93d5f1da-5d48-4a24-926e-6df432969e39.json
@@ -1,0 +1,8 @@
+{
+    "id": "93d5f1da-5d48-4a24-926e-6df432969e39",
+    "type": "bugfix",
+    "description": "Validate modeled HTTP response codes",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/836"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -523,8 +523,8 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
      * Renders the logic to detect if an HTTP response should be considered an error for this operation
      */
     protected open fun renderIsHttpError(ctx: ProtocolGenerator.GenerationContext, op: OperationShape, writer: KotlinWriter) {
-        writer.addImport(RuntimeTypes.Http.isSuccess)
-        writer.withBlock("if (!response.status.#T()) {", "}", RuntimeTypes.Http.isSuccess) {
+        val resolver = getProtocolHttpBindingResolver(ctx.model, ctx.service)
+        writer.withBlock("if (response.status.value != #L) {", "}", resolver.httpTrait(op).code) {
             val errorHandlerFn = operationErrorHandler(ctx, op)
             write("#T(context, response)", errorHandlerFn)
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -203,7 +203,6 @@ abstract class HttpProtocolClientGenerator(
 
             // execution context
             writer.openBlock("context {", "}") {
-                writer.write("expectedHttpStatus = ${httpTrait.code}")
                 // property from implementing SdkClient
                 writer.write("operationName = #S", op.id.name)
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -366,7 +366,7 @@ internal class ConstantQueryStringOperationSerializer: HttpSerialize<ConstantQue
 internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse> {
 
     override suspend fun deserialize(context: ExecutionContext, response: HttpResponse): SmokeTestResponse {
-        if (!response.status.isSuccess()) {
+        if (response.status.value != 234) {
             throwSmokeTestError(context, response)
         }
         val builder = SmokeTestResponse.Builder()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -80,7 +80,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooOperationSerializer()
             deserializer = GetFooOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFoo"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -101,7 +100,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoInputOperationSerializer()
             deserializer = GetFooNoInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoInput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -122,7 +120,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoOutputOperationSerializer()
             deserializer = GetFooNoOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoOutput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -143,7 +140,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingInputOperationSerializer()
             deserializer = GetFooStreamingInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingInput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -164,7 +160,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingOutputOperationSerializer()
             deserializer = GetFooStreamingOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -185,7 +180,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingOutputNoInputOperationSerializer()
             deserializer = GetFooStreamingOutputNoInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutputNoInput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -206,7 +200,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingInputNoOutputOperationSerializer()
             deserializer = GetFooStreamingInputNoOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingInputNoOutput"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -227,7 +220,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoRequiredOperationSerializer()
             deserializer = GetFooNoRequiredOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoRequired"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -248,7 +240,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooSomeRequiredOperationSerializer()
             deserializer = GetFooSomeRequiredOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooSomeRequired"
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
@@ -325,7 +316,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetStatusOperationSerializer()
             deserializer = GetStatusOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetStatus"
                 hostPrefix = "$prefix"
             }

--- a/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/http-binding-protocol-generator-test.smithy
+++ b/codegen/smithy-kotlin-codegen/src/test/resources/software/amazon/smithy/kotlin/codegen/http-binding-protocol-generator-test.smithy
@@ -30,7 +30,7 @@ service Test {
     ]
 }
 
-@http(method: "POST", uri: "/smoketest/{label1}/foo")
+@http(method: "POST", uri: "/smoketest/{label1}/foo", code: 234)
 operation SmokeTest {
     input: SmokeTestRequest,
     output: SmokeTestResponse,

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -198,17 +198,14 @@ public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpDes
 
 public class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Builder : aws/smithy/kotlin/runtime/client/ClientOptionsBuilder {
 	public fun <init> ()V
-	public final fun getExpectedHttpStatus ()Ljava/lang/Integer;
 	public final fun getHostPrefix ()Ljava/lang/String;
 	public final fun getOperationName ()Ljava/lang/String;
-	public final fun setExpectedHttpStatus (Ljava/lang/Integer;)V
 	public final fun setHostPrefix (Ljava/lang/String;)V
 	public final fun setOperationName (Ljava/lang/String;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Companion {
 	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/operation/ExecutionContext;
-	public final fun getExpectedHttpStatus ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHostPrefix ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHttpCallList ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getOperationInput ()Laws/smithy/kotlin/runtime/util/AttributeKey;

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -24,11 +24,6 @@ public open class HttpOperationContext {
 
     public companion object {
         /**
-         * The expected HTTP status code of a successful response is stored under this key
-         */
-        public val ExpectedHttpStatus: AttributeKey<Int> = AttributeKey("aws.smithy.kotlin#ExpectedHttpStatus")
-
-        /**
          * A prefix to prepend the resolved hostname with.
          * See [endpointTrait](https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#endpoint-trait)
          */
@@ -68,11 +63,6 @@ public open class HttpOperationContext {
          * The name of the operation
          */
         public var operationName: String? by requiredOption(SdkClientOption.OperationName)
-
-        /**
-         * The expected HTTP status code on success
-         */
-        public var expectedHttpStatus: Int? by option(ExpectedHttpStatus)
 
         /**
          * (Optional) prefix to prepend to a (resolved) hostname

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
@@ -15,11 +15,9 @@ class HttpOperationContextTest {
     fun testBuilder() {
         val op = HttpOperationContext.build {
             operationName = "operation"
-            expectedHttpStatus = 418
         }
 
         assertEquals("operation", op[SdkClientOption.OperationName])
-        assertEquals(418, op[HttpOperationContext.ExpectedHttpStatus])
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
HTTP status codes are modeled on operations using the `@http` trait's `code` field, which [defaults to 200](https://smithy.io/2.0/spec/http-bindings.html?highlight=http#http-trait).

Currently we validate HTTP responses by checking if the code is in the 2xx range. Instead, we should validate using the modeled response code. 

- Change validation logic from `!response.status.isSuccess()` to `response.status.value != {expected HTTP status code}` **only if** the modeled code differs from the default value of 200.
- Remove `expectedHttpStatus` from the HTTP operation's execution context, since it was not being used anywhere. (Optional change, up for debate if we should keep it)


## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/smithy-kotlin/issues/836

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required to only validate the modeled HTTP response code. Currently the SDK may consider some responses "valid" even if the service did not intend for them to be valid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
