### PR TITLE
fix: allow non-HTTPS URLs in presigning

### DIFF
--- a/.changes/aeef9722-fc30-4771-80f3-abcca702b45f.json
+++ b/.changes/aeef9722-fc30-4771-80f3-abcca702b45f.json
@@ -1,0 +1,8 @@
+{
+    "id": "aeef9722-fc30-4771-80f3-abcca702b45f",
+    "type": "bugfix",
+    "description": "Allow non-HTTPS URLs in presigning",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#938"
+    ]
+}

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -23,6 +23,12 @@ kotlin {
             }
         }
 
+        commonTest {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+            }
+        }
+
         all {
             languageSettings.optIn("aws.smithy.kotlin.runtime.InternalApi")
         }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -13,7 +13,6 @@ import aws.smithy.kotlin.runtime.http.operation.ResolveEndpointRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.header
-import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 
@@ -53,7 +52,7 @@ public suspend fun presignRequest(
     return HttpRequest(
         method = signedRequest.method,
         url = Url(
-            scheme = Scheme.HTTPS,
+            scheme = endpoint.uri.scheme,
             host = endpoint.uri.host,
             port = endpoint.uri.port,
             path = signedRequest.url.path,

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.auth.awssigning
+
+import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
+import aws.smithy.kotlin.runtime.http.Headers
+import aws.smithy.kotlin.runtime.http.operation.EndpointResolver
+import aws.smithy.kotlin.runtime.http.operation.ResolveEndpointRequest
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.request.url
+import aws.smithy.kotlin.runtime.net.Url
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.util.Attributes
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val NON_HTTPS_URL = "http://localhost:8080/path/to/resource?foo=bar"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PresignerTest {
+    @Test
+    fun testSignedUrlAllowsHttp() = testSigningUrl("http://localhost:8080/path/to/resource?foo=bar")
+
+    @Test
+    fun testSignedUrlAllowsHttps() = testSigningUrl("https://localhost:8088/path/to/resource?bar=foo")
+
+    private fun testSigningUrl(url: String) = runTest {
+        val expectedUrl = Url.parse(url)
+
+        val unsignedRequestBuilder = HttpRequestBuilder()
+        val ctx = ExecutionContext()
+        val credentialsProvider = StaticCredentialsProvider(Credentials("foo", "bar"))
+        val endpointResolver = StaticEndpointResolver(Endpoint(expectedUrl))
+        val signer = StaticSigner(HttpRequest { url(expectedUrl) })
+        val signingConfig: AwsSigningConfig.Builder.() -> Unit = {
+            service = "launch-service"
+            region = "the-moon"
+        }
+
+        val presignedRequest = presignRequest(
+            unsignedRequestBuilder,
+            ctx,
+            credentialsProvider,
+            endpointResolver,
+            signer,
+            signingConfig,
+        )
+
+        val actualUrl = presignedRequest.url
+
+        assertEquals(expectedUrl.scheme, actualUrl.scheme)
+        assertEquals(expectedUrl.host, actualUrl.host)
+        assertEquals(expectedUrl.port, actualUrl.port)
+        assertEquals(expectedUrl.path, actualUrl.path)
+        expectedUrl.parameters.forEach { key, value ->
+            assertEquals(value, actualUrl.parameters.getAll(key))
+        }
+    }
+}
+
+private class StaticCredentialsProvider(private val credentials: Credentials) : CredentialsProvider {
+    override suspend fun resolve(attributes: Attributes): Credentials = credentials
+}
+
+private class StaticEndpointResolver(private val resolvedEndpoint: Endpoint) : EndpointResolver {
+    override suspend fun resolve(request: ResolveEndpointRequest): Endpoint = resolvedEndpoint
+}
+
+private class StaticSigner(private val signedOutput: HttpRequest) : AwsSigner {
+    override suspend fun sign(request: HttpRequest, config: AwsSigningConfig): AwsSigningResult<HttpRequest> =
+        AwsSigningResult(signedOutput, byteArrayOf())
+
+    override suspend fun signChunk(
+        chunkBody: ByteArray,
+        prevSignature: ByteArray,
+        config: AwsSigningConfig,
+    ): AwsSigningResult<Unit> = error("Method should not be called")
+
+    override suspend fun signChunkTrailer(
+        trailingHeaders: Headers,
+        prevSignature: ByteArray,
+        config: AwsSigningConfig,
+    ): AwsSigningResult<Unit> = error("Method should not be called")
+}


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#938](https://github.com/awslabs/aws-sdk-kotlin/issues/938)

## Description of changes

Presigning code currently coerces the URL scheme to HTTPS regardless of the resolved endpoint. This is particularly bad when specifying a custom endpoint resolver to the client with the intent of using non-HTTPS URLs. This change respects the URL scheme of the resolved endpoint via the signed request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
