### PR TITLE
fix: correctly deserialize restjson error code

### DIFF
--- a/.changes/5F4A433D-A734-4A96-B15B-71D5146CE142.json
+++ b/.changes/5F4A433D-A734-4A96-B15B-71D5146CE142.json
@@ -1,8 +1,0 @@
-{
-  "id": "5F4A433D-A734-4A96-B15B-71D5146CE142",
-  "type": "bugfix",
-  "description": "Fix restjson deserializer protocol",
-  "issues": [
-    "awslabs/smithy-kotlin#828"
-  ]
-}

--- a/.changes/5F4A433D-A734-4A96-B15B-71D5146CE142.json
+++ b/.changes/5F4A433D-A734-4A96-B15B-71D5146CE142.json
@@ -1,0 +1,8 @@
+{
+  "id": "5F4A433D-A734-4A96-B15B-71D5146CE142",
+  "type": "bugfix",
+  "description": "Fix restjson deserializer protocol",
+  "issues": [
+    "awslabs/smithy-kotlin#828"
+  ]
+}

--- a/.changes/c641c1f7-0758-49d2-8dbd-e375853143c7.json
+++ b/.changes/c641c1f7-0758-49d2-8dbd-e375853143c7.json
@@ -1,0 +1,8 @@
+{
+    "id": "c641c1f7-0758-49d2-8dbd-e375853143c7",
+    "type": "bugfix",
+    "description": "Use correct precedence order for determining restJson error codes",
+    "issues": [
+        "awslabs/smithy-kotlin#828"
+    ]
+}

