### PR TITLE
chore: update notice file to credit Hadoop and Ktor

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,12 @@
+AWS SDK for Kotlin
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+This software includes a copy of the CRC32C implementation (runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/hashing/Crc32c.kt)
+from the Apache Hadoop project (https://github.com/apache/hadoop).
+Copyright 2006 and onwards The Apache Software Foundation.
+
+
+This software includes a copy of async primitives (runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/internal/AwaitingSlot.kt) 
+from the Ktor project (https://github.com/ktorio/ktor).
+Copyright 2014-2021 JetBrains s.r.o and contributors.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Updates the `NOTICE` file (following Apache [instructions](https://infra.apache.org/licensing-howto.html#mod-notice)).

See also Java v2: https://github.com/aws/aws-sdk-java-v2/blob/master/NOTICE.txt

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
