### PR TITLE
refactor telemetry instrumentation

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -64,7 +64,7 @@ object RuntimeTypes {
             val OperationAuthConfig = symbol("OperationAuthConfig")
             val OperationRequest = symbol("OperationRequest")
             val roundTrip = symbol("roundTrip")
-            val sdkRequestId = symbol("sdkRequestId")
+            val telemetry = symbol("telemetry")
             val SdkHttpOperation = symbol("SdkHttpOperation")
             val SdkHttpRequest = symbol("SdkHttpRequest")
             val setResolvedEndpoint = symbol("setResolvedEndpoint")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -55,7 +55,7 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
-    override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.None
+    override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global
 """
         contents.shouldContainWithDiff(expectedProps)
 
@@ -122,8 +122,8 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
         override var retryStrategy: RetryStrategy? = null
 
         /**
-         * The telemetry provider used to instrument the SDK operations with. By default this will be a no-op
-         * implementation.
+         * The telemetry provider used to instrument the SDK operations with. By default, the global telemetry
+         * provider will be used.
          */
         override var telemetryProvider: TelemetryProvider? = null
 
@@ -254,7 +254,7 @@ public class Config private constructor(builder: Builder) {
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
     override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
-    override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.None"""
+    override val telemetryProvider: TelemetryProvider = builder.telemetryProvider ?: TelemetryProvider.Global"""
         contents.shouldContainWithDiff(expectedConfigValues)
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -80,6 +80,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFoo"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -87,10 +91,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFoo")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -101,6 +102,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooNoInput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -108,10 +113,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooNoInput")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -122,6 +124,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooNoOutput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -129,10 +135,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooNoOutput")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -143,6 +146,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooStreamingInput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -150,10 +157,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooStreamingInput")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -164,6 +168,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -171,10 +179,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooStreamingOutput")
-        return withSpan(span, telemetryCtx) {
-            op.execute(client, input, block)
-        }
+        return op.execute(client, input, block)
     }
 """,
 """
@@ -185,6 +190,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutputNoInput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -192,10 +201,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooStreamingOutputNoInput")
-        return withSpan(span, telemetryCtx) {
-            op.execute(client, input, block)
-        }
+        return op.execute(client, input, block)
     }
 """,
 """
@@ -206,6 +212,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooStreamingInputNoOutput"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -213,10 +223,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooStreamingInputNoOutput")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -227,6 +234,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooNoRequired"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -234,10 +245,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooNoRequired")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
 """
@@ -248,6 +256,10 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetFooSomeRequired"
+                serviceName = ServiceId
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -255,10 +267,7 @@ class HttpProtocolClientGeneratorTest {
         }
         op.install(MockMiddleware(configurationField1 = "testing"))
         op.interceptors.addAll(config.interceptors)
-        val (span, telemetryCtx) = instrumentOperation("GetFooSomeRequired")
-        return withSpan(span, telemetryCtx) {
-            op.roundTrip(client, input)
-        }
+        return op.roundTrip(client, input)
     }
 """,
         )
@@ -325,7 +334,11 @@ class HttpProtocolClientGeneratorTest {
             context {
                 expectedHttpStatus = 200
                 operationName = "GetStatus"
+                serviceName = ServiceId
                 hostPrefix = "$prefix"
+            }
+            telemetry {
+                provider = config.telemetryProvider
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -442,6 +442,7 @@ private fun buildOperation(
 
         context {
             operationName = "testSigningOperation"
+            serviceName = "testService"
             set(AwsSigningAttributes.SigningRegion, config.region)
             config.signingDate.let {
                 set(AwsSigningAttributes.SigningDate, it)

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -79,6 +79,7 @@ public abstract class AwsHttpSignerTestBase(
 
             context {
                 operationName = "testSigningOperation"
+                serviceName = "testService"
                 set(AwsSigningAttributes.SigningRegion, "us-east-1")
                 set(AwsSigningAttributes.SigningDate, Instant.fromIso8601("2020-10-16T19:56:00Z"))
                 set(AwsSigningAttributes.SigningService, "demo")

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -115,6 +115,9 @@ public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider$Co
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement {
 	public abstract fun record (Ljava/lang/Number;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -12,6 +12,7 @@ import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 
 /**
  * Coroutine scoped telemetry context used for carrying telemetry provider configuration
@@ -42,9 +43,11 @@ public val CoroutineContext.loggingContext: Map<String, Any>
 @InternalApi
 public suspend inline fun<R> withLogCtx(
     vararg kvPairs: Pair<String, Any>,
-    crossinline block: () -> R,
+    crossinline block: suspend () -> R,
 ): R {
-    val loggingCtx = LoggingContextElement(kvPairs.toMap())
+    val ctxMap = coroutineContext.loggingContext.toMutableMap()
+    ctxMap.putAll(kvPairs)
+    val loggingCtx = LoggingContextElement(ctxMap)
     return withContext(loggingCtx) {
         block()
     }

--- a/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
+++ b/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
@@ -28,7 +28,4 @@ class TestLoggingContext {
             }
         }
     }
-
-    suspend fun test() {
-    }
 }

--- a/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
+++ b/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.telemetry.logging
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestLoggingContext {
+    @Test
+    fun testWithLogCtx() = runTest {
+        withLogCtx("foo" to "bar", "tay" to "hammer") {
+            val cc = kotlin.coroutines.coroutineContext
+            val outerLogCtx = cc.loggingContext
+            assertEquals("bar", outerLogCtx["foo"])
+            assertEquals("hammer", outerLogCtx["tay"])
+
+            withLogCtx("baz" to "quux", "tay" to "comb") {
+                val innerLogCtx = kotlin.coroutines.coroutineContext.loggingContext
+                assertEquals("bar", innerLogCtx["foo"])
+                assertEquals("quux", innerLogCtx["baz"])
+                assertEquals("comb", innerLogCtx["tay"])
+            }
+        }
+    }
+
+    suspend fun test() {
+    }
+}

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
@@ -28,6 +28,7 @@ class AwsJsonProtocolTest {
             deserializer = IdentityDeserializer
             context {
                 operationName = "Bar"
+                serviceName = "Foo"
             }
         }
         val client = SdkHttpClient(TestEngine())
@@ -50,6 +51,7 @@ class AwsJsonProtocolTest {
             deserializer = IdentityDeserializer
             context {
                 operationName = "Bar"
+                serviceName = "Foo"
             }
         }
         val client = SdkHttpClient(TestEngine())
@@ -75,6 +77,7 @@ class AwsJsonProtocolTest {
             deserializer = IdentityDeserializer
             context {
                 operationName = "Bar"
+                serviceName = "Foo"
             }
         }
         val client = SdkHttpClient(TestEngine())

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -201,9 +201,11 @@ public class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Build
 	public final fun getExpectedHttpStatus ()Ljava/lang/Integer;
 	public final fun getHostPrefix ()Ljava/lang/String;
 	public final fun getOperationName ()Ljava/lang/String;
+	public final fun getServiceName ()Ljava/lang/String;
 	public final fun setExpectedHttpStatus (Ljava/lang/Integer;)V
 	public final fun setHostPrefix (Ljava/lang/String;)V
 	public final fun setOperationName (Ljava/lang/String;)V
+	public final fun setServiceName (Ljava/lang/String;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext$Companion {
@@ -212,7 +214,7 @@ public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext
 	public final fun getHostPrefix ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHttpCallList ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getOperationInput ()Laws/smithy/kotlin/runtime/util/AttributeKey;
-	public final fun getSdkRequestId ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getSdkInvocationId ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpSerialize {
@@ -258,6 +260,9 @@ public final class aws/smithy/kotlin/runtime/http/operation/OperationRequest {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/http/operation/OperationTelemetryKt {
+}
+
 public final class aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware$DefaultImpls {
 	public static fun install (Laws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
@@ -266,7 +271,7 @@ public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation$Com
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperationKt {
-	public static final fun getSdkRequestId (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
+	public static final fun getSdkInvocationId (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/UnitDeserializer : aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
@@ -7,6 +7,8 @@ package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProviderContext
+import aws.smithy.kotlin.runtime.telemetry.logging.LoggingContextElement
+import aws.smithy.kotlin.runtime.telemetry.logging.loggingContext
 import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
@@ -25,7 +27,8 @@ internal fun HttpClientEngine.createCallContext(outerContext: CoroutineContext):
     val reqContext = coroutineContext +
         requestJob +
         CoroutineName("request-context") +
-        TelemetryProviderContext(outerContext.telemetryProvider)
+        TelemetryProviderContext(outerContext.telemetryProvider) +
+        LoggingContextElement(outerContext.loggingContext)
 
     // attach req to outer context, if the user cancels it will be propagated to the request
     attachToOuterJob(outerContext, requestJob)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -66,6 +66,11 @@ public open class HttpOperationContext {
         public var operationName: String? by requiredOption(SdkClientOption.OperationName)
 
         /**
+         * The name of the service the request is sent to
+         */
+        public var serviceName: String? by requiredOption(SdkClientOption.ServiceName)
+
+        /**
          * The expected HTTP status code on success
          */
         public var expectedHttpStatus: Int? by option(ExpectedHttpStatus)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -40,7 +40,7 @@ public open class HttpOperationContext {
          *
          * NOTE: This is guaranteed to exist.
          */
-        public val SdkRequestId: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#SdkRequestId")
+        public val SdkInvocationId: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#SdkInvocationId")
 
         /**
          * The operation input pre-serialization.

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http.operation
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.client.operationName
+import aws.smithy.kotlin.runtime.client.serviceName
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProviderContext
+import aws.smithy.kotlin.runtime.telemetry.context.TelemetryContextElement
+import aws.smithy.kotlin.runtime.telemetry.logging.LoggingContextElement
+import aws.smithy.kotlin.runtime.telemetry.trace.SpanKind
+import aws.smithy.kotlin.runtime.telemetry.trace.TraceSpan
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+import aws.smithy.kotlin.runtime.util.merge
+import aws.smithy.kotlin.runtime.util.mutableAttributesOf
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Telemetry parameters used to instrument an operation
+ *
+ * @property provider the telemetry provider to use to instrument the operation with
+ * @property spanName the overall operation span name to use (defaults to <Service.Operation>)
+ * @property spanKind the kind of span to create for the operation (defaults to [SpanKind.CLIENT])
+ * @property attributes initial attributes to add to the operation span
+ */
+@InternalApi
+public class SdkOperationTelemetry {
+    public var provider: TelemetryProvider = TelemetryProvider.None
+    public var spanName: String? = null
+    public var spanKind: SpanKind = SpanKind.CLIENT
+    public var attributes: Attributes = emptyAttributes()
+}
+
+/**
+ * Configure operation telemetry parameters
+ */
+@InternalApi
+public inline fun<I, O> SdkHttpOperationBuilder<I, O>.telemetry(block: SdkOperationTelemetry.() -> Unit) {
+    telemetry.apply(block)
+}
+
+/**
+ * Instrument an operation with telemetry. This should be invoked right when the operation is actually executed
+ * as the returned span is in the active state (i.e. current).
+ * @return the span for the operation and the additional coroutine context to execute the operation with containing
+ * telemetry elements.
+ */
+internal fun<I, O> SdkHttpOperation<I, O>.instrument(): Pair<TraceSpan, CoroutineContext> {
+    val serviceName = checkNotNull(context.serviceName)
+    val opName = checkNotNull(context.operationName)
+
+    val tracer = telemetry.provider.tracerProvider.getOrCreateTracer(serviceName)
+    val parentCtx = telemetry.provider.contextManager.current()
+    val telemetryCtx = TelemetryProviderContext(telemetry.provider) +
+        TelemetryContextElement(parentCtx) +
+        LoggingContextElement(
+            "operation" to opName,
+            "sdkInvocationId" to context.sdkInvocationId,
+        )
+
+    val initialAttributes = mutableAttributesOf {
+        "rpc.service" to serviceName
+        "rpc.method" to opName
+    }
+
+    initialAttributes.merge(telemetry.attributes)
+
+    val spanName = telemetry.spanName ?: "$serviceName.$opName"
+
+    val span = tracer.createSpan(
+        spanName,
+        initialAttributes,
+        telemetry.spanKind,
+        parentCtx,
+    )
+    return span to telemetryCtx
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
@@ -56,10 +56,11 @@ internal fun<I, O> SdkHttpOperation<I, O>.instrument(): Pair<TraceSpan, Coroutin
 
     val tracer = telemetry.provider.tracerProvider.getOrCreateTracer(serviceName)
     val parentCtx = telemetry.provider.contextManager.current()
+    val rpcName = "$serviceName.$opName"
     val telemetryCtx = TelemetryProviderContext(telemetry.provider) +
         TelemetryContextElement(parentCtx) +
         LoggingContextElement(
-            "operation" to opName,
+            "rpc" to rpcName,
             "sdkInvocationId" to context.sdkInvocationId,
         )
 
@@ -70,7 +71,7 @@ internal fun<I, O> SdkHttpOperation<I, O>.instrument(): Pair<TraceSpan, Coroutin
 
     initialAttributes.merge(telemetry.attributes)
 
-    val spanName = telemetry.spanName ?: "$serviceName.$opName"
+    val spanName = telemetry.spanName ?: rpcName
 
     val span = tracer.createSpan(
         spanName,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.http.HttpHandler
 import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.telemetry.trace.withSpan
 import aws.smithy.kotlin.runtime.util.*
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.job
@@ -21,7 +22,8 @@ import kotlin.reflect.KClass
  * @property context An [ExecutionContext] instance scoped to this operation
  * @property serializer The component responsible for serializing the input type `I` into an HTTP request builder
  * @property deserializer The component responsible for deserializing an HTTP response into the output type `O`
- * @property signer The component responsible for signing the request
+ * @property typeInfo the operation type info used internally for interceptors to function correctly
+ * @property telemetry the telemetry parameters used to instrument the operation with
  */
 @OptIn(Uuid.WeakRng::class)
 @InternalApi
@@ -31,6 +33,7 @@ public class SdkHttpOperation<I, O> internal constructor(
     internal val serializer: HttpSerialize<I>,
     internal val deserializer: HttpDeserialize<O>,
     internal val typeInfo: OperationTypeInfo,
+    internal val telemetry: SdkOperationTelemetry,
 ) {
     init {
         context[HttpOperationContext.SdkInvocationId] = Uuid.random().toString()
@@ -93,9 +96,12 @@ public suspend fun <I, O, R> SdkHttpOperation<I, O>.execute(
 ): R {
     val handler = execution.decorate(httpHandler, this)
     val request = OperationRequest(context, input)
+    val (span, telemetryCtx) = instrument()
     try {
-        val output = handler.call(request)
-        return block(output)
+        return withSpan(span, telemetryCtx) {
+            val output = handler.call(request)
+            block(output)
+        }
     } finally {
         context.cleanup()
     }
@@ -111,6 +117,7 @@ public class SdkHttpOperationBuilder<I, O> (
     private val inputType: KClass<*>,
     private val outputType: KClass<*>,
 ) {
+    public val telemetry: SdkOperationTelemetry = SdkOperationTelemetry()
     public var serializer: HttpSerialize<I>? = null
     public var deserializer: HttpDeserialize<O>? = null
     public val execution: SdkOperationExecution<I, O> = SdkOperationExecution()
@@ -120,7 +127,7 @@ public class SdkHttpOperationBuilder<I, O> (
         val opSerializer = requireNotNull(serializer) { "SdkHttpOperation.serializer must not be null" }
         val opDeserializer = requireNotNull(deserializer) { "SdkHttpOperation.deserializer must not be null" }
         val typeInfo = OperationTypeInfo(inputType, outputType)
-        return SdkHttpOperation(execution, context.build(), opSerializer, opDeserializer, typeInfo)
+        return SdkHttpOperation(execution, context.build(), opSerializer, opDeserializer, typeInfo, telemetry)
     }
 }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation.kt
@@ -33,8 +33,7 @@ public class SdkHttpOperation<I, O> internal constructor(
     internal val typeInfo: OperationTypeInfo,
 ) {
     init {
-        val sdkRequestId = Uuid.random().toString()
-        context[HttpOperationContext.SdkRequestId] = sdkRequestId
+        context[HttpOperationContext.SdkInvocationId] = Uuid.random().toString()
     }
 
     /**
@@ -68,8 +67,8 @@ public class SdkHttpOperation<I, O> internal constructor(
 /**
  * Gets the unique ID that identifies the active SDK request in this [ExecutionContext].
  */
-public val ExecutionContext.sdkRequestId: String
-    get() = get(HttpOperationContext.SdkRequestId)
+public val ExecutionContext.sdkInvocationId: String
+    get() = get(HttpOperationContext.SdkInvocationId)
 
 /**
  * Round trip an operation using the given [HttpHandler]

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
@@ -37,6 +37,7 @@ inline fun <reified I> newTestOperation(serialized: HttpRequestBuilder): SdkHttp
         context {
             // required operation context
             operationName = "TestOperation"
+            serviceName = "TestService"
         }
     }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTest.kt
@@ -262,7 +262,8 @@ class HttpInterceptorTest {
             op.roundTrip(client, Unit)
         }
 
-        assertEquals(1, ex.suppressed.size)
-        assertIs<TestException>(ex.suppressed.last())
+        val cause = assertNotNull(ex.cause)
+        assertEquals(1, cause.suppressed.size)
+        assertIs<TestException>(cause.suppressed.last())
     }
 }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
@@ -15,6 +15,7 @@ class HttpOperationContextTest {
     fun testBuilder() {
         val op = HttpOperationContext.build {
             operationName = "operation"
+            serviceName = "service"
             expectedHttpStatus = 418
         }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperationTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkHttpOperationTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http.operation
+
+import aws.smithy.kotlin.runtime.http.SdkHttpClient
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.httptest.TestEngine
+import aws.smithy.kotlin.runtime.telemetry.logging.loggingContext
+import aws.smithy.kotlin.runtime.telemetry.trace.traceSpan
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SdkHttpOperationTest {
+    @Test
+    fun testTelemetryInstrumentation() = runTest {
+        val op = newTestOperation<Unit, Unit>(HttpRequestBuilder(), Unit)
+        val client = SdkHttpClient(TestEngine())
+        op.execute(client, Unit) {
+            val cc = kotlin.coroutines.coroutineContext
+            // test certain elements are setup correctly
+            assertEquals("TestService.TestOperation", cc.loggingContext["rpc"])
+            assertNotNull(cc.loggingContext["sdkInvocationId"])
+            assertNotNull(cc.traceSpan)
+        }
+    }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/TestOperation.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/TestOperation.kt
@@ -29,6 +29,7 @@ inline fun <reified I, reified O> newTestOperation(serialized: HttpRequestBuilde
         context {
             // required operation context
             operationName = "TestOperation"
+            serviceName = "TestService"
         }
     }
 

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -187,6 +187,7 @@ public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 	public final fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getLogMode ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getOperationName ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getServiceName ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
 
 public final class aws/smithy/kotlin/runtime/client/SdkClientOptionKt {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientOption.kt
@@ -16,27 +16,32 @@ public object SdkClientOption {
     /**
      * The name of the operation
      */
-    public val OperationName: ClientOption<String> = ClientOption("OperationName")
+    public val OperationName: ClientOption<String> = ClientOption("aws.smithy.kotlin#OperationName")
 
     /**
      * The service name the operation is executed against
+     */
+    public val ServiceName: ClientOption<String> = ClientOption("aws.smithy.kotlin#ServiceName")
+
+    /**
+     * The unique name given to a service client (often the same as [ServiceName]).
      */
     public val ClientName: ClientOption<String> = ClientOption("aws.smithy.kotlin#ClientName")
 
     /**
      * A token generator for idempotency tokens
      */
-    public val IdempotencyTokenProvider: ClientOption<IdempotencyTokenProvider> = ClientOption("IdempotencyTokenProvider")
+    public val IdempotencyTokenProvider: ClientOption<IdempotencyTokenProvider> = ClientOption("aws.smithy.kotlin#IdempotencyTokenProvider")
 
     /**
      * The client logging mode (see [LogMode])
      */
-    public val LogMode: ClientOption<LogMode> = ClientOption("LogMode")
+    public val LogMode: ClientOption<LogMode> = ClientOption("aws.smithy.kotlin#LogMode")
 
     /**
      * Whether endpoint discovery is enabled or not. Default is true
      */
-    public val EndpointDiscoveryEnabled: ClientOption<Boolean> = ClientOption("EndpointDiscoveryEnabled")
+    public val EndpointDiscoveryEnabled: ClientOption<Boolean> = ClientOption("aws.smithy.kotlin#EndpointDiscoveryEnabled")
 }
 
 /**
@@ -54,8 +59,15 @@ public val ExecutionContext.logMode: LogMode
     get() = getOrNull(SdkClientOption.LogMode) ?: LogMode.Default
 
 /**
- * Get the name of the operation from the context.
+ * Get the name of the operation being invoked from the context.
  */
 @InternalApi
 public val ExecutionContext.operationName: String?
     get() = getOrNull(SdkClientOption.OperationName)
+
+/**
+ * Get the name of the service being invoked from the context.
+ */
+@InternalApi
+public val ExecutionContext.serviceName: String?
+    get() = getOrNull(SdkClientOption.ServiceName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Moves most of the instrumentation into the runtime
* Adds back `ServiceName` as required execution context (now we have the service and operation being invoked in the context which was what we had before and we removed/broke at some point).
* Adds a logging coroutine context element that defines default key/value pairs to include with all log records emitted through the `Coroutine.log*` APIs (which is what we should be using directly/indirectly everywhere in the runtime).
    * This moves the handling of key/value pairs back to the underlying logger (e.g. log4j basically treats these as MDC for the individual log record). 


## Output Examples

### Simple logger output (just adds key=value as a prefix)
```
24 [main] TRACE aws.smithy.kotlin.runtime.http.operation.SerializeHandler - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c request serialized in 25.824854ms
66 [main] TRACE aws.smithy.kotlin.runtime.auth.awscredentials.CachedCredentialsProvider - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c refreshing credentials cache
72 [main] TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@673fdbce
74 [main] TRACE aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Attempting to load credentials from env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN
80 [main] DEBUG aws.smithy.kotlin.runtime.identity.IdentityProviderChain - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c unable to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@673fdbce: Missing value for environment variable `AWS_ACCESS_KEY_ID`
84 [main] TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider@17bffc17
99 [main] DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Loading credentials from profile `dev-admin-west`
109 [main] DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Resolving credentials from process
1284 [main] DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - rpc=S3.ListBuckets sdkInvocationId=670894cb-7d9d-4d01-9d58-d0b7d08ca56c Obtained credentials from profile; expiration=2023-06-21T22:53:42Z
```


### Log4j with config pattern:
```xml
<PatternLayout pattern="%d{DEFAULT_MICROS} %-5p %c - %encode{%m}{CRLF}%n"/>
```

```
2023-06-21 12:11:42,188340 TRACE aws.smithy.kotlin.runtime.http.operation.SerializeHandler - request serialized in 5.346304ms
2023-06-21 12:11:42,201338 TRACE aws.smithy.kotlin.runtime.auth.awscredentials.CachedCredentialsProvider - refreshing credentials cache
2023-06-21 12:11:42,203340 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@547c04c4
2023-06-21 12:11:42,204045 TRACE aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider - Attempting to load credentials from env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN
2023-06-21 12:11:42,205484 DEBUG aws.smithy.kotlin.runtime.identity.IdentityProviderChain - unable to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@547c04c4: Missing value for environment variable `AWS_ACCESS_KEY_ID`
2023-06-21 12:11:42,206693 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider@412c995d
2023-06-21 12:11:42,213762 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - Loading credentials from profile `dev-admin-west`
2023-06-21 12:11:42,221125 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - Resolving credentials from process
2023-06-21 12:11:42,843615 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider - Obtained credentials from profile; expiration=2023-06-21T22:53:42Z
```


### Using log4j with `%X`

```xml
<PatternLayout pattern="%d{DEFAULT_MICROS} %-5p %c %X - %encode{%m}{CRLF}%n"/>
```

```
2023-06-21 12:13:20,047048 TRACE aws.smithy.kotlin.runtime.http.operation.SerializeHandler {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - request serialized in 4.851666ms
2023-06-21 12:13:20,058737 TRACE aws.smithy.kotlin.runtime.auth.awscredentials.CachedCredentialsProvider {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - refreshing credentials cache
2023-06-21 12:13:20,060550 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@7fae4d4a
2023-06-21 12:13:20,061289 TRACE aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Attempting to load credentials from env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN
2023-06-21 12:13:20,062793 DEBUG aws.smithy.kotlin.runtime.identity.IdentityProviderChain {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - unable to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@7fae4d4a: Missing value for environment variable `AWS_ACCESS_KEY_ID`
2023-06-21 12:13:20,064008 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider@4dd94a58
2023-06-21 12:13:20,070404 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Loading credentials from profile `dev-admin-west`
2023-06-21 12:13:20,074683 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Resolving credentials from process
2023-06-21 12:13:20,500891 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider {rpc=S3.ListBuckets, sdkInvocationId=089896c5-efef-4545-baa2-b08680e9b62c} - Obtained credentials from profile; expiration=2023-06-21T22:53:42Z
```

### Log4j custom Pattern layout for MDC / Key/Value pairs:
```xml
<PatternLayout pattern="%d{DEFAULT_MICROS} %-5p %c op=%X{operation}; sdkId=%X{sdkInvocationId} - %encode{%m}{CRLF}%n"/>
```

```
2023-06-21 12:15:43,775442 TRACE aws.smithy.kotlin.runtime.http.operation.SerializeHandler op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - request serialized in 5.675101ms
2023-06-21 12:15:43,785253 TRACE aws.smithy.kotlin.runtime.auth.awscredentials.CachedCredentialsProvider op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - refreshing credentials cache
2023-06-21 12:15:43,786784 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@7fae4d4a
2023-06-21 12:15:43,787327 TRACE aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Attempting to load credentials from env vars AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN
2023-06-21 12:15:43,788592 DEBUG aws.smithy.kotlin.runtime.identity.IdentityProviderChain op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - unable to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.EnvironmentCredentialsProvider@7fae4d4a: Missing value for environment variable `AWS_ACCESS_KEY_ID`
2023-06-21 12:15:43,789832 TRACE aws.smithy.kotlin.runtime.identity.IdentityProviderChain op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Attempting to resolve identity from aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider@4dd94a58
2023-06-21 12:15:43,794641 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Loading credentials from profile `dev-admin-west`
2023-06-21 12:15:43,798590 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Resolving credentials from process
2023-06-21 12:15:44,386989 DEBUG aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider op=S3.ListBuckets; sdkId=fd69722a-f502-49e4-b20e-a29ea9a1f557 - Obtained credentials from profile; expiration=2023-06-21T22:53:42Z
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
