### PR TITLE
feat: telemetry coroutine extensions

### DIFF
--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -1,5 +1,6 @@
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/TelemetryProvider {
 	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider$Companion;
+	public abstract fun getContextManager ()Laws/smithy/kotlin/runtime/telemetry/context/ContextManager;
 	public abstract fun getLoggerProvider ()Laws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider;
 	public abstract fun getMeterProvider ()Laws/smithy/kotlin/runtime/telemetry/metrics/MeterProvider;
 	public abstract fun getTracerProvider ()Laws/smithy/kotlin/runtime/telemetry/trace/TracerProvider;
@@ -9,12 +10,40 @@ public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProvider$Compani
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContextKt {
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/context/Context {
 	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/context/Context$Companion;
+	public abstract fun makeCurrent ()Laws/smithy/kotlin/runtime/telemetry/context/Scope;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/context/Context$Companion {
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/context/Context;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/telemetry/context/ContextManager {
+	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/context/ContextManager$Companion;
+	public abstract fun current ()Laws/smithy/kotlin/runtime/telemetry/context/Context;
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/context/ContextManager$Companion {
+	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/context/ContextManager;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/telemetry/context/Scope : java/io/Closeable {
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElementKt {
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExtKt {
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/logging/LogLevel : java/lang/Enum {
@@ -30,9 +59,10 @@ public final class aws/smithy/kotlin/runtime/telemetry/logging/LogLevel : java/l
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder {
 	public abstract fun emit ()V
-	public abstract fun setAllAttributes (Laws/smithy/kotlin/runtime/util/Attributes;)V
+	public abstract fun mergeAttributes (Laws/smithy/kotlin/runtime/util/Attributes;)V
 	public abstract fun setAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun setCause (Ljava/lang/Throwable;)V
+	public abstract fun setContext (Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
 	public abstract fun setLevel (Laws/smithy/kotlin/runtime/telemetry/logging/LogLevel;)V
 	public abstract fun setMessage (Ljava/lang/String;)V
 	public abstract fun setMessage (Lkotlin/jvm/functions/Function0;)V
@@ -40,7 +70,7 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/logging/LogR
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder$DefaultImpls {
-	public static fun setAllAttributes (Laws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder;Laws/smithy/kotlin/runtime/util/Attributes;)V
+	public static fun mergeAttributes (Laws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder;Laws/smithy/kotlin/runtime/util/Attributes;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/logging/Logger {
@@ -145,6 +175,9 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Def
 	public static synthetic fun add$default (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;JLaws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExtKt {
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/trace/SpanKind : java/lang/Enum {
 	public static final field CLIENT Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;
 	public static final field INTERNAL Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;
@@ -161,10 +194,9 @@ public final class aws/smithy/kotlin/runtime/telemetry/trace/SpanStatus : java/l
 	public static fun values ()[Laws/smithy/kotlin/runtime/telemetry/trace/SpanStatus;
 }
 
-public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan : java/io/Closeable {
+public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan : aws/smithy/kotlin/runtime/telemetry/context/Scope {
 	public abstract fun close ()V
 	public abstract fun emitEvent (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)V
-	public abstract fun getContext ()Laws/smithy/kotlin/runtime/telemetry/context/Context;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun mergeAttributes (Laws/smithy/kotlin/runtime/util/Attributes;)V
 	public abstract fun set (Laws/smithy/kotlin/runtime/util/AttributeKey;Ljava/lang/Object;)V
@@ -175,12 +207,20 @@ public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan$DefaultIm
 	public static synthetic fun emitEvent$default (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanExtKt {
+	public static final fun recordException (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Ljava/lang/Throwable;Z)V
+	public static final fun setAttribute (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Ljava/lang/String;Ljava/lang/Object;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/Tracer {
-	public abstract fun createSpan (Ljava/lang/String;Laws/smithy/kotlin/runtime/telemetry/context/Context;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
+	public abstract fun createSpan (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Laws/smithy/kotlin/runtime/telemetry/context/Context;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/trace/Tracer$DefaultImpls {
-	public static synthetic fun createSpan$default (Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;Ljava/lang/String;Laws/smithy/kotlin/runtime/telemetry/context/Context;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
+	public static synthetic fun createSpan$default (Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TracerProvider {

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
@@ -5,6 +5,8 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
+import aws.smithy.kotlin.runtime.telemetry.context.Context
+import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
 import aws.smithy.kotlin.runtime.telemetry.metrics.MeterProvider
 import aws.smithy.kotlin.runtime.telemetry.trace.TracerProvider
@@ -34,10 +36,16 @@ public interface TelemetryProvider {
      * Get the [LoggerProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.logging.Logger] instances
      */
     public val loggerProvider: LoggerProvider
+
+    /**
+     * Get the [ContextManager] used to get the current [Context]
+     */
+    public val contextManager: ContextManager
 }
 
 private object NoOpTelemetryProvider : TelemetryProvider {
     override val meterProvider: MeterProvider = MeterProvider.None
     override val tracerProvider: TracerProvider = TracerProvider.None
     override val loggerProvider: LoggerProvider = LoggerProvider.None
+    override val contextManager: ContextManager = ContextManager.None
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry
+
+import aws.smithy.kotlin.runtime.InternalApi
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Coroutine scoped telemetry context used for carrying telemetry provider configuration
+ * @param provider The telemetry provider to instrument with
+ */
+@InternalApi
+public data class TelemetryProviderContext(
+    val provider: TelemetryProvider,
+) : AbstractCoroutineContextElement(TelemetryProviderContext) {
+    public companion object Key : CoroutineContext.Key<TelemetryProviderContext>
+    override fun toString(): String = "TelemetryContext($provider)"
+}
+
+/**
+ * Get the active [TelemetryProvider] from this [CoroutineContext]. If none exists
+ * a no-op provider will be returned.
+ */
+@InternalApi
+public val CoroutineContext.telemetryProvider: TelemetryProvider
+    get() = get(TelemetryProviderContext)?.provider ?: TelemetryProvider.None

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/Context.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/Context.kt
@@ -14,6 +14,22 @@ public interface Context {
         /**
          * A no-op [Context]
          */
-        public val None: Context = object : Context {}
+        public val None: Context = NoOpContext
     }
+
+    /**
+     * Make this the currently active context
+     *
+     * @return handle to a [Scope] that MUST be disposed of (via [Scope.close]) when the current context
+     * is considered no longer active (returning the current active context to whatever it was previously if set).
+     */
+    public fun makeCurrent(): Scope
+}
+
+private object NoOpContext : Context {
+    override fun makeCurrent(): Scope = NoOpScope
+}
+
+private object NoOpScope : Scope {
+    override fun close() {}
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/ContextManager.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/ContextManager.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.context
+
+/**
+ * Responsible for managing the current context with callers current execution unit. For example, some implementations
+ * use Thread Local storage for managing the current context.
+ */
+public interface ContextManager {
+    public companion object {
+        public val None: ContextManager = NoOpContextManager
+    }
+
+    /**
+     * Return the current [Context]
+     */
+    public fun current(): Context
+}
+
+private object NoOpContextManager : ContextManager {
+    override fun current(): Context = Context.None
+}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/Scope.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/Scope.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.context
+
+import aws.smithy.kotlin.runtime.io.Closeable
+
+/**
+ * Delineates a logical scope that has a beginning and end (e.g. a function)
+ */
+public interface Scope : Closeable

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.context
+
+import aws.smithy.kotlin.runtime.InternalApi
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A [CoroutineContext] element that carries a telemetry [Context].
+ * @param context The active context
+ */
+@InternalApi
+public expect class TelemetryContextElement(context: Context) : CoroutineContext.Element {
+    public companion object Key : CoroutineContext.Key<TelemetryContextElement>
+
+    public val context: Context
+}
+
+/**
+ * Extract the current telemetry [Context] from the coroutine context if available.
+ */
+@InternalApi
+public val CoroutineContext.telemetryContext: Context?
+    get() = get(TelemetryContextElement)?.context

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -10,6 +10,9 @@ import aws.smithy.kotlin.runtime.telemetry.context.telemetryContext
 import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
 import kotlin.coroutines.CoroutineContext
 
+// TODO - add new context element for "LoggingContext" to set key/value pairs/MDC with. e.g. `sdkInvocationId`
+//        e.g. withLogCtx(key to value, key to value) { ... }
+
 /**
  * Logs a message using the current [LoggerProvider] configured in this [CoroutineContext].
  * @param level The level (or severity) of this event

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -5,4 +5,184 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
-// TODO CoroutineContext.log, .debug, .trace, etc
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.telemetry.context.telemetryContext
+import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Logs a message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param level The level (or severity) of this event
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.log(
+    level: LogLevel,
+    sourceComponent: String,
+    ex: Throwable? = null,
+    content: () -> Any,
+) {
+    val logger = this.telemetryProvider.loggerProvider.getOrCreateLogger(sourceComponent)
+    if (!logger.isEnabledFor(level)) return
+    val context = this.telemetryContext
+    logger.logRecordBuilder()
+        .apply {
+            setLevel(level)
+            ex?.let { setCause(it) }
+            setMessage(content)
+            context?.let { setContext(it) }
+        }.emit()
+}
+
+/**
+ * Logs a message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param level The level (or severity) of this event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.log(
+    level: LogLevel,
+    ex: Throwable? = null,
+    noinline content: () -> Any,
+) {
+    val sourceComponent = requireNotNull(T::class.qualifiedName) { "log<T> cannot be used on an anonymous object" }
+    log(level, sourceComponent, ex, content)
+}
+
+/**
+ * Logs a fatal message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.fatal(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Fatal, sourceComponent, ex, content)
+
+/**
+ * Logs a fatal message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.fatal(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Fatal, ex, content)
+
+/**
+ * Logs an error message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.error(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Error, sourceComponent, ex, content)
+
+/**
+ * Logs an error message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.error(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Error, ex, content)
+
+/**
+ * Logs a warning message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.warn(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Warning, sourceComponent, ex, content)
+
+/**
+ * Logs a warning message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.warn(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Warning, ex, content)
+
+/**
+ * Logs an info message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.info(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Info, sourceComponent, ex, content)
+
+/**
+ * Logs an info message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.info(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Info, ex, content)
+
+/**
+ * Logs a debug message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.debug(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Debug, sourceComponent, ex, content)
+
+/**
+ * Logs a debug message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.debug(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Debug, ex, content)
+
+/**
+ * Logs a trace message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param sourceComponent The name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public fun CoroutineContext.trace(sourceComponent: String, ex: Throwable? = null, content: () -> Any): Unit =
+    log(LogLevel.Trace, sourceComponent, ex, content)
+
+/**
+ * Logs a trace message using the current [LoggerProvider] configured in this [CoroutineContext].
+ * @param T The class to use for the name of the component that generated the event
+ * @param ex An optional exception which explains the message
+ * @param content A lambda which provides the content of the message. This content does not need to include any data
+ * from the exception (if any), which may be concatenated later based on probe behavior.
+ */
+@InternalApi
+public inline fun <reified T> CoroutineContext.trace(ex: Throwable? = null, noinline content: () -> Any): Unit =
+    log<T>(LogLevel.Trace, ex, content)

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.logging
+
+// TODO CoroutineContext.log, .debug, .trace, etc

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.get
 
 /**
- * Construct a logging record and emits it to an underlying logger
+ * Construct a logging record that can be emitted to an underlying logger.
  */
 public interface LogRecordBuilder {
     /**

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
+import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
@@ -54,10 +55,16 @@ public interface LogRecordBuilder {
     public fun setAttribute(name: String, value: Any)
 
     /**
+     * Set the telemetry context to associate with this log record
+     * @param context the context to associate
+     */
+    public fun setContext(context: Context)
+
+    /**
      * Associate all key/value pairs from [attributes] with this log record
      * @param attributes the attributes to associate with this log record
      */
-    public fun setAllAttributes(attributes: Attributes) {
+    public fun mergeAttributes(attributes: Attributes) {
         attributes.keys.forEach { key ->
             @Suppress("UNCHECKED_CAST")
             setAttribute(key.name, attributes[key as AttributeKey<Any>])

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider.kt
@@ -14,6 +14,8 @@ public interface LoggerProvider {
          * A no-op [LoggerProvider] that does nothing
          */
         public val None: LoggerProvider = NoOpLoggerProvider
+
+        // TODO - Default/Global logger (JVM -> SLF4J)
     }
 
     /**

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
+import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
 
@@ -29,6 +30,7 @@ private object NoOpLogRecordBuilder : LogRecordBuilder {
     override fun setMessage(message: String) {}
     override fun setMessage(message: () -> Any) {}
     override fun setAttribute(name: String, value: Any) {}
-    override fun setAllAttributes(attributes: Attributes) {}
+    override fun setContext(context: Context) {}
+    override fun mergeAttributes(attributes: Attributes) {}
     override fun emit() {}
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.trace
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.telemetry.context.telemetryContext
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.coroutineContext
+
+/**
+ * A [CoroutineContext] element that carries a [TraceSpan].
+ * @param traceSpan The active trace span for this context.
+ */
+@InternalApi
+public data class TraceSpanContext(public val traceSpan: TraceSpan) : AbstractCoroutineContextElement(TraceSpanContext) {
+    public companion object Key : CoroutineContext.Key<TraceSpanContext>
+    override fun toString(): String = "TraceSpanContextElement($traceSpan)"
+}
+
+/**
+ * Gets the active [TraceSpan] from this [CoroutineContext].
+ */
+@InternalApi
+public val CoroutineContext.traceSpan: TraceSpan?
+    get() = get(TraceSpanContext)?.traceSpan
+
+/**
+ * Creates a new [TraceSpan] and executes [block] within the scope of the new span.
+ * The [block] of code is executed with a new coroutine context that contains the newly
+ * created span set.
+ */
+@InternalApi
+public suspend inline fun <R> Tracer.withSpan(
+    name: String,
+    initialAttributes: Attributes = emptyAttributes(),
+    spanKind: SpanKind = SpanKind.INTERNAL,
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline block: suspend CoroutineScope.(span: TraceSpan) -> R,
+): R {
+    val parent = coroutineContext.telemetryContext
+    val span = createSpan(name, initialAttributes, spanKind, parent)
+    return withSpan(span, context, block)
+}
+
+/**
+ * Executes [block] within the scope of [TraceSpan]. The [block] of code is executed
+ * with a new coroutine context that contains the [span] set in the context.
+ */
+@InternalApi
+public suspend inline fun <R> withSpan(
+    span: TraceSpan,
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline block: suspend CoroutineScope.(span: TraceSpan) -> R,
+): R = try {
+    withContext(context + TraceSpanContext(span)) {
+        block(span)
+    }
+} catch (ex: Exception) {
+    if (ex !is CancellationException) {
+        span.setStatus(SpanStatus.ERROR)
+    }
+    span.recordException(ex, true)
+    throw ex
+} finally {
+    span.close()
+}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/NoOpTracerProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/NoOpTracerProvider.kt
@@ -16,15 +16,14 @@ internal object NoOpTracerProvider : TracerProvider {
 private object NoOpTracer : Tracer {
     override fun createSpan(
         name: String,
-        parentContext: Context?,
         initialAttributes: Attributes,
         spanKind: SpanKind,
+        parentContext: Context?,
     ): TraceSpan = NoOpTraceSpan
 }
 
 private object NoOpTraceSpan : TraceSpan {
     override val name: String = "NoOpSpan"
-    override val context: Context = Context.None
     override fun emitEvent(name: String, attributes: Attributes) {}
     override fun setStatus(status: SpanStatus) {}
     override operator fun <T : Any> set(key: AttributeKey<T>, value: T) {}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.telemetry.trace
 
 import aws.smithy.kotlin.runtime.io.Closeable
-import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
@@ -22,11 +21,6 @@ public interface TraceSpan : Closeable {
     public val name: String
 
     /**
-     * The span's context
-     */
-    public val context: Context
-
-    /**
      * Set an attribute on the span
      * @param key the attribute key to use
      * @param value the value to associate with the key
@@ -40,6 +34,7 @@ public interface TraceSpan : Closeable {
      */
     public fun mergeAttributes(attributes: Attributes)
 
+    // FIXME - when would we use OTeL trace events vs logs?
     /**
      * Add an event to this span
      * @param name the name of the event

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
@@ -5,7 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry.trace
 
-import aws.smithy.kotlin.runtime.io.Closeable
+import aws.smithy.kotlin.runtime.telemetry.context.Scope
 import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
@@ -14,7 +14,7 @@ import aws.smithy.kotlin.runtime.util.emptyAttributes
  * Represents a single operation/task within a trace. Each trace contains a root span and
  * optionally one or more child spans.
  */
-public interface TraceSpan : Closeable {
+public interface TraceSpan : Scope {
     /**
      * The name of the span
      */

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanExt.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.trace
+
+import aws.smithy.kotlin.runtime.util.AttributeKey
+
+/**
+ * Set common error attributes from an exception
+ * @param ex the exception to record attributes for
+ * @param escaped true if this exception escaped the current function
+ */
+public fun TraceSpan.recordException(ex: Throwable, escaped: Boolean) {
+    // https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
+    val exType = ex::class.qualifiedName ?: ex::class.simpleName
+    setAttribute("error", true)
+    ex.message?.let { setAttribute("exception.message", it) }
+    exType?.let { setAttribute("exception.type", it) }
+    setAttribute("exception.stacktrace", ex.stackTraceToString())
+    ex.cause?.let { setAttribute("exception.cause", it.toString()) }
+    setAttribute("exception.escaped", escaped)
+}
+
+/**
+ * Set an attribute on the span using a string key
+ * @param key the attribute key to use
+ * @param value the value to associate with the key
+ */
+public fun <T : Any> TraceSpan.setAttribute(key: String, value: T): Unit =
+    set(AttributeKey(key), value)

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/Tracer.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/Tracer.kt
@@ -16,7 +16,7 @@ public interface Tracer {
     // TODO - do we want to be able to explicitly say "no parent", e.g. Context.root()
 
     /**
-     * Creates a new span and makes it active.
+     * Creates a new span and makes it active in the current [Context].
      *
      * @param name the name of the span
      * @param parentContext the parent context to use for this span, if not set it is
@@ -24,8 +24,8 @@ public interface Tracer {
      */
     public fun createSpan(
         name: String,
-        parentContext: Context? = null,
         initialAttributes: Attributes = emptyAttributes(),
         spanKind: SpanKind = SpanKind.INTERNAL,
+        parentContext: Context? = null,
     ): TraceSpan
 }

--- a/runtime/observability/telemetry-api/jvm/src/aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElementJVM.kt
+++ b/runtime/observability/telemetry-api/jvm/src/aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElementJVM.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.context
+
+import aws.smithy.kotlin.runtime.InternalApi
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+@InternalApi
+public actual class TelemetryContextElement public actual constructor(
+    public actual val context: Context,
+) : CoroutineContext.Element, ThreadContextElement<Scope>, AbstractCoroutineContextElement(TelemetryContextElement) {
+
+    public actual companion object Key : CoroutineContext.Key<TelemetryContextElement>
+
+    override fun updateThreadContext(context: CoroutineContext): Scope =
+        this.context.makeCurrent()
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: Scope) {
+        oldState.close()
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR expands the telemetry API with coroutine extensions that the actual generated SDK clients and runtime will mostly use.

* Adds a new `ContextManager` interface. This is used to bridge the gap between the external calling code/observability backend and the SDK notion of context which relies on coroutine context for API boundary propagation. 
    * Consider this experimental for now as we figure out the best way to deal with some of the rubber meets the road issues around actually plugging in an observability backend like OTeL
* Adds coroutine extensions for logging, trace span creation, and propagation of `Context`, `TelemetryProvider`, etc.

## Example Instrumentation

The following is a strawman example of what instrumenting an operation might look like. This will likely change and/or get abstracted to be less verbose/more reusable. 

```kotlin
private suspend fun testOperation(provider: TelemetryProvider) {
    val tracer = provider.tracerProvider.getOrCreateTracer("S3")
    val currentContext = provider.contextManager.current()

    val telemetryCtx = TelemetryProviderContext(provider) + TelemetryContextElement(currentContext)
    val span = tracer.createSpan(
        "S3.GetObject",
        attributesOf {
            "rpc.method" to "GetObject"
            "rpc.service" to "S3"
        },
        SpanKind.CLIENT,
        currentContext,
    )

    withSpan(span, telemetryCtx) {
        span.setAttribute("rpc.system", "aws-api")
        testChild()
    }
}

private suspend fun testChild() {
    // FIXME - would require getting a tracer for child spans...
    // thats _ok_ but probably want to use an existing service client tracer instance if possible?
}

```

This leaves some open questions on how we want 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
