### PR TITLE
feat!: simplify mechanisms for setting/updating retry strategies in client config

### DIFF
--- a/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
+++ b/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
@@ -1,0 +1,8 @@
+{
+    "id": "c50a8d50-f66f-4598-8a58-f5c3dfc8302a",
+    "type": "feature",
+    "description": "**Breaking**: Simplify mechanisms for setting/updating retry strategies in client config",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#701"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -112,14 +112,9 @@ object RuntimeTypes {
             val Outcome = symbol("Outcome")
             val RetryStrategy = symbol("RetryStrategy")
             val StandardRetryStrategy = symbol("StandardRetryStrategy")
-            val StandardRetryStrategyOptions = symbol("StandardRetryStrategyOptions")
 
             object Delay : RuntimeTypePackage(KotlinDependency.CORE, "retries.delay") {
-                val ExponentialBackoffWithJitter = symbol("ExponentialBackoffWithJitter")
-                val ExponentialBackoffWithJitterOptions = symbol("ExponentialBackoffWithJitterOptions")
                 val InfiniteTokenBucket = symbol("InfiniteTokenBucket")
-                val StandardRetryTokenBucket = symbol("StandardRetryTokenBucket")
-                val StandardRetryTokenBucketOptions = symbol("StandardRetryTokenBucketOptions")
             }
 
             object Policy : RuntimeTypePackage(KotlinDependency.CORE, "retries.policy") {
@@ -176,6 +171,9 @@ object RuntimeTypes {
         val SdkClient = symbol("SdkClient")
         val AbstractSdkClientBuilder = symbol("AbstractSdkClientBuilder")
         val LogMode = symbol("LogMode")
+        val RetryClientConfig = symbol("RetryClientConfig")
+        val RetryStrategyClientConfig = symbol("RetryStrategyClientConfig")
+        val RetryStrategyClientConfigImpl = symbol("RetryStrategyClientConfigImpl")
         val SdkClientConfig = symbol("SdkClientConfig")
         val SdkClientFactory = symbol("SdkClientFactory")
         val SdkClientOption = symbol("SdkClientOption")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigPropertyType.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigPropertyType.kt
@@ -9,6 +9,10 @@ package software.amazon.smithy.kotlin.codegen.rendering.util
  * Descriptor for how a configuration property is rendered when the configuration is built
  */
 sealed class ConfigPropertyType {
+    companion object {
+        val DoNotRender = Custom(render = { _, _ -> }, renderBuilder = { _, _ -> })
+    }
+
     /**
      * A property type that uses the symbol type and builder symbol directly
      */

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -42,7 +42,7 @@ class ServiceClientConfigGeneratorTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedCtor = """
-public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, SdkClientConfig, TracingClientConfig {
+public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TracingClientConfig {
 """
         contents.shouldContainWithDiff(expectedCtor)
 
@@ -54,13 +54,12 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
-    override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, clientName)
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilder = """
-    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, SdkClientConfig.Builder<Config>, TracingClientConfig.Builder {
+    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, RetryClientConfig.Builder, RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl(), SdkClientConfig.Builder<Config>, TracingClientConfig.Builder {
         /**
          * A reader-friendly name for the client.
          */
@@ -114,12 +113,6 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
          * The policy to use for evaluating operation results and determining whether/how to retry.
          */
         override var retryPolicy: RetryPolicy<Any?>? = null
-
-        /**
-         * The [RetryStrategy] implementation to use for service calls. All API calls will be wrapped by the
-         * strategy.
-         */
-        override var retryStrategy: RetryStrategy? = null
 
         /**
          * The tracer that is responsible for creating trace spans and wiring them up to a tracing backend (e.g.,
@@ -255,7 +248,6 @@ public class Config private constructor(builder: Builder) {
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
-    override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, clientName)"""
         contents.shouldContainWithDiff(expectedConfigValues)
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
@@ -73,7 +73,7 @@ class ServiceClientGeneratorTest {
 
     @Test
     fun `it generates config`() {
-        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, SdkClientConfig, TracingClientConfig"
+        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TracingClientConfig"
         commonTestContents.shouldContainOnlyOnce(expected)
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -78,17 +78,15 @@ class ServiceWaitersGeneratorTest {
     @Test
     fun testRetryStrategy() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 2_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 120_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-            
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 2_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 120_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContainOnlyOnce(expected)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
@@ -28,17 +28,15 @@ class WaiterGeneratorTest {
     @Test
     fun testDefaultDelays() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 2_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 120_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 2_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 120_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContain(expected)
@@ -47,17 +45,15 @@ class WaiterGeneratorTest {
     @Test
     fun testCustomDelays() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 5_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 30_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 5_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 30_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContainOnlyOnce(expected)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 # SDK
-sdkVersion=0.21.4-SNAPSHOT
+sdkVersion=0.22.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.8.10

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
@@ -12,10 +12,6 @@ import aws.smithy.kotlin.runtime.http.operation.roundTrip
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
-import aws.smithy.kotlin.runtime.retries.StandardRetryStrategyOptions
-import aws.smithy.kotlin.runtime.retries.delay.DelayProvider
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucketOptions
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
@@ -44,13 +40,7 @@ class RetryMiddlewareTest {
     fun testRetryMiddleware() = runTest {
         val req = HttpRequestBuilder()
         val op = newTestOperation<Unit, Unit>(req, Unit)
-
-        val delayProvider = DelayProvider { }
-        val strategy = StandardRetryStrategy(
-            StandardRetryStrategyOptions.Default,
-            StandardRetryTokenBucket(StandardRetryTokenBucketOptions.Default),
-            delayProvider,
-        )
+        val strategy = StandardRetryStrategy()
 
         op.execution.retryStrategy = strategy
         op.execution.retryPolicy = policy

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1455,15 +1455,6 @@ public final class aws/smithy/kotlin/runtime/util/ConvenienceKt {
 public final class aws/smithy/kotlin/runtime/util/CoroutineUtilsKt {
 }
 
-public final class aws/smithy/kotlin/runtime/util/DslBuilderProperty {
-	public fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun dsl (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
-	public final fun getInstance ()Ljava/lang/Object;
-	public final fun getSupply ()Lkotlin/jvm/functions/Function0;
-	public final fun setInstance (Ljava/lang/Object;)V
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/util/DslFactory {
 	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -990,42 +990,64 @@ public final class aws/smithy/kotlin/runtime/retries/RetryFailureException : aws
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
-public abstract interface class aws/smithy/kotlin/runtime/retries/RetryOptions {
-	public abstract fun getMaxAttempts ()Ljava/lang/Integer;
-}
-
-public final class aws/smithy/kotlin/runtime/retries/RetryOptions$DefaultImpls {
-	public static fun getMaxAttempts (Laws/smithy/kotlin/runtime/retries/RetryOptions;)Ljava/lang/Integer;
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy {
-	public abstract fun getOptions ()Laws/smithy/kotlin/runtime/retries/RetryOptions;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
 	public abstract fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+	public abstract fun getMaxAttempts ()I
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+	public abstract fun getMaxAttempts ()I
+	public abstract fun setMaxAttempts (I)V
+}
+
+public abstract interface annotation class aws/smithy/kotlin/runtime/retries/RetryStrategyConfigDsl : java/lang/annotation/Annotation {
+}
+
 public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy : aws/smithy/kotlin/runtime/retries/RetryStrategy {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion;
 	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun getOptions ()Laws/smithy/kotlin/runtime/retries/RetryOptions;
-	public fun getOptions ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
 	public fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions : aws/smithy/kotlin/runtime/retries/RetryOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions$Companion;
-	public fun <init> (I)V
-	public final fun component1 ()I
-	public final fun copy (I)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
-	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;IILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getMaxAttempts ()Ljava/lang/Integer;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion;
+	public static final field DEFAULT_MAX_ATTEMPTS I
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+	public fun <init> ()V
+	public final fun delayProvider (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun delayProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public final fun setDelayProvider (Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
+	public fun setMaxAttempts (I)V
+	public final fun setTokenBucket (Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;)V
+	public final fun tokenBucket (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun tokenBucket (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion {
+	public final fun default ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/TimedOutException : aws/smithy/kotlin/runtime/retries/RetryException {
@@ -1038,41 +1060,60 @@ public final class aws/smithy/kotlin/runtime/retries/TooManyAttemptsException : 
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
 	public abstract fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter : aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Companion;
 	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOptions ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions$Companion;
-	public synthetic fun <init> (JDDJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-UwyO8pc ()J
-	public final fun component2 ()D
-	public final fun component3 ()D
-	public final fun component4-UwyO8pc ()J
-	public final fun copy-A4u-v98 (JDDJ)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
-	public static synthetic fun copy-A4u-v98$default (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;JDDJILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
-	public fun equals (Ljava/lang/Object;)Z
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Builder;)V
 	public final fun getInitialDelay-UwyO8pc ()J
 	public final fun getJitter ()D
 	public final fun getMaxBackoff-UwyO8pc ()J
 	public final fun getScaleFactor ()D
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
+	public fun <init> ()V
+	public final fun getInitialDelay-UwyO8pc ()J
+	public final fun getJitter ()D
+	public final fun getMaxBackoff-UwyO8pc ()J
+	public final fun getScaleFactor ()D
+	public final fun setInitialDelay-LRDsOJo (J)V
+	public final fun setJitter (D)V
+	public final fun setMaxBackoff-LRDsOJo (J)V
+	public final fun setScaleFactor (D)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket;
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/RetryCapacityExceededException : aws/smithy/kotlin/runtime/ClientException {
@@ -1087,29 +1128,32 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTok
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
 	public abstract fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
-	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOptions ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions$Companion;
-	public fun <init> (IIZIIII)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()Z
-	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun component6 ()I
-	public final fun component7 ()I
-	public final fun copy (IIZIIII)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
-	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;IIZIIIIILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
-	public fun equals (Ljava/lang/Object;)Z
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder;)V
 	public final fun getCircuitBreakerMode ()Z
 	public final fun getInitialTryCost ()I
 	public final fun getInitialTrySuccessIncrement ()I
@@ -1117,12 +1161,29 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 	public final fun getRefillUnitsPerSecond ()I
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
+	public fun <init> ()V
+	public final fun getCircuitBreakerMode ()Z
+	public final fun getInitialTryCost ()I
+	public final fun getInitialTrySuccessIncrement ()I
+	public final fun getMaxCapacity ()I
+	public final fun getRefillUnitsPerSecond ()I
+	public final fun getRetryCost ()I
+	public final fun getTimeoutRetryCost ()I
+	public final fun setCircuitBreakerMode (Z)V
+	public final fun setInitialTryCost (I)V
+	public final fun setInitialTrySuccessIncrement (I)V
+	public final fun setMaxCapacity (I)V
+	public final fun setRefillUnitsPerSecond (I)V
+	public final fun setRetryCost (I)V
+	public final fun setTimeoutRetryCost (I)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
 }
 
 public abstract class aws/smithy/kotlin/runtime/retries/policy/Acceptor {
@@ -1392,6 +1453,19 @@ public final class aws/smithy/kotlin/runtime/util/ConvenienceKt {
 }
 
 public final class aws/smithy/kotlin/runtime/util/CoroutineUtilsKt {
+}
+
+public final class aws/smithy/kotlin/runtime/util/DslBuilderProperty {
+	public fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun dsl (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun getInstance ()Ljava/lang/Object;
+	public final fun getSupply ()Lkotlin/jvm/functions/Function0;
+	public final fun setInstance (Ljava/lang/Object;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/util/DslFactory {
+	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/util/EnvironmentProvider {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
@@ -5,16 +5,20 @@
 
 package aws.smithy.kotlin.runtime.retries
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+
+@DslMarker
+public annotation class RetryStrategyConfigDsl
 
 /**
  * A strategy for trying a block of code one or more times.
  */
 public interface RetryStrategy {
     /**
-     * Common retry strategy options
+     * The configured parameters for this strategy
      */
-    public val options: RetryOptions
+    public val config: Config
 
     /**
      * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
@@ -24,12 +28,25 @@ public interface RetryStrategy {
      * @return The successful [Outcome] of the final retry attempt.
      */
     public suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R>
-}
 
-public interface RetryOptions {
     /**
-     * Maximum retry attempts allowed by a strategy
+     * Options for configuring a retry strategy
      */
-    public val maxAttempts: Int?
-        get() = null
+    public interface Config {
+        /**
+         * Maximum retry attempts allowed by a strategy
+         */
+        public val maxAttempts: Int
+
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        @RetryStrategyConfigDsl
+        public interface Builder {
+            /**
+             * Maximum retry attempts allowed by a strategy
+             */
+            public var maxAttempts: Int
+        }
+    }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
@@ -5,13 +5,32 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
+
 /**
  * An object that can be used to delay between iterations of code.
  */
-public fun interface DelayProvider {
+public interface DelayProvider {
+    public val config: Config
+
     /**
      * Delays for an appropriate amount of time after the given attempt number.
      * @param attempt The ordinal index of the attempt, used in calculating the exact amount of time to delay.
      */
     public suspend fun backoff(attempt: Int)
+
+    /**
+     * Configuration for a delay provider
+     */
+    public interface Config {
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        /**
+         * A builder for configs for delay providers
+         */
+        @RetryStrategyConfigDsl
+        public interface Builder
+    }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 
 /**
@@ -12,6 +13,11 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
  * operations immediately succeed and no blocking occurs.
  */
 public object InfiniteTokenBucket : RetryTokenBucket {
+    override val config: RetryTokenBucket.Config = object : RetryTokenBucket.Config {
+        @InternalApi
+        override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = { }
+    }
+
     override suspend fun acquireToken(): RetryToken = object : RetryToken {
         override suspend fun notifyFailure() = Unit
         override suspend fun notifySuccess() = Unit

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
@@ -6,18 +6,36 @@
 package aws.smithy.kotlin.runtime.retries.delay
 
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 
 /**
  * A rate-limiting token bucket for use in a client-throttled retry strategy.
  */
 public interface RetryTokenBucket {
+    public val config: Config
+
     /**
      * Acquire a token from the token bucket. This method should be called before the initial retry attempt for a block
      * of code. This method may delay if there are already insufficient tokens in the bucket due to prior retry
      * failures or large numbers of simultaneous requests.
      */
     public suspend fun acquireToken(): RetryToken
+
+    /**
+     * Configuration for a tucket bucket
+     */
+    public interface Config {
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        /**
+         * A builder for configs for token buckets
+         */
+        @RetryStrategyConfigDsl
+        public interface Builder
+    }
 }
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -5,29 +5,41 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.util.DslFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeSource
 
-private const val MS_PER_S = 1_000
-
 /**
  * The standard implementation of a [RetryTokenBucket].
- * @param options The configuration to use for this bucket.
+ * @param config The configuration to use for this bucket.
  * @param timeSource A monotonic time source to use for calculating the temporal token fill of the bucket.
  */
 @OptIn(ExperimentalTime::class)
-public class StandardRetryTokenBucket constructor(
-    public val options: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions.Default,
-    private val timeSource: TimeSource = TimeSource.Monotonic,
+public class StandardRetryTokenBucket internal constructor(
+    override val config: Config,
+    private val timeSource: TimeSource,
 ) : RetryTokenBucket {
-    internal var capacity = options.maxCapacity
+    /**
+     * Initializes a new [StandardRetryTokenBucket].
+     */
+    public constructor(options: Config = Config.Default) : this(options, timeSource = TimeSource.Monotonic)
+
+    public companion object : DslFactory<Config.Builder, StandardRetryTokenBucket> {
+        override fun invoke(block: Config.Builder.() -> Unit): StandardRetryTokenBucket =
+            StandardRetryTokenBucket(Config(Config.Builder().apply(block)))
+    }
+
+    internal var capacity = config.maxCapacity
         private set
 
     private var lastTimeMark = timeSource.markNow()
@@ -39,8 +51,8 @@ public class StandardRetryTokenBucket constructor(
      * failures or large numbers of simultaneous requests.
      */
     override suspend fun acquireToken(): RetryToken {
-        checkoutCapacity(options.initialTryCost)
-        return StandardRetryToken(options.initialTrySuccessIncrement)
+        checkoutCapacity(config.initialTryCost)
+        return StandardRetryToken(config.initialTrySuccessIncrement)
     }
 
     private suspend fun checkoutCapacity(size: Int): Unit = mutex.withLock {
@@ -49,13 +61,13 @@ public class StandardRetryTokenBucket constructor(
         if (size <= capacity) {
             capacity -= size
         } else {
-            if (options.circuitBreakerMode) {
+            if (config.circuitBreakerMode) {
                 throw RetryCapacityExceededException("Insufficient capacity to attempt another retry")
             }
 
             val extraRequiredCapacity = size - capacity
-            val delayMs = ceil(extraRequiredCapacity.toDouble() / options.refillUnitsPerSecond * MS_PER_S).toLong()
-            delay(delayMs)
+            val delayDuration = ceil(extraRequiredCapacity.toDouble() / config.refillUnitsPerSecond).seconds
+            delay(delayDuration)
             capacity = 0
         }
 
@@ -63,15 +75,15 @@ public class StandardRetryTokenBucket constructor(
     }
 
     private fun refillCapacity() {
-        val refillMs = lastTimeMark.elapsedNow().inWholeMilliseconds
-        val refillSize = floor(options.refillUnitsPerSecond.toDouble() / MS_PER_S * refillMs).toInt()
-        capacity = min(options.maxCapacity, capacity + refillSize)
+        val refillSeconds = lastTimeMark.elapsedNow().toDouble(DurationUnit.SECONDS)
+        val refillSize = floor(config.refillUnitsPerSecond * refillSeconds).toInt()
+        capacity = min(config.maxCapacity, capacity + refillSize)
     }
 
     private suspend fun returnCapacity(size: Int): Unit = mutex.withLock {
         refillCapacity()
 
-        capacity = min(options.maxCapacity, capacity + size)
+        capacity = min(config.maxCapacity, capacity + size)
         lastTimeMark = timeSource.markNow()
     }
 
@@ -79,7 +91,7 @@ public class StandardRetryTokenBucket constructor(
      * A standard implementation of a [RetryToken].
      * @param returnSize The amount of capacity to return to the bucket on a successful try.
      */
-    internal inner class StandardRetryToken(public val returnSize: Int) : RetryToken {
+    internal inner class StandardRetryToken(private val returnSize: Int) : RetryToken {
         /**
          * Completes this token because retrying has been abandoned. This implementation doesn't actually increment any
          * capacity upon failure...capacity just refills based on time.
@@ -100,48 +112,127 @@ public class StandardRetryTokenBucket constructor(
          */
         override suspend fun scheduleRetry(reason: RetryErrorType): RetryToken {
             val size = when (reason) {
-                RetryErrorType.Transient, RetryErrorType.Throttling -> options.timeoutRetryCost
-                else -> options.retryCost
+                RetryErrorType.Transient, RetryErrorType.Throttling -> config.timeoutRetryCost
+                else -> config.retryCost
             }
             checkoutCapacity(size)
             return StandardRetryToken(size)
         }
     }
-}
 
-/**
- * The configuration options for a [StandardRetryTokenBucket].
- * @param maxCapacity The maximum capacity for the bucket.
- * @param refillUnitsPerSecond The amount of capacity to return per second.
- * @param circuitBreakerMode When true, indicates that attempts to acquire tokens or schedule retries should fail if all
- * capacity has been depleted. When false, calls to acquire tokens or schedule retries will delay until sufficient
- * capacity is available.
- * @param retryCost The amount of capacity to decrement for standard retries.
- * @param timeoutRetryCost The amount of capacity to decrement for timeout or throttling retries.
- * @param initialTryCost The amount of capacity to decrement for the initial try.
- * @param initialTrySuccessIncrement The amount of capacity to return if the initial try is successful.
- */
-public data class StandardRetryTokenBucketOptions(
-    public val maxCapacity: Int,
-    public val refillUnitsPerSecond: Int,
-    public val circuitBreakerMode: Boolean,
-    public val retryCost: Int,
-    public val timeoutRetryCost: Int,
-    public val initialTryCost: Int,
-    public val initialTrySuccessIncrement: Int,
-) {
-    public companion object {
+    /**
+     * Options for configuring a [StandardRetryTokenBucket]
+     */
+    public class Config(builder: Builder) : RetryTokenBucket.Config {
+        public companion object {
+            /**
+             * The default configuration to use
+             */
+            public val Default: Config = Config(Builder())
+
+            /**
+             * Initializes a new config instance
+             * @param block A DSL builder block which sets the parameters for this config
+             */
+            public operator fun invoke(block: Builder.() -> Unit): Config = Config(Builder().apply(block))
+        }
+
         /**
-         * The default configuration for a [StandardRetryTokenBucket].
+         * When `true`, indicates that attempts to acquire tokens or schedule retries should fail if all capacity has
+         * been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient capacity
+         * is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
          */
-        public val Default: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions(
-            maxCapacity = 500,
-            refillUnitsPerSecond = 10,
-            circuitBreakerMode = false,
-            retryCost = 5,
-            timeoutRetryCost = 10,
-            initialTryCost = 0,
-            initialTrySuccessIncrement = 1,
-        )
+        public val circuitBreakerMode: Boolean = builder.circuitBreakerMode
+
+        /**
+         * The amount of capacity to decrement for the initial try
+         */
+        public val initialTryCost: Int = builder.initialTryCost
+
+        /**
+         * The amount of capacity to return if the initial try is successful
+         */
+        public val initialTrySuccessIncrement: Int = builder.initialTrySuccessIncrement
+
+        /**
+         * The maximum capacity for the bucket
+         */
+        public val maxCapacity: Int = builder.maxCapacity
+
+        /**
+         * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
+         * `true`.
+         */
+        public val refillUnitsPerSecond: Int = builder.refillUnitsPerSecond
+
+        /**
+         * The amount of capacity to decrement for standard retries
+         */
+        public val retryCost: Int = builder.retryCost
+
+        /**
+         * The amount of capacity to decrement for timeout or throttling retries
+         */
+        public val timeoutRetryCost: Int = builder.timeoutRetryCost
+
+        @InternalApi
+        override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = {
+            if (this is Builder) {
+                circuitBreakerMode = this@Config.circuitBreakerMode
+                initialTryCost = this@Config.initialTryCost
+                initialTrySuccessIncrement = this@Config.initialTrySuccessIncrement
+                maxCapacity = this@Config.maxCapacity
+                refillUnitsPerSecond = this@Config.refillUnitsPerSecond
+                retryCost = this@Config.retryCost
+                timeoutRetryCost = this@Config.timeoutRetryCost
+            }
+        }
+
+        /**
+         * A mutable builder for a [Config]
+         */
+        public class Builder : RetryTokenBucket.Config.Builder {
+            /**
+             * When `true`, indicates that attempts to acquire tokens or schedule retries should fail if all capacity
+             * has been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient
+             * capacity is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
+             */
+            public var circuitBreakerMode: Boolean = true
+
+            /**
+             * The amount of capacity to decrement for the initial try
+             */
+            public var initialTryCost: Int = 0
+
+            /**
+             * The amount of capacity to return if the initial try is successful
+             */
+            public var initialTrySuccessIncrement: Int = 1
+
+            /**
+             * The maximum capacity for the bucket
+             */
+            public var maxCapacity: Int = 500
+
+            /**
+             * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
+             * `true`.
+             */
+            public var refillUnitsPerSecond: Int = 0
+                set(value) {
+                    if (value == 0) circuitBreakerMode = true
+                    field = value
+                }
+
+            /**
+             * The amount of capacity to decrement for standard retries
+             */
+            public var retryCost: Int = 5
+
+            /**
+             * The amount of capacity to decrement for timeout or throttling retries
+             */
+            public var timeoutRetryCost: Int = 10
+        }
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
@@ -5,7 +5,27 @@
 package aws.smithy.kotlin.runtime.util
 
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
 
+/**
+ * Encapsulates a mutable property for a complex (i.e., non-scalar) type meant to be modified in a mutable builder
+ * implementation. This single property provides an [instance] field for setting a literal value and two [dsl] overloads
+ * for providing configuration for a dynamically-constructed instance. Note that callers should not _read_ the value of
+ * [instance] and should instead use the [supply] function.
+ *
+ * @param SuperBuilder The topmost class/interface for valid builder instances for this property. Any subtype builders
+ * must inherit/implement this type. Instances of [SuperBuilder] should build to a [SuperBuilt] instance.
+ * @param SuperBuilt The topmost class/interface for valid _built_ instances of this property. Any subtypes must
+ * inherit/implement this type.
+ * @param defaultFactory The default factory type to use for constructing new instances. This default type will be used
+ * if no specific instance has been set and no [dsl] invocation has specified a different factory.
+ * @param toBuilderApplicator A method that can turn a built instance (i.e., of [SuperBuilt]) into an applicator
+ * function that applies the built properties to a builder instance.
+ * @param managedTransform An optional transformation that will apply to instances built from [dsl] but not instances
+ * set directly on [instance]. This is useful for example when applying management wrappers around types whose lifetime
+ * will be managed by the runtime, not by callers.
+ */
+@InternalApi
 public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
     private val defaultFactory: DslFactory<SuperBuilder, SuperBuilt>,
     private val toBuilderApplicator: SuperBuilt.() -> (SuperBuilder.() -> Unit),
@@ -15,9 +35,17 @@ public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
     private var factory: DslFactory<SuperBuilder, SuperBuilt> = defaultFactory
     private var state = SupplierState.NOT_INITIALIZED
 
+    /**
+     * Yields the final instance of this property, either directly from [instance] or as built given the factory and
+     * DSL block passed to [dsl].
+     */
     public var supply: () -> SuperBuilt = { managedTransform(factory { }) }
         private set
 
+    /**
+     * Sets the value of this property to a literal instance. Note that callers should not _read_ the value of
+     * [instance] and should instead use the [supply] function.
+     */
     public var instance: SuperBuilt? = null
         set(value) {
             state = when (state) {
@@ -38,6 +66,16 @@ public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
             configApplicator = value?.toBuilderApplicator() ?: { }
         }
 
+    /**
+     * Configure a builder for this property value.
+     * @param SubBuilder The subtype of the [SuperBuilder] type which describes the specific type being used for the DSL
+     * block.
+     * @param SubBuilt The subtype of the [SuperBuilt] type which describes the specific type of instance which will be
+     * built.
+     * @param factory The factory which can turn a builder into a built instance. The specific [SubBuilder] type of this
+     * factory will be used in the DSL block.
+     * @param block A DSL block which is applied to the builder instance before being built.
+     */
     public fun <SubBuilder : SuperBuilder, SubBuilt : SuperBuilt> dsl(
         factory: DslFactory<SubBuilder, SubBuilt>,
         block: SubBuilder.() -> Unit,
@@ -53,8 +91,19 @@ public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
         configApplicator = {
             previousApplicator()
 
-            @Suppress("UNCHECKED_CAST") // This is safe because [factory] is definitely the right type
-            block(this as SubBuilder)
+            try {
+                // This should be safe to cast if no one tried to change the type from before.
+                @Suppress("UNCHECKED_CAST")
+                this as SubBuilder
+            } catch (e: ClassCastException) {
+                // Otherwise, throw an exception!
+                throw ClientException(
+                    "Cannot change DSL property type after initially setting it to ${this!!::class.simpleName}",
+                    e,
+                )
+            }
+
+            block(this)
         }
         supply = { managedTransform(factory(configApplicator)) }
     }
@@ -65,8 +114,4 @@ private enum class SupplierState {
     INITIALIZED,
     EXPLICIT_CONFIG,
     EXPLICIT_INSTANCE,
-}
-
-public interface DslFactory<out Builder, out Built> {
-    public operator fun invoke(block: Builder.() -> Unit): Built
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.ClientException
+
+public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
+    private val defaultFactory: DslFactory<SuperBuilder, SuperBuilt>,
+    private val toBuilderApplicator: SuperBuilt.() -> (SuperBuilder.() -> Unit),
+    private val managedTransform: (SuperBuilt) -> SuperBuilt = { it },
+) {
+    private var configApplicator: SuperBuilder.() -> Unit = { }
+    private var factory: DslFactory<SuperBuilder, SuperBuilt> = defaultFactory
+    private var state = SupplierState.NOT_INITIALIZED
+
+    public var supply: () -> SuperBuilt = { managedTransform(factory { }) }
+        private set
+
+    public var instance: SuperBuilt? = null
+        set(value) {
+            state = when (state) {
+                SupplierState.NOT_INITIALIZED -> SupplierState.INITIALIZED
+                else -> SupplierState.EXPLICIT_INSTANCE
+            }
+
+            field = value
+            supply = when (value) {
+                null -> {
+                    // Reset factory back to default
+                    factory = defaultFactory
+                    { managedTransform(factory { }) }
+                }
+                else -> { { value } }
+            }
+
+            configApplicator = value?.toBuilderApplicator() ?: { }
+        }
+
+    public fun <SubBuilder : SuperBuilder, SubBuilt : SuperBuilt> dsl(
+        factory: DslFactory<SubBuilder, SubBuilt>,
+        block: SubBuilder.() -> Unit,
+    ) {
+        when (state) {
+            SupplierState.EXPLICIT_INSTANCE -> throw ClientException("An explicit instance is already configured and its configuration cannot be modified")
+            else -> state = SupplierState.EXPLICIT_CONFIG
+        }
+
+        this.factory = factory
+
+        val previousApplicator = configApplicator
+        configApplicator = {
+            previousApplicator()
+
+            @Suppress("UNCHECKED_CAST") // This is safe because [factory] is definitely the right type
+            block(this as SubBuilder)
+        }
+        supply = { managedTransform(factory(configApplicator)) }
+    }
+}
+
+private enum class SupplierState {
+    NOT_INITIALIZED,
+    INITIALIZED,
+    EXPLICIT_CONFIG,
+    EXPLICIT_INSTANCE,
+}
+
+public interface DslFactory<out Builder, out Built> {
+    public operator fun invoke(block: Builder.() -> Unit): Built
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslFactory.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslFactory.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+/**
+ * A factory type that can turn a [Builder] instance into a [Built] instance. Implementing this factory type can enable
+ * usage of custom classes in DSL builders.
+ */
+public interface DslFactory<out Builder, out Built> {
+    /**
+     * Turns a [Builder] instance into a [Built] instance, first applying the given DSL block to the builder.
+     * @param block A DSL block to apply to the builder.
+     */
+    public operator fun invoke(block: Builder.() -> Unit): Built
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -7,32 +7,26 @@ package aws.smithy.kotlin.runtime.retries.delay
 
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.TestTimeSource
+import kotlin.time.TimeSource
 
+private const val DEFAULT_RETRY_COST = 2
+private const val DEFAULT_TIMEOUT_RETRY_COST = 3
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class StandardRetryTokenBucketTest {
-    companion object {
-        private val DefaultOptions = StandardRetryTokenBucketOptions(
-            maxCapacity = 10,
-            refillUnitsPerSecond = 10,
-            circuitBreakerMode = false,
-            retryCost = 2,
-            timeoutRetryCost = 3,
-            initialTryCost = 0,
-            initialTrySuccessIncrement = 1,
-        )
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testWaitForCapacity() = runTest {
         // A bucket that only allows one initial try per second
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 10))
+        val bucket = tokenBucket(initialTryCost = 10)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -40,11 +34,10 @@ class StandardRetryTokenBucketTest {
         assertTime(1000) { bucket.acquireToken() }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testReturnCapacityOnSuccess() = runTest {
         // A bucket that costs capacity for an initial try and doesn't return the same capacity (for easy measuring)
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 5, initialTrySuccessIncrement = 3))
+        val bucket = tokenBucket(initialTryCost = 5, initialTrySuccessIncrement = 3)
 
         assertEquals(10, bucket.capacity)
         val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -53,11 +46,10 @@ class StandardRetryTokenBucketTest {
         assertEquals(8, bucket.capacity)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testNoCapacityChangeOnFailure() = runTest {
         // A bucket that costs capacity for an initial try
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 1))
+        val bucket = tokenBucket(initialTryCost = 1)
 
         assertEquals(10, bucket.capacity)
         val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -66,16 +58,15 @@ class StandardRetryTokenBucketTest {
         assertEquals(9, bucket.capacity)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testRetryCapacityAdjustments() = runTest {
         mapOf(
-            RetryErrorType.Throttling to DefaultOptions.timeoutRetryCost,
-            RetryErrorType.Transient to DefaultOptions.timeoutRetryCost,
-            RetryErrorType.ClientSide to DefaultOptions.retryCost,
-            RetryErrorType.ServerSide to DefaultOptions.retryCost,
+            RetryErrorType.Throttling to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.Transient to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.ClientSide to DEFAULT_RETRY_COST,
+            RetryErrorType.ServerSide to DEFAULT_RETRY_COST,
         ).forEach { (errorType, cost) ->
-            val bucket = StandardRetryTokenBucket(DefaultOptions)
+            val bucket = tokenBucket()
 
             assertEquals(10, bucket.capacity)
             val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -85,13 +76,12 @@ class StandardRetryTokenBucketTest {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
     @Test
     fun testRefillOverTime() = runTest {
         val timeSource = TestTimeSource()
 
         // A bucket that costs capacity for an initial try
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 5), timeSource)
+        val bucket = tokenBucket(initialTryCost = 5, timeSource = timeSource)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -104,11 +94,10 @@ class StandardRetryTokenBucketTest {
         assertEquals(2, bucket.capacity) // We had 5, 2 refilled, and then we decremented 5 more.
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testCircuitBreakerMode() = runTest {
         // A bucket that only allows one initial try per second
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 10, circuitBreakerMode = true))
+        val bucket = tokenBucket(initialTryCost = 10, circuitBreakerMode = true)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -116,4 +105,27 @@ class StandardRetryTokenBucketTest {
         val result = runCatching { bucket.acquireToken() }
         assertIs<RetryCapacityExceededException>(result.exceptionOrNull())
     }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+private fun TestScope.tokenBucket(
+    circuitBreakerMode: Boolean = false,
+    initialTryCost: Int = 0,
+    initialTrySuccessIncrement: Int = 1,
+    maxCapacity: Int = 10,
+    refillUnitsPerSecond: Int = 10,
+    retryCost: Int = DEFAULT_RETRY_COST,
+    timeoutRetryCost: Int = DEFAULT_TIMEOUT_RETRY_COST,
+    timeSource: TimeSource = testTimeSource,
+): StandardRetryTokenBucket {
+    val config = StandardRetryTokenBucket.Config {
+        this.circuitBreakerMode = circuitBreakerMode
+        this.initialTryCost = initialTryCost
+        this.initialTrySuccessIncrement = initialTrySuccessIncrement
+        this.maxCapacity = maxCapacity
+        this.refillUnitsPerSecond = refillUnitsPerSecond
+        this.retryCost = retryCost
+        this.timeoutRetryCost = timeoutRetryCost
+    }
+    return StandardRetryTokenBucket(config, timeSource)
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/DslBuilderPropertyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/DslBuilderPropertyTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.ClientException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+private const val DEFAULT_COLOR = "(unknown)"
+private const val DEFAULT_DOORS = 4
+private const val DEFAULT_GEARS = 1
+
+class DslBuilderPropertyTest {
+    @Test
+    fun testSetInstance() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.instance = OrangeMtnBike
+        assertEquals(OrangeMtnBike, prop.supply())
+
+        // Test reset back to default factory
+        prop.instance = null
+        val actual = prop.supply()
+        assertIs<Car>(actual)
+        assertEquals(DEFAULT_COLOR, actual.config.color)
+        assertEquals(DEFAULT_DOORS, actual.config.doors)
+    }
+
+    @Test
+    fun testSetDsl() {
+        val prop = vehicleProp()
+
+        prop.dsl(Bike) { color = "yellow" }
+        var actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("yellow", actual.config.color)
+        assertEquals(DEFAULT_GEARS, actual.config.gears)
+
+        prop.dsl(Bike) { gears = 5 }
+        actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("yellow", actual.config.color)
+        assertEquals(5, actual.config.gears)
+
+        prop.dsl(Bike) { color = "purple" }
+        actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("purple", actual.config.color)
+        assertEquals(5, actual.config.gears)
+    }
+
+    @Test
+    fun testSetDslAfterInitialInstance() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.dsl(Car) {
+            assertEquals(BlueCoupe.config.color, color)
+            assertEquals(BlueCoupe.config.doors, doors)
+
+            doors = 4
+        }
+
+        val actual = prop.supply()
+        assertIs<Car>(actual)
+        assertEquals(BlueCoupe.config.color, actual.config.color)
+        assertEquals(4, actual.config.doors)
+    }
+
+    @Test
+    fun testSetDslAfterInitialInstanceAndChangeType() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.dsl(Bike) {
+            assertEquals(BlueCoupe.config.color, color)
+
+            gears = 10
+        }
+
+        val actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals(BlueCoupe.config.color, actual.config.color)
+        assertEquals(10, actual.config.gears)
+    }
+
+    @Test
+    fun testStateWithInstanceFirst() {
+        val prop = vehicleProp() // SupplierState.NOT_INITIALIZED
+
+        prop.instance = BlueCoupe // SupplierState.INITIALIZED
+
+        prop.instance = OrangeMtnBike // SupplierState.EXPLICIT_INSTANCE
+
+        assertThrows<ClientException> { // Cannot switch from EXPLICIT_INSTANCE to EXPLICIT_CONFIG
+            prop.dsl(Bike) { }
+        }
+    }
+
+    @Test
+    fun testStateWithConfigFirst() {
+        val prop = vehicleProp() // SupplierState.NOT_INITIALIZED
+
+        prop.instance = BlueCoupe // SupplierState.INITIALIZED
+
+        prop.dsl(Bike) { } // SupplierState.EXPLICIT_CONFIG
+
+        prop.instance = OrangeMtnBike // SupplierState.EXPLICIT_INSTANCE
+
+        assertThrows<ClientException> { // Cannot switch from EXPLICIT_INSTANCE to EXPLICIT_CONFIG
+            prop.dsl(Car) { }
+        }
+    }
+}
+
+private fun vehicleProp(managedTransform: (Vehicle) -> Vehicle = { it }) =
+    DslBuilderProperty<Vehicle.Config.Builder, Vehicle>(Car, Vehicle::toBuilderApplicator, managedTransform)
+
+// Super interfaces for a DSL
+private interface Vehicle {
+    fun toBuilderApplicator(): (Config.Builder.() -> Unit)
+
+    interface Config {
+        val color: String
+        interface Builder {
+            var color: String?
+        }
+    }
+}
+
+// Subtypes for the DSL
+private class Car(val config: Config) : Vehicle {
+    companion object : DslFactory<Config.Builder, Car> {
+        override fun invoke(block: Config.Builder.() -> Unit) = Car(Config(Config.Builder().apply(block)))
+    }
+
+    override fun toBuilderApplicator(): Vehicle.Config.Builder.() -> Unit = {
+        color = config.color
+        if (this is Config.Builder) {
+            doors = config.doors
+        }
+    }
+
+    class Config(builder: Builder) : Vehicle.Config {
+        override val color: String = builder.color ?: DEFAULT_COLOR
+        val doors: Int = builder.doors ?: DEFAULT_DOORS
+
+        class Builder : Vehicle.Config.Builder {
+            override var color: String? = null
+            var doors: Int? = null
+        }
+    }
+}
+private val BlueCoupe = Car { color = "blue"; doors = 2 }
+
+private class Bike(val config: Config) : Vehicle {
+    companion object : DslFactory<Config.Builder, Bike> {
+        override fun invoke(block: Config.Builder.() -> Unit) = Bike(Config(Config.Builder().apply(block)))
+    }
+
+    override fun toBuilderApplicator(): Vehicle.Config.Builder.() -> Unit = {
+        color = config.color
+        if (this is Config.Builder) {
+            gears = config.gears
+        }
+    }
+
+    class Config(builder: Builder) : Vehicle.Config {
+        override val color: String = builder.color ?: DEFAULT_COLOR
+        val gears: Int = builder.gears ?: DEFAULT_GEARS
+
+        class Builder : Vehicle.Config.Builder {
+            override var color: String? = null
+            var gears: Int? = null
+        }
+    }
+}
+private val OrangeMtnBike = Bike { color = "orange"; gears = 9 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.retries.impl
 
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.TooManyAttemptsException
-import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
 import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
 import aws.smithy.kotlin.runtime.retries.getOrThrow
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -34,18 +34,12 @@ class StandardRetryIntegrationTest {
                 maxAttempts = tc.given.maxAttempts
                 this.tokenBucket = tokenBucket
                 delayProvider {
-                    println("Actually setting the delay provider values!")
                     initialDelay = tc.given.exponentialBase.milliseconds
                     scaleFactor = tc.given.exponentialPower
                     jitter = 0.0 // None of the tests use jitter
                     maxBackoff = tc.given.maxBackoffTime.milliseconds
                 }
             }
-            val delayConfig = (retryer.config.delayProvider as ExponentialBackoffWithJitter).config
-            println("retrier configured with initial delay ${delayConfig.initialDelay}")
-            println("retrier configured with scale factor ${delayConfig.scaleFactor}")
-            println("retrier configured with jitter ${delayConfig.jitter}")
-            println("retrier configured with max backoff ${delayConfig.maxBackoff}")
 
             val block = object {
                 var index = 0

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -145,6 +145,26 @@ public abstract interface class aws/smithy/kotlin/runtime/client/ResponseInterce
 	public abstract fun getResponse-d1pmJ48 ()Ljava/lang/Object;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryClientConfig : aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig {
+	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryClientConfig$Builder {
+	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
+	public abstract fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig {
+	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig$Builder {
+	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+	public abstract fun retryStrategy (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun retryStrategy (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient : java/io/Closeable {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/client/SdkClientConfig;
 }
@@ -156,19 +176,13 @@ public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient$Build
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig {
 	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getLogMode ()Laws/smithy/kotlin/runtime/client/LogMode;
-	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
-	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig$Builder : aws/smithy/kotlin/runtime/util/Buildable {
 	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getLogMode ()Laws/smithy/kotlin/runtime/client/LogMode;
-	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
-	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 	public abstract fun setClientName (Ljava/lang/String;)V
 	public abstract fun setLogMode (Laws/smithy/kotlin/runtime/client/LogMode;)V
-	public abstract fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
-	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientFactory {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/RetryClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/RetryClientConfig.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.client
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategy
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
+import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import aws.smithy.kotlin.runtime.util.DslBuilderProperty
+import aws.smithy.kotlin.runtime.util.DslFactory
+
+public interface RetryClientConfig : RetryStrategyClientConfig {
+    /**
+     * The policy to use for evaluating operation results and determining whether/how to retry.
+     */
+    public val retryPolicy: RetryPolicy<Any?>
+
+    public interface Builder {
+        /**
+         * The policy to use for evaluating operation results and determining whether/how to retry.
+         */
+        public var retryPolicy: RetryPolicy<Any?>?
+    }
+}
+
+public interface RetryStrategyClientConfig {
+    /**
+     * The [RetryStrategy] the client will use to retry failed operations.
+     */
+    public val retryStrategy: RetryStrategy
+
+    @RetryStrategyConfigDsl
+    public interface Builder {
+        public fun retryStrategy(block: StandardRetryStrategy.Config.Builder.() -> Unit)
+
+        public fun <B : RetryStrategy.Config.Builder, R : RetryStrategy> retryStrategy(
+            factory: DslFactory<B, R>,
+            block: B.() -> Unit,
+        )
+
+        /**
+         * The [RetryStrategy] the client will use to retry failed operations.
+         */
+        public var retryStrategy: RetryStrategy?
+
+        @InternalApi
+        public fun buildRetryStrategyClientConfig(): RetryStrategyClientConfig
+    }
+}
+
+@InternalApi
+public class RetryStrategyClientConfigImpl private constructor(
+    override val retryStrategy: RetryStrategy,
+) : RetryStrategyClientConfig {
+    @InternalApi
+    public class BuilderImpl : RetryStrategyClientConfig.Builder {
+        private val retryStrategyProperty = DslBuilderProperty<RetryStrategy.Config.Builder, RetryStrategy>(
+            StandardRetryStrategy,
+            { config.toBuilderApplicator() },
+        )
+
+        override var retryStrategy: RetryStrategy? by retryStrategyProperty::instance
+
+        override fun retryStrategy(block: StandardRetryStrategy.Config.Builder.() -> Unit) {
+            retryStrategyProperty.dsl(StandardRetryStrategy, block)
+        }
+
+        override fun <B : RetryStrategy.Config.Builder, R : RetryStrategy> retryStrategy(
+            factory: DslFactory<B, R>,
+            block: B.() -> Unit,
+        ) {
+            retryStrategyProperty.dsl(factory, block)
+        }
+
+        @InternalApi
+        override fun buildRetryStrategyClientConfig(): RetryStrategyClientConfig =
+            RetryStrategyClientConfigImpl(retryStrategyProperty.supply())
+    }
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
@@ -4,8 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.client
 
-import aws.smithy.kotlin.runtime.retries.RetryStrategy
-import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.util.Buildable
 
 /**
@@ -28,16 +26,6 @@ public interface SdkClientConfig {
      * debug purposes.
      */
     public val logMode: LogMode
-
-    /**
-     * The policy to use for evaluating operation results and determining whether/how to retry.
-     */
-    public val retryPolicy: RetryPolicy<Any?>
-
-    /**
-     * The [RetryStrategy] the client will use to retry failed operations.
-     */
-    public val retryStrategy: RetryStrategy
 
     /**
      * Configurable properties that all client configuration exposes.
@@ -63,15 +51,5 @@ public interface SdkClientConfig {
          * debug purposes.
          */
         public var logMode: LogMode?
-
-        /**
-         * The policy to use for evaluating operation results and determining whether/how to retry.
-         */
-        public var retryPolicy: RetryPolicy<Any?>?
-
-        /**
-         * Configure the [RetryStrategy] the client will use to retry failed operations.
-         */
-        public var retryStrategy: RetryStrategy?
     }
 }


### PR DESCRIPTION
## Issue \#

Related to [aws-sdk-kotlin#701](https://github.com/awslabs/aws-sdk-kotlin/issues/701)

## Description of changes

This change adds DSL builder methods for constructing retry strategies, making them easier to use during client initialization and re-initialization via `withConfig`. It also abstracts the core logic of DSL-style properties into a new `DslBuilderProperty` which should hopefully simplify future features like this.

**Companion PR**: [aws-sdk-kotlin#954](https://github.com/awslabs/aws-sdk-kotlin/pull/954)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
