### PR TITLE
fix(codegen): allow symbol provider to give a fully qualified name hint that takes precedence

### DIFF
--- a/.changes/a646a910-2f13-4231-aa51-a5feb2e335a2.json
+++ b/.changes/a646a910-2f13-4231-aa51-a5feb2e335a2.json
@@ -1,0 +1,8 @@
+{
+    "id": "a646a910-2f13-4231-aa51-a5feb2e335a2",
+    "type": "bugfix",
+    "description": "Add fully qualified name hint for collection types",
+    "issues": [
+        "awslabs/smithy-kotlin#867"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriter.kt
@@ -296,7 +296,7 @@ private class KotlinSymbolFormatter(
             is Symbol -> {
                 // writer will omit unnecessary same package imports and dedupe
                 writer.addImport(type)
-                return if (fullyQualifiedPredicate(type)) type.fullName else type.name
+                return if (fullyQualifiedPredicate(type)) (type.fullNameHint ?: type.fullName) else type.name
             }
             else -> throw CodegenException("Invalid type provided for #T. Expected a Symbol, but found `$type`")
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/SymbolExt.kt
@@ -47,6 +47,11 @@ object SymbolProperty {
 
     // Denotes the symbol is a reference to a static member of an object (e.g. of an object or companion object)
     const val OBJECT_REF: String = "objectRef"
+
+    // Adds a property to give a hint at what the fully qualified name should be. Used by #Q symbol formatter to
+    // give symbols fine-grained control over their fully qualified name (e.g. collections with generics can fully
+    // qualify the generic type)
+    const val FULLY_QUALIFIED_NAME_HINT: String = "fullyQualifiedNameHint"
 }
 
 /**
@@ -217,3 +222,9 @@ val Symbol.isObjectRef: Boolean
  */
 val Symbol.objectRef: Symbol?
     get() = getProperty(SymbolProperty.OBJECT_REF, Symbol::class.java).getOrNull()
+
+/**
+ * Get the fully qualified name hint if one is set
+ */
+val Symbol.fullNameHint: String?
+    get() = getProperty(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, String::class.java).getOrNull()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinWriterTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.kotlin.codegen.core
 import io.kotest.matchers.string.shouldNotContain
 import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.integration.SectionKey
+import software.amazon.smithy.kotlin.codegen.model.SymbolProperty
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
@@ -308,5 +309,21 @@ class KotlinWriterTest {
         val contents = unit.toString()
         contents.shouldNotContain("import com.test.Foo")
         contents.shouldContainWithDiff("import com.test.subpkg.Bar")
+    }
+
+    @Test
+    fun itFavorsFullNameHint() {
+        val unit = KotlinWriter("com.test")
+
+        val symbol = buildSymbol {
+            name = "Foo"
+            namespace = "com.test"
+            properties { set(SymbolProperty.FULLY_QUALIFIED_NAME_HINT, "baz.quux.Foo") }
+        }
+
+        unit.write("val foo = #Q", symbol)
+
+        val contents = unit.toString()
+        contents.shouldContainWithDiff("baz.quux.Foo")
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinDependency.Companion.CORE
 import software.amazon.smithy.kotlin.codegen.model.defaultValue
 import software.amazon.smithy.kotlin.codegen.model.expectShape
+import software.amazon.smithy.kotlin.codegen.model.fullNameHint
 import software.amazon.smithy.kotlin.codegen.model.isNullable
 import software.amazon.smithy.kotlin.codegen.model.traits.SYNTHETIC_NAMESPACE
 import software.amazon.smithy.kotlin.codegen.test.*
@@ -459,6 +460,10 @@ class SymbolProviderTest {
 
         // collections should contain a reference to the member type
         assertEquals("Record", sparseListSymbol.references[0].symbol.name)
+
+        // check the fully qualified name hint is set
+        assertEquals("List<foo.bar.model.Record>", listSymbol.fullNameHint)
+        assertEquals("List<foo.bar.model.Record?>", sparseListSymbol.fullNameHint)
     }
 
     @Test
@@ -520,6 +525,10 @@ class SymbolProviderTest {
 
         // collections should contain a reference to the member type
         assertEquals("Record", sparseMapSymbol.references[0].symbol.name)
+
+        // check the fully qualified name hint is set
+        assertEquals("Map<kotlin.String, com.test.model.Record>", mapSymbol.fullNameHint)
+        assertEquals("Map<kotlin.String, com.test.model.Record?>", sparseMapSymbol.fullNameHint)
     }
 
     @DisplayName("creates bigNumbers")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes #867 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds a way for symbol provide and writer to use a fully qualified name with more nuance than just `namespace` + `symbolName`. Collection shapes like map and list are generated with a symbol using the kotlin stdlib `Map`/`List` type. These are not the only types referenced in the resulting "Symbol" though (the generics need to be fully qualified as well).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