--- a/runtime/protocol/aws-json-protocols/common/src/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializer.kt
+++ b/runtime/protocol/aws-json-protocols/common/src/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializer.kt
@@ -46,15 +46,17 @@ public object RestJsonErrorDeserializer {
     }
 
     public fun deserialize(headers: Headers, payload: ByteArray?): ErrorDetails {
-        var code: String? = headers[X_AMZN_ERROR_TYPE_HEADER_NAME]
-        var message: String? = if (headers[X_AMZN_ERROR_MESSAGE_HEADER_NAME] == null) headers[X_AMZN_EVENT_ERROR_MESSAGE_HEADER_NAME] else headers[X_AMZN_ERROR_MESSAGE_HEADER_NAME]
+        var message = headers[X_AMZN_ERROR_MESSAGE_HEADER_NAME] ?: headers[X_AMZN_ERROR_MESSAGE_HEADER_NAME]
+        val headerCode: String? = headers[X_AMZN_ERROR_TYPE_HEADER_NAME]
+        var bodyCode: String? = null
+        var bodyType: String? = null
 
         if (payload != null) {
             JsonDeserializer(payload).deserializeStruct(OBJ_DESCRIPTOR) {
                 loop@ while (true) {
                     when (findNextFieldIndex()) {
-                        ERR_CODE_ALT1_DESCRIPTOR.index -> if (code == null) code = deserializeString()
-                        ERR_CODE_ALT2_DESCRIPTOR.index -> if (code == null) code = deserializeString()
+                        ERR_CODE_ALT1_DESCRIPTOR.index -> bodyCode = deserializeString()
+                        ERR_CODE_ALT2_DESCRIPTOR.index -> bodyType = deserializeString()
                         MESSAGE_ALT1_DESCRIPTOR.index,
                         MESSAGE_ALT2_DESCRIPTOR.index,
                         MESSAGE_ALT3_DESCRIPTOR.index,
@@ -65,7 +67,7 @@ public object RestJsonErrorDeserializer {
                 }
             }
         }
-        return ErrorDetails(sanitize(code), message, requestId = null)
+        return ErrorDetails(chooseCode(headerCode, bodyCode, bodyType), message, requestId = null)
     }
 }
 
@@ -83,3 +85,14 @@ public object RestJsonErrorDeserializer {
  * aws.protocoltests.restjson#FooError:http://amazon.com/smithy/com.amazon.smithy.validate/
  */
 private fun sanitize(code: String?): String? = code?.substringAfter("#")?.substringBefore(":")
+
+/**
+ * According to the spec we should check the following locations in order:
+ *
+ * HTTP header x-amzn-errortype
+ * top-level body field code
+ * top-level body field __type
+ *
+ * Source: https://github.com/awslabs/aws-sdk-kotlin/issues/828
+ */
+private fun chooseCode(headerCode: String?, bodyCode: String?, bodyType: String?): String? = sanitize(headerCode ?: bodyCode ?: bodyType)

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
@@ -120,6 +120,18 @@ class RestJsonErrorDeserializerTest {
         """.trimIndent().encodeToByteArray()
         actual = RestJsonErrorDeserializer.deserialize(headers, payload)
         assertEquals("BodyCode", actual.code)
+
+        headers = Headers {}
+        payload = """
+            {
+                "foo": "bar",
+                "__type": "TypeCode",
+                "code": "BodyCode",
+                "baz": "quux"
+            }
+        """.trimIndent().encodeToByteArray()
+        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
+        assertEquals("BodyCode", actual.code)
     }
 
     @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
@@ -82,9 +82,6 @@ class RestJsonErrorDeserializerTest {
         var actual = RestJsonErrorDeserializer.deserialize(headers, payload)
         assertEquals("HeaderCode", actual.code)
 
-        headers = Headers {
-            append(X_AMZN_ERROR_TYPE_HEADER_NAME, "HeaderCode")
-        }
         payload = """
             {
                 "foo": "bar",
@@ -95,9 +92,6 @@ class RestJsonErrorDeserializerTest {
         actual = RestJsonErrorDeserializer.deserialize(headers, payload)
         assertEquals("HeaderCode", actual.code)
 
-        headers = Headers {
-            append(X_AMZN_ERROR_TYPE_HEADER_NAME, "HeaderCode")
-        }
         payload = """
             {
                 "foo": "bar",
@@ -121,7 +115,6 @@ class RestJsonErrorDeserializerTest {
         actual = RestJsonErrorDeserializer.deserialize(headers, payload)
         assertEquals("BodyCode", actual.code)
 
-        headers = Headers {}
         payload = """
             {
                 "foo": "bar",

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
@@ -66,6 +66,64 @@ class RestJsonErrorDeserializerTest {
 
     @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
     @Test
+    fun `it deserializes aws restJson error codes using right location check order`() = runTest {
+        // Checking for header code return
+        var headers = Headers {
+            append(X_AMZN_ERROR_TYPE_HEADER_NAME, "HeaderCode")
+        }
+        var payload = """
+            {
+                "foo": "bar",
+                "code": "BodyCode",
+                "__type": "TypeCode",
+                "baz": "quux"
+            }
+        """.trimIndent().encodeToByteArray()
+        var actual = RestJsonErrorDeserializer.deserialize(headers, payload)
+        assertEquals("HeaderCode", actual.code)
+
+        headers = Headers {
+            append(X_AMZN_ERROR_TYPE_HEADER_NAME, "HeaderCode")
+        }
+        payload = """
+            {
+                "foo": "bar",
+                "__type": "TypeCode",
+                "baz": "quux"
+            }
+        """.trimIndent().encodeToByteArray()
+        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
+        assertEquals("HeaderCode", actual.code)
+
+        headers = Headers {
+            append(X_AMZN_ERROR_TYPE_HEADER_NAME, "HeaderCode")
+        }
+        payload = """
+            {
+                "foo": "bar",
+                "code": "BodyCode",
+                "baz": "quux"
+            }
+        """.trimIndent().encodeToByteArray()
+        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
+        assertEquals("HeaderCode", actual.code)
+
+        // Checking for body code return
+        headers = Headers {}
+        payload = """
+            {
+                "foo": "bar",
+                "code": "BodyCode",
+                "__type": "TypeCode",
+                "baz": "quux"
+            }
+        """.trimIndent().encodeToByteArray()
+        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
+        assertEquals("BodyCode", actual.code)
+    }
+
+    @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
+    @Test
     fun `it deserializes aws restJson error messages`() = runTest {
         val expected = "one ring to rule bring them all, and in the darkness bind them"
 

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
@@ -73,58 +73,43 @@ class RestJsonErrorDeserializerTest {
         }
         var payload = """
             {
-                "foo": "bar",
                 "code": "BodyCode",
-                "__type": "TypeCode",
-                "baz": "quux"
+                "__type": "TypeCode"
             }
         """.trimIndent().encodeToByteArray()
-        var actual = RestJsonErrorDeserializer.deserialize(headers, payload)
-        assertEquals("HeaderCode", actual.code)
+        assertEquals("HeaderCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
 
         payload = """
             {
-                "foo": "bar",
-                "__type": "TypeCode",
-                "baz": "quux"
+                "__type": "TypeCode"
             }
         """.trimIndent().encodeToByteArray()
-        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
-        assertEquals("HeaderCode", actual.code)
+        assertEquals("HeaderCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
 
         payload = """
             {
-                "foo": "bar",
-                "code": "BodyCode",
-                "baz": "quux"
+                "code": "BodyCode"
             }
         """.trimIndent().encodeToByteArray()
-        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
-        assertEquals("HeaderCode", actual.code)
+        assertEquals("HeaderCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
 
         // Checking for body code return
         headers = Headers {}
         payload = """
             {
-                "foo": "bar",
                 "code": "BodyCode",
-                "__type": "TypeCode",
-                "baz": "quux"
+                "__type": "TypeCode"
             }
         """.trimIndent().encodeToByteArray()
-        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
-        assertEquals("BodyCode", actual.code)
+        assertEquals("BodyCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
 
         payload = """
             {
-                "foo": "bar",
                 "__type": "TypeCode",
-                "code": "BodyCode",
-                "baz": "quux"
+                "code": "BodyCode"
             }
         """.trimIndent().encodeToByteArray()
-        actual = RestJsonErrorDeserializer.deserialize(headers, payload)
-        assertEquals("BodyCode", actual.code)
+        assertEquals("BodyCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
     }
 
     @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Fixed how restjson error codes are deserialized
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/828

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
It will fix the way restjson error codes are deserialized.

It will now check the following locations in order:

HTTP header x-amzn-errortype
top-level body field code
top-level body field __type


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
