### PR TITLE
feat: retry config overhaul and adaptive retries

### DIFF
--- a/.changes/2cca656d-2f6e-41ff-87ae-233465e3fe8d.json
+++ b/.changes/2cca656d-2f6e-41ff-87ae-233465e3fe8d.json
@@ -1,0 +1,8 @@
+{
+    "id": "2cca656d-2f6e-41ff-87ae-233465e3fe8d",
+    "type": "feature",
+    "description": "Add adaptive retry mode",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#701"
+    ]
+}

--- a/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
+++ b/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
@@ -1,7 +1,7 @@
 {
     "id": "c50a8d50-f66f-4598-8a58-f5c3dfc8302a",
     "type": "feature",
-    "description": "**Breaking**: Simplify mechanisms for setting/updating retry strategies in client config",
+    "description": "**Breaking**: Simplify mechanisms for setting/updating retry strategies in client config. See [this discussion post](https://github.com/awslabs/aws-sdk-kotlin/discussions/964) for more details.",
     "issues": [
         "awslabs/aws-sdk-kotlin#701"
     ]

--- a/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
+++ b/.changes/c50a8d50-f66f-4598-8a58-f5c3dfc8302a.json
@@ -1,0 +1,8 @@
+{
+    "id": "c50a8d50-f66f-4598-8a58-f5c3dfc8302a",
+    "type": "feature",
+    "description": "**Breaking**: Simplify mechanisms for setting/updating retry strategies in client config",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#701"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -112,14 +112,9 @@ object RuntimeTypes {
             val Outcome = symbol("Outcome")
             val RetryStrategy = symbol("RetryStrategy")
             val StandardRetryStrategy = symbol("StandardRetryStrategy")
-            val StandardRetryStrategyOptions = symbol("StandardRetryStrategyOptions")
 
             object Delay : RuntimeTypePackage(KotlinDependency.CORE, "retries.delay") {
-                val ExponentialBackoffWithJitter = symbol("ExponentialBackoffWithJitter")
-                val ExponentialBackoffWithJitterOptions = symbol("ExponentialBackoffWithJitterOptions")
                 val InfiniteTokenBucket = symbol("InfiniteTokenBucket")
-                val StandardRetryTokenBucket = symbol("StandardRetryTokenBucket")
-                val StandardRetryTokenBucketOptions = symbol("StandardRetryTokenBucketOptions")
             }
 
             object Policy : RuntimeTypePackage(KotlinDependency.CORE, "retries.policy") {
@@ -176,6 +171,9 @@ object RuntimeTypes {
         val SdkClient = symbol("SdkClient")
         val AbstractSdkClientBuilder = symbol("AbstractSdkClientBuilder")
         val LogMode = symbol("LogMode")
+        val RetryClientConfig = symbol("RetryClientConfig")
+        val RetryStrategyClientConfig = symbol("RetryStrategyClientConfig")
+        val RetryStrategyClientConfigImpl = symbol("RetryStrategyClientConfigImpl")
         val SdkClientConfig = symbol("SdkClientConfig")
         val SdkClientFactory = symbol("SdkClientFactory")
         val SdkClientOption = symbol("SdkClientOption")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigPropertyType.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/ConfigPropertyType.kt
@@ -9,6 +9,10 @@ package software.amazon.smithy.kotlin.codegen.rendering.util
  * Descriptor for how a configuration property is rendered when the configuration is built
  */
 sealed class ConfigPropertyType {
+    companion object {
+        val DoNotRender = Custom(render = { _, _ -> }, renderBuilder = { _, _ -> })
+    }
+
     /**
      * A property type that uses the symbol type and builder symbol directly
      */

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -42,7 +42,7 @@ class ServiceClientConfigGeneratorTest {
         contents.assertBalancedBracesAndParens()
 
         val expectedCtor = """
-public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, SdkClientConfig, TracingClientConfig {
+public class Config private constructor(builder: Builder) : HttpAuthConfig, HttpClientConfig, HttpEngineConfig by builder.buildHttpEngineConfig(), IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TracingClientConfig {
 """
         contents.shouldContainWithDiff(expectedCtor)
 
@@ -54,13 +54,12 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
-    override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, clientName)
 """
         contents.shouldContainWithDiff(expectedProps)
 
         val expectedBuilder = """
-    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, SdkClientConfig.Builder<Config>, TracingClientConfig.Builder {
+    public class Builder : HttpAuthConfig.Builder, HttpClientConfig.Builder, HttpEngineConfig.Builder by HttpEngineConfigImpl.BuilderImpl(), IdempotencyTokenConfig.Builder, RetryClientConfig.Builder, RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl(), SdkClientConfig.Builder<Config>, TracingClientConfig.Builder {
         /**
          * A reader-friendly name for the client.
          */
@@ -114,12 +113,6 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
          * The policy to use for evaluating operation results and determining whether/how to retry.
          */
         override var retryPolicy: RetryPolicy<Any?>? = null
-
-        /**
-         * The [RetryStrategy] implementation to use for service calls. All API calls will be wrapped by the
-         * strategy.
-         */
-        override var retryStrategy: RetryStrategy? = null
 
         /**
          * The tracer that is responsible for creating trace spans and wiring them up to a tracing backend (e.g.,
@@ -255,7 +248,6 @@ public class Config private constructor(builder: Builder) {
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest
     override val retryPolicy: RetryPolicy<Any?> = builder.retryPolicy ?: StandardRetryPolicy.Default
-    override val retryStrategy: RetryStrategy = builder.retryStrategy ?: StandardRetryStrategy()
     override val tracer: Tracer = builder.tracer ?: DefaultTracer(LoggingTraceProbe, clientName)"""
         contents.shouldContainWithDiff(expectedConfigValues)
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGeneratorTest.kt
@@ -73,7 +73,7 @@ class ServiceClientGeneratorTest {
 
     @Test
     fun `it generates config`() {
-        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, SdkClientConfig, TracingClientConfig"
+        val expected = "public class Config private constructor(builder: Builder) : IdempotencyTokenConfig, RetryClientConfig, RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig(), SdkClientConfig, TracingClientConfig"
         commonTestContents.shouldContainOnlyOnce(expected)
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/ServiceWaitersGeneratorTest.kt
@@ -78,17 +78,15 @@ class ServiceWaitersGeneratorTest {
     @Test
     fun testRetryStrategy() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 2_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 120_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-            
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 2_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 120_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContainOnlyOnce(expected)

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/WaiterGeneratorTest.kt
@@ -28,17 +28,15 @@ class WaiterGeneratorTest {
     @Test
     fun testDefaultDelays() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 2_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 120_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 2_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 120_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContain(expected)
@@ -47,17 +45,15 @@ class WaiterGeneratorTest {
     @Test
     fun testCustomDelays() {
         val expected = """
-            val strategy = run {
-                val delayOptions = ExponentialBackoffWithJitterOptions(
-                    initialDelay = 5_000.milliseconds,
-                    scaleFactor = 1.5,
-                    jitter = 1.0,
-                    maxBackoff = 30_000.milliseconds,
-                )
-                val delay = ExponentialBackoffWithJitter(delayOptions)
-
-                val waiterOptions = StandardRetryStrategyOptions(maxAttempts = 20)
-                StandardRetryStrategy(waiterOptions, InfiniteTokenBucket, delay)
+            val strategy = StandardRetryStrategy {
+                maxAttempts = 20
+                tokenBucket = InfiniteTokenBucket
+                delayProvider {
+                    initialDelay = 5_000.milliseconds
+                    scaleFactor = 1.5
+                    jitter = 1.0
+                    maxBackoff = 30_000.milliseconds
+                }
             }
         """.formatForTest()
         generated.shouldContainOnlyOnce(expected)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 # SDK
-sdkVersion=0.21.4-SNAPSHOT
+sdkVersion=0.22.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.8.10

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
@@ -12,10 +12,6 @@ import aws.smithy.kotlin.runtime.http.operation.roundTrip
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
-import aws.smithy.kotlin.runtime.retries.StandardRetryStrategyOptions
-import aws.smithy.kotlin.runtime.retries.delay.DelayProvider
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucketOptions
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
@@ -44,13 +40,7 @@ class RetryMiddlewareTest {
     fun testRetryMiddleware() = runTest {
         val req = HttpRequestBuilder()
         val op = newTestOperation<Unit, Unit>(req, Unit)
-
-        val delayProvider = DelayProvider { }
-        val strategy = StandardRetryStrategy(
-            StandardRetryStrategyOptions.Default,
-            StandardRetryTokenBucket(StandardRetryTokenBucketOptions.Default),
-            delayProvider,
-        )
+        val strategy = StandardRetryStrategy()
 
         op.execution.retryStrategy = strategy
         op.execution.retryPolicy = policy

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -944,6 +944,39 @@ public final class aws/smithy/kotlin/runtime/operation/ExecutionContext$Executio
 	public final fun setAttributes (Laws/smithy/kotlin/runtime/util/MutableAttributes;)V
 }
 
+public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy : aws/smithy/kotlin/runtime/retries/StandardRetryStrategy {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Companion;
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Builder;)V
+	public final fun getClientRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder {
+	public fun <init> ()V
+	public final fun clientRateLimiter (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun clientRateLimiter (Lkotlin/jvm/functions/Function1;)V
+	public final fun getClientRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;
+	public final fun setClientRateLimiter (Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;
+}
+
 public abstract class aws/smithy/kotlin/runtime/retries/Outcome {
 	public abstract fun getAttempts ()I
 }
@@ -1007,11 +1040,14 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$
 public abstract interface annotation class aws/smithy/kotlin/runtime/retries/RetryStrategyConfigDsl : java/lang/annotation/Annotation {
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy : aws/smithy/kotlin/runtime/retries/RetryStrategy {
+public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy : aws/smithy/kotlin/runtime/retries/RetryStrategy {
 	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion;
 	public fun <init> ()V
 	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;)V
 	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun afterTry (ILjava/lang/Object;Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun beforeInitialTry (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun beforeRetry (ILjava/lang/Object;Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
 	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
 	public fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1022,7 +1058,7 @@ public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Compa
 	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
 	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion;
 	public static final field DEFAULT_MAX_ATTEMPTS I
 	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder;)V
@@ -1032,7 +1068,7 @@ public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Confi
 	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
 	public fun <init> ()V
 	public final fun delayProvider (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
 	public final fun delayProvider (Lkotlin/jvm/functions/Function1;)V
@@ -1056,6 +1092,65 @@ public final class aws/smithy/kotlin/runtime/retries/TimedOutException : aws/smi
 
 public final class aws/smithy/kotlin/runtime/retries/TooManyAttemptsException : aws/smithy/kotlin/runtime/retries/RetryException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;Ljava/lang/Throwable;)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun acquire (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config;
+	public fun update (Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Builder;)V
+	public final fun getBeta ()D
+	public final fun getMeasurementBucketDuration-UwyO8pc ()J
+	public final fun getMinCapacity ()D
+	public final fun getMinFillRate ()D
+	public final fun getScaleConstant ()D
+	public final fun getSmoothing ()D
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config$Builder {
+	public fun <init> ()V
+	public final fun getBeta ()D
+	public final fun getMeasurementBucketDuration-UwyO8pc ()J
+	public final fun getMinCapacity ()D
+	public final fun getMinFillRate ()D
+	public final fun getScaleConstant ()D
+	public final fun getSmoothing ()D
+	public final fun setBeta (D)V
+	public final fun setMeasurementBucketDuration-LRDsOJo (J)V
+	public final fun setMinCapacity (D)V
+	public final fun setMinFillRate (D)V
+	public final fun setScaleConstant (D)V
+	public final fun setSmoothing (D)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter {
+	public abstract fun acquire (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config;
+	public abstract fun update (Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config$Builder {
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -990,42 +990,64 @@ public final class aws/smithy/kotlin/runtime/retries/RetryFailureException : aws
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
 }
 
-public abstract interface class aws/smithy/kotlin/runtime/retries/RetryOptions {
-	public abstract fun getMaxAttempts ()Ljava/lang/Integer;
-}
-
-public final class aws/smithy/kotlin/runtime/retries/RetryOptions$DefaultImpls {
-	public static fun getMaxAttempts (Laws/smithy/kotlin/runtime/retries/RetryOptions;)Ljava/lang/Integer;
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy {
-	public abstract fun getOptions ()Laws/smithy/kotlin/runtime/retries/RetryOptions;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
 	public abstract fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+	public abstract fun getMaxAttempts ()I
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+	public abstract fun getMaxAttempts ()I
+	public abstract fun setMaxAttempts (I)V
+}
+
+public abstract interface annotation class aws/smithy/kotlin/runtime/retries/RetryStrategyConfigDsl : java/lang/annotation/Annotation {
+}
+
 public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy : aws/smithy/kotlin/runtime/retries/RetryStrategy {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion;
 	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun getOptions ()Laws/smithy/kotlin/runtime/retries/RetryOptions;
-	public fun getOptions ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
 	public fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions : aws/smithy/kotlin/runtime/retries/RetryOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions$Companion;
-	public fun <init> (I)V
-	public final fun component1 ()I
-	public final fun copy (I)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
-	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;IILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getMaxAttempts ()Ljava/lang/Integer;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategyOptions;
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion;
+	public static final field DEFAULT_MAX_ATTEMPTS I
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+	public fun <init> ()V
+	public final fun delayProvider (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun delayProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public final fun setDelayProvider (Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
+	public fun setMaxAttempts (I)V
+	public final fun setTokenBucket (Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;)V
+	public final fun tokenBucket (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun tokenBucket (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion {
+	public final fun default ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/TimedOutException : aws/smithy/kotlin/runtime/retries/RetryException {
@@ -1038,41 +1060,60 @@ public final class aws/smithy/kotlin/runtime/retries/TooManyAttemptsException : 
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
 	public abstract fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter : aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Companion;
 	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOptions ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions$Companion;
-	public synthetic fun <init> (JDDJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-UwyO8pc ()J
-	public final fun component2 ()D
-	public final fun component3 ()D
-	public final fun component4-UwyO8pc ()J
-	public final fun copy-A4u-v98 (JDDJ)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
-	public static synthetic fun copy-A4u-v98$default (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;JDDJILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
-	public fun equals (Ljava/lang/Object;)Z
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Builder;)V
 	public final fun getInitialDelay-UwyO8pc ()J
 	public final fun getJitter ()D
 	public final fun getMaxBackoff-UwyO8pc ()J
 	public final fun getScaleFactor ()D
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterOptions;
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
+	public fun <init> ()V
+	public final fun getInitialDelay-UwyO8pc ()J
+	public final fun getJitter ()D
+	public final fun getMaxBackoff-UwyO8pc ()J
+	public final fun getScaleFactor ()D
+	public final fun setInitialDelay-LRDsOJo (J)V
+	public final fun setJitter (D)V
+	public final fun setMaxBackoff-LRDsOJo (J)V
+	public final fun setScaleFactor (D)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket;
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/RetryCapacityExceededException : aws/smithy/kotlin/runtime/ClientException {
@@ -1087,29 +1128,32 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTok
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
 	public abstract fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {
-	public fun <init> ()V
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;Lkotlin/time/TimeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getOptions ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions$Companion;
-	public fun <init> (IIZIIII)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()Z
-	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun component6 ()I
-	public final fun component7 ()I
-	public final fun copy (IIZIIII)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
-	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;IIZIIIIILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
-	public fun equals (Ljava/lang/Object;)Z
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder;)V
 	public final fun getCircuitBreakerMode ()Z
 	public final fun getInitialTryCost ()I
 	public final fun getInitialTrySuccessIncrement ()I
@@ -1117,12 +1161,29 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 	public final fun getRefillUnitsPerSecond ()I
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketOptions;
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
+	public fun <init> ()V
+	public final fun getCircuitBreakerMode ()Z
+	public final fun getInitialTryCost ()I
+	public final fun getInitialTrySuccessIncrement ()I
+	public final fun getMaxCapacity ()I
+	public final fun getRefillUnitsPerSecond ()I
+	public final fun getRetryCost ()I
+	public final fun getTimeoutRetryCost ()I
+	public final fun setCircuitBreakerMode (Z)V
+	public final fun setInitialTryCost (I)V
+	public final fun setInitialTrySuccessIncrement (I)V
+	public final fun setMaxCapacity (I)V
+	public final fun setRefillUnitsPerSecond (I)V
+	public final fun setRetryCost (I)V
+	public final fun setTimeoutRetryCost (I)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
 }
 
 public abstract class aws/smithy/kotlin/runtime/retries/policy/Acceptor {
@@ -1392,6 +1453,10 @@ public final class aws/smithy/kotlin/runtime/util/ConvenienceKt {
 }
 
 public final class aws/smithy/kotlin/runtime/util/CoroutineUtilsKt {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/util/DslFactory {
+	public abstract fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/util/EnvironmentProvider {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -962,15 +962,15 @@ public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Compa
 public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config {
 	public static final field Companion Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Companion;
 	public fun <init> (Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Builder;)V
-	public final fun getClientRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;
+	public final fun getRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/RateLimiter;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder {
 	public fun <init> ()V
-	public final fun clientRateLimiter (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
-	public final fun clientRateLimiter (Lkotlin/jvm/functions/Function1;)V
-	public final fun getClientRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;
-	public final fun setClientRateLimiter (Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter;)V
+	public final fun getRateLimiter ()Laws/smithy/kotlin/runtime/retries/delay/RateLimiter;
+	public final fun rateLimiter (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun rateLimiter (Lkotlin/jvm/functions/Function1;)V
+	public final fun setRateLimiter (Laws/smithy/kotlin/runtime/retries/delay/RateLimiter;)V
 }
 
 public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Companion {
@@ -1094,24 +1094,24 @@ public final class aws/smithy/kotlin/runtime/retries/TooManyAttemptsException : 
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;Ljava/lang/Throwable;)V
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Companion;
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;)V
-	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter : aws/smithy/kotlin/runtime/retries/delay/RateLimiter {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun acquire (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;
-	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config;
 	public fun update (Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
-	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter;
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter;
 	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config {
-	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Companion;
-	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Builder;)V
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config : aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config$Builder;)V
 	public final fun getBeta ()D
 	public final fun getMeasurementBucketDuration-UwyO8pc ()J
 	public final fun getMinCapacity ()D
@@ -1121,7 +1121,7 @@ public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLim
 	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config$Builder {
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config$Builder {
 	public fun <init> ()V
 	public final fun getBeta ()D
 	public final fun getMeasurementBucketDuration-UwyO8pc ()J
@@ -1137,20 +1137,8 @@ public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLim
 	public final fun setSmoothing (D)V
 }
 
-public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config$Companion {
-	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter$Config;
-}
-
-public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter {
-	public abstract fun acquire (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config;
-	public abstract fun update (Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config {
-}
-
-public abstract interface class aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter$Config$Builder {
+public final class aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter$Config;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
@@ -1209,6 +1197,18 @@ public final class aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket :
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket;
 	public fun acquireToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter {
+	public abstract fun acquire (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config;
+	public abstract fun update (Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config$Builder {
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/RetryCapacityExceededException : aws/smithy/kotlin/runtime/ClientException {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1249,31 +1249,31 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
 	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion;
 	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder;)V
-	public final fun getCircuitBreakerMode ()Z
 	public final fun getInitialTryCost ()I
 	public final fun getInitialTrySuccessIncrement ()I
 	public final fun getMaxCapacity ()I
 	public final fun getRefillUnitsPerSecond ()I
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
+	public final fun getUseCircuitBreakerMode ()Z
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
 	public fun <init> ()V
-	public final fun getCircuitBreakerMode ()Z
 	public final fun getInitialTryCost ()I
 	public final fun getInitialTrySuccessIncrement ()I
 	public final fun getMaxCapacity ()I
 	public final fun getRefillUnitsPerSecond ()I
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
-	public final fun setCircuitBreakerMode (Z)V
+	public final fun getUseCircuitBreakerMode ()Z
 	public final fun setInitialTryCost (I)V
 	public final fun setInitialTrySuccessIncrement (I)V
 	public final fun setMaxCapacity (I)V
 	public final fun setRefillUnitsPerSecond (I)V
 	public final fun setRetryCost (I)V
 	public final fun setTimeoutRetryCost (I)V
+	public final fun setUseCircuitBreakerMode (Z)V
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries
+
+import aws.smithy.kotlin.runtime.retries.delay.*
+import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import aws.smithy.kotlin.runtime.util.DslBuilderProperty
+import aws.smithy.kotlin.runtime.util.DslFactory
+
+/**
+ * Implements a retry strategy with exponential backoff, a token bucket for limiting retries, and a client-side
+ * rate limiter for achieving the ideal request rate. Note that the backoff delayer, token bucket, and rate limiter all
+ * work independently of each other. Any of the three may delay retries (and the rate limiter may delay the initial try
+ * as well).
+ * @param config The configuration for this retry strategy
+ */
+public class AdaptiveRetryStrategy(override val config: Config = Config.Default) : StandardRetryStrategy(config) {
+    public companion object : DslFactory<Config.Builder, AdaptiveRetryStrategy> {
+        override fun invoke(block: Config.Builder.() -> Unit): AdaptiveRetryStrategy =
+            AdaptiveRetryStrategy(Config(Config.Builder().apply(block)))
+    }
+
+    override suspend fun beforeInitialTry() {
+        super.beforeInitialTry()
+        config.clientRateLimiter.acquire(1)
+    }
+
+    override suspend fun <R> afterTry(
+        attempt: Int,
+        callResult: Result<R>,
+        evaluation: RetryDirective,
+        policy: RetryPolicy<R>,
+    ) {
+        super.afterTry(attempt, callResult, evaluation, policy)
+        val errorType = (evaluation as? RetryDirective.RetryError)?.reason
+        config.clientRateLimiter.update(errorType)
+    }
+
+    override suspend fun <R> beforeRetry(
+        attempt: Int,
+        callResult: Result<R>,
+        evaluation: RetryDirective,
+        policy: RetryPolicy<R>,
+    ) {
+        super.beforeRetry(attempt, callResult, evaluation, policy)
+        config.clientRateLimiter.acquire(1)
+    }
+
+    /**
+     * Configuration parameters for an adaptive retry strategy
+     */
+    public class Config(builder: Builder) : StandardRetryStrategy.Config(builder) {
+        public companion object {
+            /**
+             * The default configuration
+             */
+            public val Default: Config = Config(Builder())
+        }
+
+        /**
+         * The rate limiter which may delay initial tries or retries. Defaults to an [AdaptiveClientRateLimiter].
+         */
+        public val clientRateLimiter: ClientRateLimiter = builder.clientRateLimiterProperty.supply()
+
+        public class Builder : StandardRetryStrategy.Config.Builder() {
+            internal val clientRateLimiterProperty = DslBuilderProperty<ClientRateLimiter.Config.Builder, ClientRateLimiter>(
+                AdaptiveClientRateLimiter,
+                { config.toBuilderApplicator() },
+            )
+
+            /**
+             * The rate limiter which may delay initial tries or retries. Defaults to an [AdaptiveClientRateLimiter].
+             */
+            public var clientRateLimiter: ClientRateLimiter? by clientRateLimiterProperty::instance
+
+            public fun clientRateLimiter(block: AdaptiveClientRateLimiter.Config.Builder.() -> Unit) {
+                clientRateLimiterProperty.dsl(AdaptiveClientRateLimiter, block)
+            }
+
+            public fun <B : ClientRateLimiter.Config.Builder, C : ClientRateLimiter> clientRateLimiter(
+                factory: DslFactory<B, C>,
+                block: B.() -> Unit,
+            ) {
+                clientRateLimiterProperty.dsl(factory, block)
+            }
+        }
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/RetryStrategy.kt
@@ -5,16 +5,20 @@
 
 package aws.smithy.kotlin.runtime.retries
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+
+@DslMarker
+public annotation class RetryStrategyConfigDsl
 
 /**
  * A strategy for trying a block of code one or more times.
  */
 public interface RetryStrategy {
     /**
-     * Common retry strategy options
+     * The configured parameters for this strategy
      */
-    public val options: RetryOptions
+    public val config: Config
 
     /**
      * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
@@ -24,12 +28,25 @@ public interface RetryStrategy {
      * @return The successful [Outcome] of the final retry attempt.
      */
     public suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R>
-}
 
-public interface RetryOptions {
     /**
-     * Maximum retry attempts allowed by a strategy
+     * Options for configuring a retry strategy
      */
-    public val maxAttempts: Int?
-        get() = null
+    public interface Config {
+        /**
+         * Maximum retry attempts allowed by a strategy
+         */
+        public val maxAttempts: Int
+
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        @RetryStrategyConfigDsl
+        public interface Builder {
+            /**
+             * Maximum retry attempts allowed by a strategy
+             */
+            public var maxAttempts: Int
+        }
+    }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -168,7 +168,7 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
     private fun <R> throwTooManyAttempts(attempt: Int, result: Result<R>): Nothing =
         when (val ex = result.exceptionOrNull()) {
             null -> throw TooManyAttemptsException(
-                "Took more than ${config.maxAttempts} to get a successful response",
+                "Took more than ${config.maxAttempts} attempts to get a successful response",
                 null,
                 attempt,
                 result.getOrNull(),

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.CancellationException
  * Implements a retry strategy utilizing backoff delayer and a token bucket for rate limiting and circuit breaking. Note
  * that the backoff delayer and token bucket work independently of each other. Either can delay retries (and the token
  * bucket can delay the initial try). The delayer is called first so that the token bucket can refill as appropriate.
+ *
+ * [StandardRetryStrategy] is the recommended retry mode for the majority of use cases.
  * @param config The options that control the functionality of this strategy.
  */
 public open class StandardRetryStrategy(override val config: Config = Config.default()) : RetryStrategy {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/AdaptiveClientRateLimiter.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries.delay
+
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.util.DslFactory
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.time.*
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A client-side rate limiter backed by a token bucket. This limiter adaptively updates the refill rate of the bucket
+ * based on the number of successful transactions vs throttling errors. This limiter applies a smoothing function in an
+ * attempt to converge on the ideal transaction rate feasible for downstream systems.
+ */
+@OptIn(ExperimentalTime::class)
+public class AdaptiveClientRateLimiter internal constructor(
+    public override val config: Config = Config.Default,
+    private val timeSource: TimeSource,
+    private val rateMeasurer: AdaptiveRateMeasurer,
+    private val rateCalculator: CubicRateCalculator,
+) : ClientRateLimiter {
+    /**
+     * Initializes a new [AdaptiveClientRateLimiter]
+     * @param config The configuration parameters for this limiter
+     */
+    public constructor(config: Config = Config.Default) : this(
+        config,
+        TimeSource.Monotonic,
+        AdaptiveRateMeasurer(config, TimeSource.Monotonic),
+        CubicRateCalculator(config, TimeSource.Monotonic),
+    )
+
+    public companion object : DslFactory<Config.Builder, AdaptiveClientRateLimiter> {
+        /**
+         * Initializes a new [AdaptiveClientRateLimiter]
+         * @param block A DSL block which sets the configuration parameters for this limiter
+         */
+        public override operator fun invoke(block: Config.Builder.() -> Unit): AdaptiveClientRateLimiter =
+            AdaptiveClientRateLimiter(Config(Config.Builder().apply(block)))
+    }
+
+    private var capacity = 0.0
+    private var lastTimeMark: TimeMark? = null
+    internal var refillUnitsPerSecond = 0.0
+    private var maxCapacity = 0.0
+    private val mutex = Mutex()
+
+    override suspend fun acquire(cost: Int): Unit = mutex.withLock {
+        if (rateCalculator.throttlingEnabled) {
+            refillCapacity()
+            if (cost <= capacity) {
+                capacity -= cost
+            } else {
+                val extraRequiredCapacity = cost - capacity
+                val delayDuration = (extraRequiredCapacity / refillUnitsPerSecond).seconds
+                delay(delayDuration)
+                capacity = 0.0
+            }
+        }
+    }
+
+    private fun refillCapacity() {
+        lastTimeMark?.let {
+            val refillSeconds = it.elapsedNow().toDouble(DurationUnit.SECONDS)
+            val refillCapacity = refillUnitsPerSecond * refillSeconds
+            capacity = min(maxCapacity, capacity + refillCapacity)
+        }
+        lastTimeMark = timeSource.markNow()
+    }
+
+    override suspend fun update(errorType: RetryErrorType?): Unit = mutex.withLock {
+        val measuredTxRate = rateMeasurer.updateMeasuredRate()
+        val calculatedRate = rateCalculator.calculate(errorType, measuredTxRate, refillUnitsPerSecond)
+        val newRate = min(calculatedRate, 2 * measuredTxRate)
+        updateRefillRate(newRate)
+    }
+
+    private fun updateRefillRate(newRate: Double) {
+        refillCapacity()
+        refillUnitsPerSecond = max(newRate, config.minFillRate)
+        maxCapacity = max(newRate, config.minCapacity)
+        capacity = min(capacity, maxCapacity)
+    }
+
+    /**
+     * The configuration for an adaptive client-side rate limiter
+     */
+    public class Config(builder: Builder) : ClientRateLimiter.Config {
+        public companion object {
+            /**
+             * The default configuration
+             */
+            public val Default: Config = Config(Builder())
+        }
+
+        /**
+         * How much to scale back after receiving a throttling response. Ranges from 0.0 (do not scale back) to 1.0
+         * (scale back completely). Defaults to 0.7 (scale back 70%).
+         *
+         * **Note**: This is an advanced parameter and modifying it is not recommended.
+         */
+        public val beta: Double = builder.beta
+
+        /**
+         * The duration of individual measurement buckets used in measuring the effective transaction rate. Defaults to
+         * 0.5 seconds.
+         */
+        public val measurementBucketDuration: Duration = builder.measurementBucketDuration
+
+        /**
+         * The minimum capacity of permits. Defaults to 1.
+         */
+        public val minCapacity: Double = builder.minCapacity
+
+        /**
+         * The minimum refill rate (per second) of permits. Defaults to 0.5.
+         */
+        public val minFillRate: Double = builder.minFillRate
+
+        /**
+         * How much to scale up after receiving a successful response. Ranges from 0.0 (do not scale up) to 1.0 (scale
+         * up completely). Defaults to 0.4 (scale up 40%).
+         *
+         * **Note**: This is an advanced parameter and modifying it is not recommended.
+         */
+        public val scaleConstant: Double = builder.scaleConstant
+
+        /**
+         * The exponential smoothing factor to apply when measuring the effective rate of transactions. Ranges from 0.0
+         * (do not accept new rate updates) to 1.0 (immediately accept new rates with no smoothing). Defaults to 0.8
+         * (new rates are factored into the measured rate at 80%).
+         *
+         * **Note**: This is an advanced parameter and modifying it is not recommended.
+         */
+        public val smoothing: Double = builder.smoothing
+
+        override fun toBuilderApplicator(): ClientRateLimiter.Config.Builder.() -> Unit = {
+            if (this is Builder) {
+                beta = this@Config.beta
+                measurementBucketDuration = this@Config.measurementBucketDuration
+                minCapacity = this@Config.minCapacity
+                minFillRate = this@Config.minFillRate
+                scaleConstant = this@Config.scaleConstant
+                smoothing = this@Config.smoothing
+            }
+        }
+
+        public class Builder : ClientRateLimiter.Config.Builder {
+            /**
+             * How much to scale back after receiving a throttling response. Ranges from 0.0 (do not scale back) to 1.0
+             * (scale back completely). Defaults to 0.7 (scale back 70%).
+             *
+             * **Note**: This is an advanced parameter and modifying it is not recommended.
+             */
+            public var beta: Double = 0.7
+
+            /**
+             * The duration of individual measurement buckets used in measuring the effective transaction rate. Defaults
+             * to 0.5 seconds.
+             */
+            public var measurementBucketDuration: Duration = 0.5.seconds
+
+            /**
+             * The minimum capacity of permits. Defaults to 1.
+             */
+            public var minCapacity: Double = 1.0
+
+            /**
+             * The minimum refill rate (per second) of permits. Defaults to 0.5.
+             */
+            public var minFillRate: Double = 0.5
+
+            /**
+             * How much to scale up after receiving a successful response. Ranges from 0.0 (do not scale up) to 1.0
+             * (scale up completely). Defaults to 0.4 (scale up 40%).
+             *
+             * **Note**: This is an advanced parameter and modifying it is not recommended.
+             */
+            public var scaleConstant: Double = 0.4
+
+            /**
+             * The exponential smoothing factor to apply when measuring the effective rate of transactions. Ranges from
+             * 0.0 (do not accept new rate updates) to 1.0 (immediately accept new rates with no smoothing). Defaults to
+             * 0.8 (new rates are factored into the measured rate at 80%).
+             *
+             * **Note**: This is an advanced parameter and modifying it is not recommended.
+             */
+            public var smoothing: Double = 0.8
+        }
+    }
+}
+
+@OptIn(ExperimentalTime::class)
+internal class CubicRateCalculator(
+    private val config: AdaptiveClientRateLimiter.Config,
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+    internal var lastMaxRate: Double = 0.0,
+    internal var lastThrottleTime: TimeMark = timeSource.markNow(),
+) {
+    var throttlingEnabled: Boolean = false
+        private set
+
+    internal var timeWindow: Double = calculateTimeWindow()
+
+    fun calculate(
+        errorType: RetryErrorType?,
+        measuredTxRate: Double,
+        refillUnitsPerSecond: Double,
+    ): Double {
+        val calculatedRate = if (errorType == RetryErrorType.Throttling) {
+            lastMaxRate = if (throttlingEnabled) min(measuredTxRate, refillUnitsPerSecond) else measuredTxRate
+            timeWindow = calculateTimeWindow()
+            lastThrottleTime = timeSource.markNow()
+            throttlingEnabled = true
+            cubicThrottle(lastMaxRate)
+        } else {
+            cubicSuccess()
+        }
+
+        return calculatedRate
+    }
+
+    internal fun calculateTimeWindow() = ((lastMaxRate * (1 - config.beta)) / config.scaleConstant).pow(1.0 / 3)
+
+    internal fun cubicSuccess(): Double {
+        val deltaSeconds = lastThrottleTime.elapsedNow().toDouble(DurationUnit.SECONDS)
+        return (config.scaleConstant * (deltaSeconds - timeWindow).pow(3) + lastMaxRate)
+    }
+
+    internal fun cubicThrottle(rate: Double) = rate * config.beta
+}
+
+@OptIn(ExperimentalTime::class)
+internal class AdaptiveRateMeasurer(
+    private val config: AdaptiveClientRateLimiter.Config,
+    private val timeSource: TimeSource,
+    private var lastTxBucketMark: TimeMark = timeSource.markNow(),
+    internal var measuredTxRate: Double = 0.0,
+    private var requestCount: Int = 0,
+) {
+    private val bucketsPerSecond = 1 / config.measurementBucketDuration.toDouble(DurationUnit.SECONDS)
+
+    fun updateMeasuredRate(): Double {
+        requestCount++
+
+        val delta = lastTxBucketMark.elapsedNow()
+
+        val bucketDelta = floor(delta / config.measurementBucketDuration)
+
+        if (bucketDelta >= 1.0) {
+            val currentRate = requestCount / bucketDelta * bucketsPerSecond
+            measuredTxRate = (currentRate * config.smoothing) + (measuredTxRate * (1 - config.smoothing))
+
+            lastTxBucketMark = lastTxBucketMark + bucketDelta * config.measurementBucketDuration
+            requestCount = 0
+        }
+
+        return measuredTxRate
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/AdaptiveRateLimiter.kt
@@ -9,10 +9,7 @@ import aws.smithy.kotlin.runtime.util.DslFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.math.floor
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
+import kotlin.math.*
 import kotlin.time.*
 import kotlin.time.Duration.Companion.seconds
 
@@ -229,7 +226,7 @@ internal class CubicRateCalculator(
         return calculatedRate
     }
 
-    internal fun calculateTimeWindow() = ((lastMaxRate * (1 - config.beta)) / config.scaleConstant).pow(1.0 / 3)
+    internal fun calculateTimeWindow() = cbrt((lastMaxRate * (1 - config.beta)) / config.scaleConstant)
 
     internal fun cubicSuccess(): Double {
         val deltaSeconds = lastThrottleTime.elapsedNow().toDouble(DurationUnit.SECONDS)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/ClientRateLimiter.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries.delay
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+
+/**
+ * A client-side utility that can limit the rate of transactions. This limiter is usually backed by some set of permits
+ * which refill over time. This kind of rate limiting is often used in conjunction with a retry algorithm, especially
+ * when it may be desirable to delay the initial attempt of a transaction (instead of just delaying subsequent
+ * attempts).
+ *
+ * Callers should invoke [acquire] with the cost of their transaction prior to executing. If
+ * there are not enough permits available currently, the call may delay.
+ *
+ * Once the transaction is completed, callers should invoke [update] and indicate the type of error (if any) the
+ * transaction yielded. The rate limiter may use this information to adjust the number of available permits or the rate
+ * of permit renewal.
+ */
+public interface ClientRateLimiter {
+    public val config: Config
+
+    /**
+     * Acquire a "permit" to conduct a transaction. If not enough permits are available, this method may delay.
+     * @param cost The relative cost of the transaction. Some transactions may take more work or represent a bundle of
+     * smaller transactions.
+     */
+    public suspend fun acquire(cost: Int)
+
+    /**
+     * Update the rate limiter with the result of a transaction. The rate limiter may use this information to adjust the
+     * number of available permits or the rate at which permits refill.
+     * @param errorType The type of error that resulted from the last transaction. A value of `null` indicates the
+     * transaction was successful.
+     */
+    public suspend fun update(errorType: RetryErrorType?)
+
+    public interface Config {
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        public interface Builder
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/DelayProvider.kt
@@ -5,13 +5,32 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
+
 /**
  * An object that can be used to delay between iterations of code.
  */
-public fun interface DelayProvider {
+public interface DelayProvider {
+    public val config: Config
+
     /**
      * Delays for an appropriate amount of time after the given attempt number.
      * @param attempt The ordinal index of the attempt, used in calculating the exact amount of time to delay.
      */
     public suspend fun backoff(attempt: Int)
+
+    /**
+     * Configuration for a delay provider
+     */
+    public interface Config {
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        /**
+         * A builder for configs for delay providers
+         */
+        @RetryStrategyConfigDsl
+        public interface Builder
+    }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/InfiniteTokenBucket.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 
 /**
@@ -12,6 +13,11 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
  * operations immediately succeed and no blocking occurs.
  */
 public object InfiniteTokenBucket : RetryTokenBucket {
+    override val config: RetryTokenBucket.Config = object : RetryTokenBucket.Config {
+        @InternalApi
+        override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = { }
+    }
+
     override suspend fun acquireToken(): RetryToken = object : RetryToken {
         override suspend fun notifyFailure() = Unit
         override suspend fun notifySuccess() = Unit

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RateLimiter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RateLimiter.kt
@@ -20,7 +20,7 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
  * transaction yielded. The rate limiter may use this information to adjust the number of available permits or the rate
  * of permit renewal.
  */
-public interface ClientRateLimiter {
+public interface RateLimiter {
     public val config: Config
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
@@ -24,7 +24,7 @@ public interface RetryTokenBucket {
     public suspend fun acquireToken(): RetryToken
 
     /**
-     * Configuration for a tucket bucket
+     * Configuration for a token bucket
      */
     public interface Config {
         @InternalApi

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket.kt
@@ -6,18 +6,36 @@
 package aws.smithy.kotlin.runtime.retries.delay
 
 import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 
 /**
  * A rate-limiting token bucket for use in a client-throttled retry strategy.
  */
 public interface RetryTokenBucket {
+    public val config: Config
+
     /**
      * Acquire a token from the token bucket. This method should be called before the initial retry attempt for a block
      * of code. This method may delay if there are already insufficient tokens in the bucket due to prior retry
      * failures or large numbers of simultaneous requests.
      */
     public suspend fun acquireToken(): RetryToken
+
+    /**
+     * Configuration for a tucket bucket
+     */
+    public interface Config {
+        @InternalApi
+        public fun toBuilderApplicator(): Builder.() -> Unit
+
+        /**
+         * A builder for configs for token buckets
+         */
+        @RetryStrategyConfigDsl
+        public interface Builder
+    }
 }
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -5,29 +5,41 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.util.DslFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.min
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeSource
 
-private const val MS_PER_S = 1_000
-
 /**
  * The standard implementation of a [RetryTokenBucket].
- * @param options The configuration to use for this bucket.
+ * @param config The configuration to use for this bucket.
  * @param timeSource A monotonic time source to use for calculating the temporal token fill of the bucket.
  */
 @OptIn(ExperimentalTime::class)
-public class StandardRetryTokenBucket constructor(
-    public val options: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions.Default,
-    private val timeSource: TimeSource = TimeSource.Monotonic,
+public class StandardRetryTokenBucket internal constructor(
+    override val config: Config,
+    private val timeSource: TimeSource,
 ) : RetryTokenBucket {
-    internal var capacity = options.maxCapacity
+    /**
+     * Initializes a new [StandardRetryTokenBucket].
+     */
+    public constructor(options: Config = Config.Default) : this(options, timeSource = TimeSource.Monotonic)
+
+    public companion object : DslFactory<Config.Builder, StandardRetryTokenBucket> {
+        override fun invoke(block: Config.Builder.() -> Unit): StandardRetryTokenBucket =
+            StandardRetryTokenBucket(Config(Config.Builder().apply(block)))
+    }
+
+    internal var capacity = config.maxCapacity
         private set
 
     private var lastTimeMark = timeSource.markNow()
@@ -39,8 +51,8 @@ public class StandardRetryTokenBucket constructor(
      * failures or large numbers of simultaneous requests.
      */
     override suspend fun acquireToken(): RetryToken {
-        checkoutCapacity(options.initialTryCost)
-        return StandardRetryToken(options.initialTrySuccessIncrement)
+        checkoutCapacity(config.initialTryCost)
+        return StandardRetryToken(config.initialTrySuccessIncrement)
     }
 
     private suspend fun checkoutCapacity(size: Int): Unit = mutex.withLock {
@@ -49,13 +61,13 @@ public class StandardRetryTokenBucket constructor(
         if (size <= capacity) {
             capacity -= size
         } else {
-            if (options.circuitBreakerMode) {
+            if (config.circuitBreakerMode) {
                 throw RetryCapacityExceededException("Insufficient capacity to attempt another retry")
             }
 
             val extraRequiredCapacity = size - capacity
-            val delayMs = ceil(extraRequiredCapacity.toDouble() / options.refillUnitsPerSecond * MS_PER_S).toLong()
-            delay(delayMs)
+            val delayDuration = ceil(extraRequiredCapacity.toDouble() / config.refillUnitsPerSecond).seconds
+            delay(delayDuration)
             capacity = 0
         }
 
@@ -63,15 +75,15 @@ public class StandardRetryTokenBucket constructor(
     }
 
     private fun refillCapacity() {
-        val refillMs = lastTimeMark.elapsedNow().inWholeMilliseconds
-        val refillSize = floor(options.refillUnitsPerSecond.toDouble() / MS_PER_S * refillMs).toInt()
-        capacity = min(options.maxCapacity, capacity + refillSize)
+        val refillSeconds = lastTimeMark.elapsedNow().toDouble(DurationUnit.SECONDS)
+        val refillSize = floor(config.refillUnitsPerSecond * refillSeconds).toInt()
+        capacity = min(config.maxCapacity, capacity + refillSize)
     }
 
     private suspend fun returnCapacity(size: Int): Unit = mutex.withLock {
         refillCapacity()
 
-        capacity = min(options.maxCapacity, capacity + size)
+        capacity = min(config.maxCapacity, capacity + size)
         lastTimeMark = timeSource.markNow()
     }
 
@@ -79,7 +91,7 @@ public class StandardRetryTokenBucket constructor(
      * A standard implementation of a [RetryToken].
      * @param returnSize The amount of capacity to return to the bucket on a successful try.
      */
-    internal inner class StandardRetryToken(public val returnSize: Int) : RetryToken {
+    internal inner class StandardRetryToken(private val returnSize: Int) : RetryToken {
         /**
          * Completes this token because retrying has been abandoned. This implementation doesn't actually increment any
          * capacity upon failure...capacity just refills based on time.
@@ -100,48 +112,127 @@ public class StandardRetryTokenBucket constructor(
          */
         override suspend fun scheduleRetry(reason: RetryErrorType): RetryToken {
             val size = when (reason) {
-                RetryErrorType.Transient, RetryErrorType.Throttling -> options.timeoutRetryCost
-                else -> options.retryCost
+                RetryErrorType.Transient, RetryErrorType.Throttling -> config.timeoutRetryCost
+                else -> config.retryCost
             }
             checkoutCapacity(size)
             return StandardRetryToken(size)
         }
     }
-}
 
-/**
- * The configuration options for a [StandardRetryTokenBucket].
- * @param maxCapacity The maximum capacity for the bucket.
- * @param refillUnitsPerSecond The amount of capacity to return per second.
- * @param circuitBreakerMode When true, indicates that attempts to acquire tokens or schedule retries should fail if all
- * capacity has been depleted. When false, calls to acquire tokens or schedule retries will delay until sufficient
- * capacity is available.
- * @param retryCost The amount of capacity to decrement for standard retries.
- * @param timeoutRetryCost The amount of capacity to decrement for timeout or throttling retries.
- * @param initialTryCost The amount of capacity to decrement for the initial try.
- * @param initialTrySuccessIncrement The amount of capacity to return if the initial try is successful.
- */
-public data class StandardRetryTokenBucketOptions(
-    public val maxCapacity: Int,
-    public val refillUnitsPerSecond: Int,
-    public val circuitBreakerMode: Boolean,
-    public val retryCost: Int,
-    public val timeoutRetryCost: Int,
-    public val initialTryCost: Int,
-    public val initialTrySuccessIncrement: Int,
-) {
-    public companion object {
+    /**
+     * Options for configuring a [StandardRetryTokenBucket]
+     */
+    public class Config(builder: Builder) : RetryTokenBucket.Config {
+        public companion object {
+            /**
+             * The default configuration to use
+             */
+            public val Default: Config = Config(Builder())
+
+            /**
+             * Initializes a new config instance
+             * @param block A DSL builder block which sets the parameters for this config
+             */
+            public operator fun invoke(block: Builder.() -> Unit): Config = Config(Builder().apply(block))
+        }
+
         /**
-         * The default configuration for a [StandardRetryTokenBucket].
+         * When `true`, indicates that attempts to acquire tokens or schedule retries should fail if all capacity has
+         * been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient capacity
+         * is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
          */
-        public val Default: StandardRetryTokenBucketOptions = StandardRetryTokenBucketOptions(
-            maxCapacity = 500,
-            refillUnitsPerSecond = 10,
-            circuitBreakerMode = false,
-            retryCost = 5,
-            timeoutRetryCost = 10,
-            initialTryCost = 0,
-            initialTrySuccessIncrement = 1,
-        )
+        public val circuitBreakerMode: Boolean = builder.circuitBreakerMode
+
+        /**
+         * The amount of capacity to decrement for the initial try
+         */
+        public val initialTryCost: Int = builder.initialTryCost
+
+        /**
+         * The amount of capacity to return if the initial try is successful
+         */
+        public val initialTrySuccessIncrement: Int = builder.initialTrySuccessIncrement
+
+        /**
+         * The maximum capacity for the bucket
+         */
+        public val maxCapacity: Int = builder.maxCapacity
+
+        /**
+         * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
+         * `true`.
+         */
+        public val refillUnitsPerSecond: Int = builder.refillUnitsPerSecond
+
+        /**
+         * The amount of capacity to decrement for standard retries
+         */
+        public val retryCost: Int = builder.retryCost
+
+        /**
+         * The amount of capacity to decrement for timeout or throttling retries
+         */
+        public val timeoutRetryCost: Int = builder.timeoutRetryCost
+
+        @InternalApi
+        override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = {
+            if (this is Builder) {
+                circuitBreakerMode = this@Config.circuitBreakerMode
+                initialTryCost = this@Config.initialTryCost
+                initialTrySuccessIncrement = this@Config.initialTrySuccessIncrement
+                maxCapacity = this@Config.maxCapacity
+                refillUnitsPerSecond = this@Config.refillUnitsPerSecond
+                retryCost = this@Config.retryCost
+                timeoutRetryCost = this@Config.timeoutRetryCost
+            }
+        }
+
+        /**
+         * A mutable builder for a [Config]
+         */
+        public class Builder : RetryTokenBucket.Config.Builder {
+            /**
+             * When `true`, indicates that attempts to acquire tokens or schedule retries should fail if all capacity
+             * has been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient
+             * capacity is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
+             */
+            public var circuitBreakerMode: Boolean = true
+
+            /**
+             * The amount of capacity to decrement for the initial try
+             */
+            public var initialTryCost: Int = 0
+
+            /**
+             * The amount of capacity to return if the initial try is successful
+             */
+            public var initialTrySuccessIncrement: Int = 1
+
+            /**
+             * The maximum capacity for the bucket
+             */
+            public var maxCapacity: Int = 500
+
+            /**
+             * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
+             * `true`.
+             */
+            public var refillUnitsPerSecond: Int = 0
+                set(value) {
+                    if (value == 0) circuitBreakerMode = true
+                    field = value
+                }
+
+            /**
+             * The amount of capacity to decrement for standard retries
+             */
+            public var retryCost: Int = 5
+
+            /**
+             * The amount of capacity to decrement for timeout or throttling retries
+             */
+            public var timeoutRetryCost: Int = 10
+        }
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -61,7 +61,7 @@ public class StandardRetryTokenBucket internal constructor(
         if (size <= capacity) {
             capacity -= size
         } else {
-            if (config.circuitBreakerMode) {
+            if (config.useCircuitBreakerMode) {
                 throw RetryCapacityExceededException("Insufficient capacity to attempt another retry")
             }
 
@@ -142,7 +142,7 @@ public class StandardRetryTokenBucket internal constructor(
          * been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient capacity
          * is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
          */
-        public val circuitBreakerMode: Boolean = builder.circuitBreakerMode
+        public val useCircuitBreakerMode: Boolean = builder.useCircuitBreakerMode
 
         /**
          * The amount of capacity to decrement for the initial try
@@ -160,7 +160,7 @@ public class StandardRetryTokenBucket internal constructor(
         public val maxCapacity: Int = builder.maxCapacity
 
         /**
-         * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
+         * The amount of capacity to return per second. Setting this to 0 automatically sets [useCircuitBreakerMode] to
          * `true`.
          */
         public val refillUnitsPerSecond: Int = builder.refillUnitsPerSecond
@@ -178,7 +178,7 @@ public class StandardRetryTokenBucket internal constructor(
         @InternalApi
         override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = {
             if (this is Builder) {
-                circuitBreakerMode = this@Config.circuitBreakerMode
+                useCircuitBreakerMode = this@Config.useCircuitBreakerMode
                 initialTryCost = this@Config.initialTryCost
                 initialTrySuccessIncrement = this@Config.initialTrySuccessIncrement
                 maxCapacity = this@Config.maxCapacity
@@ -197,7 +197,7 @@ public class StandardRetryTokenBucket internal constructor(
              * has been depleted. When `false`, calls to acquire tokens or schedule retries will delay until sufficient
              * capacity is available. This property will automatically be set to `true` if [refillUnitsPerSecond] is 0.
              */
-            public var circuitBreakerMode: Boolean = true
+            public var useCircuitBreakerMode: Boolean = true
 
             /**
              * The amount of capacity to decrement for the initial try
@@ -215,12 +215,12 @@ public class StandardRetryTokenBucket internal constructor(
             public var maxCapacity: Int = 500
 
             /**
-             * The amount of capacity to return per second. Setting this to 0 automatically sets [circuitBreakerMode] to
-             * `true`.
+             * The amount of capacity to return per second. Setting this to 0 automatically sets [useCircuitBreakerMode]
+             * to `true`.
              */
             public var refillUnitsPerSecond: Int = 0
                 set(value) {
-                    if (value == 0) circuitBreakerMode = true
+                    if (value == 0) useCircuitBreakerMode = true
                     field = value
                 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslBuilderProperty.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+
+/**
+ * Encapsulates a mutable property for a complex (i.e., non-scalar) type meant to be modified in a mutable builder
+ * implementation. This single property provides an [instance] field for setting a literal value and two [dsl] overloads
+ * for providing configuration for a dynamically-constructed instance. Note that callers should not _read_ the value of
+ * [instance] and should instead use the [supply] function.
+ *
+ * @param SuperBuilder The topmost class/interface for valid builder instances for this property. Any subtype builders
+ * must inherit/implement this type. Instances of [SuperBuilder] should build to a [SuperBuilt] instance.
+ * @param SuperBuilt The topmost class/interface for valid _built_ instances of this property. Any subtypes must
+ * inherit/implement this type.
+ * @param defaultFactory The default factory type to use for constructing new instances. This default type will be used
+ * if no specific instance has been set and no [dsl] invocation has specified a different factory.
+ * @param toBuilderApplicator A method that can turn a built instance (i.e., of [SuperBuilt]) into an applicator
+ * function that applies the built properties to a builder instance.
+ * @param managedTransform An optional transformation that will apply to instances built from [dsl] but not instances
+ * set directly on [instance]. This is useful for example when applying management wrappers around types whose lifetime
+ * will be managed by the runtime, not by callers.
+ */
+@InternalApi
+public class DslBuilderProperty<SuperBuilder, SuperBuilt>(
+    private val defaultFactory: DslFactory<SuperBuilder, SuperBuilt>,
+    private val toBuilderApplicator: SuperBuilt.() -> (SuperBuilder.() -> Unit),
+    private val managedTransform: (SuperBuilt) -> SuperBuilt = { it },
+) {
+    private var configApplicator: SuperBuilder.() -> Unit = { }
+    private var factory: DslFactory<SuperBuilder, SuperBuilt> = defaultFactory
+    private var state = SupplierState.NOT_INITIALIZED
+
+    /**
+     * Yields the final instance of this property, either directly from [instance] or as built given the factory and
+     * DSL block passed to [dsl].
+     */
+    public var supply: () -> SuperBuilt = { managedTransform(factory { }) }
+        private set
+
+    /**
+     * Sets the value of this property to a literal instance. Note that callers should not _read_ the value of
+     * [instance] and should instead use the [supply] function.
+     */
+    public var instance: SuperBuilt? = null
+        set(value) {
+            state = when (state) {
+                SupplierState.NOT_INITIALIZED -> SupplierState.INITIALIZED
+                else -> SupplierState.EXPLICIT_INSTANCE
+            }
+
+            field = value
+            supply = when (value) {
+                null -> {
+                    // Reset factory back to default
+                    factory = defaultFactory
+                    { managedTransform(factory { }) }
+                }
+                else -> { { value } }
+            }
+
+            configApplicator = value?.toBuilderApplicator() ?: { }
+        }
+
+    /**
+     * Configure a builder for this property value.
+     * @param SubBuilder The subtype of the [SuperBuilder] type which describes the specific type being used for the DSL
+     * block.
+     * @param SubBuilt The subtype of the [SuperBuilt] type which describes the specific type of instance which will be
+     * built.
+     * @param factory The factory which can turn a builder into a built instance. The specific [SubBuilder] type of this
+     * factory will be used in the DSL block.
+     * @param block A DSL block which is applied to the builder instance before being built.
+     */
+    public fun <SubBuilder : SuperBuilder, SubBuilt : SuperBuilt> dsl(
+        factory: DslFactory<SubBuilder, SubBuilt>,
+        block: SubBuilder.() -> Unit,
+    ) {
+        when (state) {
+            SupplierState.EXPLICIT_INSTANCE -> throw ClientException("An explicit instance is already configured and its configuration cannot be modified")
+            else -> state = SupplierState.EXPLICIT_CONFIG
+        }
+
+        this.factory = factory
+
+        val previousApplicator = configApplicator
+        configApplicator = {
+            previousApplicator()
+
+            try {
+                // This should be safe to cast if no one tried to change the type from before.
+                @Suppress("UNCHECKED_CAST")
+                this as SubBuilder
+            } catch (e: ClassCastException) {
+                // Otherwise, throw an exception!
+                throw ClientException(
+                    "Cannot change DSL property type after initially setting it to ${this!!::class.simpleName}",
+                    e,
+                )
+            }
+
+            block(this)
+        }
+        supply = { managedTransform(factory(configApplicator)) }
+    }
+}
+
+private enum class SupplierState {
+    NOT_INITIALIZED,
+    INITIALIZED,
+    EXPLICIT_CONFIG,
+    EXPLICIT_INSTANCE,
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslFactory.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/DslFactory.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+/**
+ * A factory type that can turn a [Builder] instance into a [Built] instance. Implementing this factory type can enable
+ * usage of custom classes in DSL builders.
+ */
+public interface DslFactory<out Builder, out Built> {
+    /**
+     * Turns a [Builder] instance into a [Built] instance, first applying the given DSL block to the builder.
+     * @param block A DSL block to apply to the builder.
+     */
+    public operator fun invoke(block: Builder.() -> Unit): Built
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.TestTimeSource
 import kotlin.time.TimeSource
@@ -29,9 +30,9 @@ class StandardRetryTokenBucketTest {
         val bucket = tokenBucket(initialTryCost = 10)
 
         assertEquals(10, bucket.capacity)
-        assertTime(0) { bucket.acquireToken() }
+        assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(0, bucket.capacity)
-        assertTime(1000) { bucket.acquireToken() }
+        assertTime(1.seconds) { bucket.acquireToken() }
     }
 
     @Test
@@ -40,9 +41,9 @@ class StandardRetryTokenBucketTest {
         val bucket = tokenBucket(initialTryCost = 5, initialTrySuccessIncrement = 3)
 
         assertEquals(10, bucket.capacity)
-        val initialToken = assertTime(0) { bucket.acquireToken() }
+        val initialToken = assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(5, bucket.capacity)
-        assertTime(0) { initialToken.notifySuccess() }
+        assertTime(0.seconds) { initialToken.notifySuccess() }
         assertEquals(8, bucket.capacity)
     }
 
@@ -52,9 +53,9 @@ class StandardRetryTokenBucketTest {
         val bucket = tokenBucket(initialTryCost = 1)
 
         assertEquals(10, bucket.capacity)
-        val initialToken = assertTime(0) { bucket.acquireToken() }
+        val initialToken = assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(9, bucket.capacity)
-        assertTime(0) { initialToken.notifyFailure() }
+        assertTime(0.seconds) { initialToken.notifyFailure() }
         assertEquals(9, bucket.capacity)
     }
 
@@ -69,9 +70,9 @@ class StandardRetryTokenBucketTest {
             val bucket = tokenBucket()
 
             assertEquals(10, bucket.capacity)
-            val initialToken = assertTime(0) { bucket.acquireToken() }
+            val initialToken = assertTime(0.seconds) { bucket.acquireToken() }
             assertEquals(10, bucket.capacity)
-            assertTime(0) { initialToken.scheduleRetry(errorType) }
+            assertTime(0.seconds) { initialToken.scheduleRetry(errorType) }
             assertEquals(10 - cost, bucket.capacity)
         }
     }
@@ -84,13 +85,13 @@ class StandardRetryTokenBucketTest {
         val bucket = tokenBucket(initialTryCost = 5, timeSource = timeSource)
 
         assertEquals(10, bucket.capacity)
-        assertTime(0) { bucket.acquireToken() }
+        assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(5, bucket.capacity)
 
         // Refill rate is 10/s == 1/100ms so after 250ms we should have 2 more tokens.
         timeSource += 250.milliseconds
 
-        assertTime(0) { bucket.acquireToken() }
+        assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(2, bucket.capacity) // We had 5, 2 refilled, and then we decremented 5 more.
     }
 
@@ -100,7 +101,7 @@ class StandardRetryTokenBucketTest {
         val bucket = tokenBucket(initialTryCost = 10, circuitBreakerMode = true)
 
         assertEquals(10, bucket.capacity)
-        assertTime(0) { bucket.acquireToken() }
+        assertTime(0.seconds) { bucket.acquireToken() }
         assertEquals(0, bucket.capacity)
         val result = runCatching { bucket.acquireToken() }
         assertIs<RetryCapacityExceededException>(result.exceptionOrNull())

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -7,32 +7,26 @@ package aws.smithy.kotlin.runtime.retries.delay
 
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.TestTimeSource
+import kotlin.time.TimeSource
 
+private const val DEFAULT_RETRY_COST = 2
+private const val DEFAULT_TIMEOUT_RETRY_COST = 3
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class StandardRetryTokenBucketTest {
-    companion object {
-        private val DefaultOptions = StandardRetryTokenBucketOptions(
-            maxCapacity = 10,
-            refillUnitsPerSecond = 10,
-            circuitBreakerMode = false,
-            retryCost = 2,
-            timeoutRetryCost = 3,
-            initialTryCost = 0,
-            initialTrySuccessIncrement = 1,
-        )
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testWaitForCapacity() = runTest {
         // A bucket that only allows one initial try per second
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 10))
+        val bucket = tokenBucket(initialTryCost = 10)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -40,11 +34,10 @@ class StandardRetryTokenBucketTest {
         assertTime(1000) { bucket.acquireToken() }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testReturnCapacityOnSuccess() = runTest {
         // A bucket that costs capacity for an initial try and doesn't return the same capacity (for easy measuring)
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 5, initialTrySuccessIncrement = 3))
+        val bucket = tokenBucket(initialTryCost = 5, initialTrySuccessIncrement = 3)
 
         assertEquals(10, bucket.capacity)
         val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -53,11 +46,10 @@ class StandardRetryTokenBucketTest {
         assertEquals(8, bucket.capacity)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testNoCapacityChangeOnFailure() = runTest {
         // A bucket that costs capacity for an initial try
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 1))
+        val bucket = tokenBucket(initialTryCost = 1)
 
         assertEquals(10, bucket.capacity)
         val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -66,16 +58,15 @@ class StandardRetryTokenBucketTest {
         assertEquals(9, bucket.capacity)
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testRetryCapacityAdjustments() = runTest {
         mapOf(
-            RetryErrorType.Throttling to DefaultOptions.timeoutRetryCost,
-            RetryErrorType.Transient to DefaultOptions.timeoutRetryCost,
-            RetryErrorType.ClientSide to DefaultOptions.retryCost,
-            RetryErrorType.ServerSide to DefaultOptions.retryCost,
+            RetryErrorType.Throttling to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.Transient to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.ClientSide to DEFAULT_RETRY_COST,
+            RetryErrorType.ServerSide to DEFAULT_RETRY_COST,
         ).forEach { (errorType, cost) ->
-            val bucket = StandardRetryTokenBucket(DefaultOptions)
+            val bucket = tokenBucket()
 
             assertEquals(10, bucket.capacity)
             val initialToken = assertTime(0) { bucket.acquireToken() }
@@ -85,13 +76,12 @@ class StandardRetryTokenBucketTest {
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
     @Test
     fun testRefillOverTime() = runTest {
         val timeSource = TestTimeSource()
 
         // A bucket that costs capacity for an initial try
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 5), timeSource)
+        val bucket = tokenBucket(initialTryCost = 5, timeSource = timeSource)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -104,11 +94,10 @@ class StandardRetryTokenBucketTest {
         assertEquals(2, bucket.capacity) // We had 5, 2 refilled, and then we decremented 5 more.
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testCircuitBreakerMode() = runTest {
         // A bucket that only allows one initial try per second
-        val bucket = StandardRetryTokenBucket(DefaultOptions.copy(initialTryCost = 10, circuitBreakerMode = true))
+        val bucket = tokenBucket(initialTryCost = 10, circuitBreakerMode = true)
 
         assertEquals(10, bucket.capacity)
         assertTime(0) { bucket.acquireToken() }
@@ -116,4 +105,27 @@ class StandardRetryTokenBucketTest {
         val result = runCatching { bucket.acquireToken() }
         assertIs<RetryCapacityExceededException>(result.exceptionOrNull())
     }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+private fun TestScope.tokenBucket(
+    circuitBreakerMode: Boolean = false,
+    initialTryCost: Int = 0,
+    initialTrySuccessIncrement: Int = 1,
+    maxCapacity: Int = 10,
+    refillUnitsPerSecond: Int = 10,
+    retryCost: Int = DEFAULT_RETRY_COST,
+    timeoutRetryCost: Int = DEFAULT_TIMEOUT_RETRY_COST,
+    timeSource: TimeSource = testTimeSource,
+): StandardRetryTokenBucket {
+    val config = StandardRetryTokenBucket.Config {
+        this.circuitBreakerMode = circuitBreakerMode
+        this.initialTryCost = initialTryCost
+        this.initialTrySuccessIncrement = initialTrySuccessIncrement
+        this.maxCapacity = maxCapacity
+        this.refillUnitsPerSecond = refillUnitsPerSecond
+        this.retryCost = retryCost
+        this.timeoutRetryCost = timeoutRetryCost
+    }
+    return StandardRetryTokenBucket(config, timeSource)
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -98,7 +98,7 @@ class StandardRetryTokenBucketTest {
     @Test
     fun testCircuitBreakerMode() = runTest {
         // A bucket that only allows one initial try per second
-        val bucket = tokenBucket(initialTryCost = 10, circuitBreakerMode = true)
+        val bucket = tokenBucket(initialTryCost = 10, useCircuitBreakerMode = true)
 
         assertEquals(10, bucket.capacity)
         assertTime(0.seconds) { bucket.acquireToken() }
@@ -110,7 +110,7 @@ class StandardRetryTokenBucketTest {
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 private fun TestScope.tokenBucket(
-    circuitBreakerMode: Boolean = false,
+    useCircuitBreakerMode: Boolean = false,
     initialTryCost: Int = 0,
     initialTrySuccessIncrement: Int = 1,
     maxCapacity: Int = 10,
@@ -120,7 +120,7 @@ private fun TestScope.tokenBucket(
     timeSource: TimeSource = testTimeSource,
 ): StandardRetryTokenBucket {
     val config = StandardRetryTokenBucket.Config {
-        this.circuitBreakerMode = circuitBreakerMode
+        this.useCircuitBreakerMode = useCircuitBreakerMode
         this.initialTryCost = initialTryCost
         this.initialTrySuccessIncrement = initialTrySuccessIncrement
         this.maxCapacity = maxCapacity

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/DslBuilderPropertyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/DslBuilderPropertyTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.util
+
+import aws.smithy.kotlin.runtime.ClientException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+private const val DEFAULT_COLOR = "(unknown)"
+private const val DEFAULT_DOORS = 4
+private const val DEFAULT_GEARS = 1
+
+class DslBuilderPropertyTest {
+    @Test
+    fun testSetInstance() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.instance = OrangeMtnBike
+        assertEquals(OrangeMtnBike, prop.supply())
+
+        // Test reset back to default factory
+        prop.instance = null
+        val actual = prop.supply()
+        assertIs<Car>(actual)
+        assertEquals(DEFAULT_COLOR, actual.config.color)
+        assertEquals(DEFAULT_DOORS, actual.config.doors)
+    }
+
+    @Test
+    fun testSetDsl() {
+        val prop = vehicleProp()
+
+        prop.dsl(Bike) { color = "yellow" }
+        var actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("yellow", actual.config.color)
+        assertEquals(DEFAULT_GEARS, actual.config.gears)
+
+        prop.dsl(Bike) { gears = 5 }
+        actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("yellow", actual.config.color)
+        assertEquals(5, actual.config.gears)
+
+        prop.dsl(Bike) { color = "purple" }
+        actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals("purple", actual.config.color)
+        assertEquals(5, actual.config.gears)
+    }
+
+    @Test
+    fun testSetDslAfterInitialInstance() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.dsl(Car) {
+            assertEquals(BlueCoupe.config.color, color)
+            assertEquals(BlueCoupe.config.doors, doors)
+
+            doors = 4
+        }
+
+        val actual = prop.supply()
+        assertIs<Car>(actual)
+        assertEquals(BlueCoupe.config.color, actual.config.color)
+        assertEquals(4, actual.config.doors)
+    }
+
+    @Test
+    fun testSetDslAfterInitialInstanceAndChangeType() {
+        val prop = vehicleProp()
+
+        prop.instance = BlueCoupe
+        assertEquals(BlueCoupe, prop.supply())
+
+        prop.dsl(Bike) {
+            assertEquals(BlueCoupe.config.color, color)
+
+            gears = 10
+        }
+
+        val actual = prop.supply()
+        assertIs<Bike>(actual)
+        assertEquals(BlueCoupe.config.color, actual.config.color)
+        assertEquals(10, actual.config.gears)
+    }
+
+    @Test
+    fun testStateWithInstanceFirst() {
+        val prop = vehicleProp() // SupplierState.NOT_INITIALIZED
+
+        prop.instance = BlueCoupe // SupplierState.INITIALIZED
+
+        prop.instance = OrangeMtnBike // SupplierState.EXPLICIT_INSTANCE
+
+        assertThrows<ClientException> { // Cannot switch from EXPLICIT_INSTANCE to EXPLICIT_CONFIG
+            prop.dsl(Bike) { }
+        }
+    }
+
+    @Test
+    fun testStateWithConfigFirst() {
+        val prop = vehicleProp() // SupplierState.NOT_INITIALIZED
+
+        prop.instance = BlueCoupe // SupplierState.INITIALIZED
+
+        prop.dsl(Bike) { } // SupplierState.EXPLICIT_CONFIG
+
+        prop.instance = OrangeMtnBike // SupplierState.EXPLICIT_INSTANCE
+
+        assertThrows<ClientException> { // Cannot switch from EXPLICIT_INSTANCE to EXPLICIT_CONFIG
+            prop.dsl(Car) { }
+        }
+    }
+}
+
+private fun vehicleProp(managedTransform: (Vehicle) -> Vehicle = { it }) =
+    DslBuilderProperty<Vehicle.Config.Builder, Vehicle>(Car, Vehicle::toBuilderApplicator, managedTransform)
+
+// Super interfaces for a DSL
+private interface Vehicle {
+    fun toBuilderApplicator(): (Config.Builder.() -> Unit)
+
+    interface Config {
+        val color: String
+        interface Builder {
+            var color: String?
+        }
+    }
+}
+
+// Subtypes for the DSL
+private class Car(val config: Config) : Vehicle {
+    companion object : DslFactory<Config.Builder, Car> {
+        override fun invoke(block: Config.Builder.() -> Unit) = Car(Config(Config.Builder().apply(block)))
+    }
+
+    override fun toBuilderApplicator(): Vehicle.Config.Builder.() -> Unit = {
+        color = config.color
+        if (this is Config.Builder) {
+            doors = config.doors
+        }
+    }
+
+    class Config(builder: Builder) : Vehicle.Config {
+        override val color: String = builder.color ?: DEFAULT_COLOR
+        val doors: Int = builder.doors ?: DEFAULT_DOORS
+
+        class Builder : Vehicle.Config.Builder {
+            override var color: String? = null
+            var doors: Int? = null
+        }
+    }
+}
+private val BlueCoupe = Car { color = "blue"; doors = 2 }
+
+private class Bike(val config: Config) : Vehicle {
+    companion object : DslFactory<Config.Builder, Bike> {
+        override fun invoke(block: Config.Builder.() -> Unit) = Bike(Config(Config.Builder().apply(block)))
+    }
+
+    override fun toBuilderApplicator(): Vehicle.Config.Builder.() -> Unit = {
+        color = config.color
+        if (this is Config.Builder) {
+            gears = config.gears
+        }
+    }
+
+    class Config(builder: Builder) : Vehicle.Config {
+        override val color: String = builder.color ?: DEFAULT_COLOR
+        val gears: Int = builder.gears ?: DEFAULT_GEARS
+
+        class Builder : Vehicle.Config.Builder {
+            override var color: String? = null
+            var gears: Int? = null
+        }
+    }
+}
+private val OrangeMtnBike = Bike { color = "orange"; gears = 9 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries.impl
+
+import aws.smithy.kotlin.runtime.retries.delay.AdaptiveClientRateLimiter
+import aws.smithy.kotlin.runtime.retries.delay.AdaptiveRateMeasurer
+import aws.smithy.kotlin.runtime.retries.delay.CubicRateCalculator
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TimeSource
+
+private const val TOLERANCE = 0.0000005
+
+@OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+class AdaptiveRetryIntegrationTest {
+    @Test
+    fun testCubicCases() = runTest {
+        val timeSource = testTimeSource as TimeSource.WithComparableMarks
+        val testCases = adaptiveRetryCubicTestCases.deserialize(CubicTestCase.serializer())
+
+        testCases.forEach { (name, tc) ->
+            val start = timeSource.markNow()
+            val tsSecondsToTimeMark = { timestamp: Double -> start + timestamp.seconds }
+
+            val rateCalculator = CubicRateCalculator(
+                AdaptiveClientRateLimiter.Config.Default,
+                timeSource,
+                lastMaxRate = tc.given.lastMaxRate,
+                lastThrottleTime = tsSecondsToTimeMark(tc.given.lastThrottleTimeSeconds),
+            )
+
+            var lastCalculatedRate = tc.given.lastMaxRate
+            tc.cases.forEachIndexed { idx, case ->
+                val caseTimeMark = tsSecondsToTimeMark(case.tsSeconds)
+                val delayDuration = caseTimeMark - timeSource.markNow()
+                delay(delayDuration)
+
+                lastCalculatedRate = when (case.response) {
+                    ResponseType.Success -> {
+                        rateCalculator.timeWindow = rateCalculator.calculateTimeWindow()
+                        rateCalculator.cubicSuccess()
+                    }
+                    ResponseType.Throttle -> {
+                        rateCalculator.lastMaxRate = lastCalculatedRate
+                        rateCalculator.timeWindow = rateCalculator.calculateTimeWindow()
+                        rateCalculator.lastThrottleTime = tsSecondsToTimeMark(case.tsSeconds)
+                        rateCalculator.cubicThrottle(lastCalculatedRate)
+                    }
+                }
+
+                assertEquals(
+                    case.calculatedRate,
+                    lastCalculatedRate,
+                    TOLERANCE,
+                    "Expected matching calculated rate for test $name, index $idx",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testE2eCases() = runTest {
+        val timeSource = testTimeSource as TimeSource.WithComparableMarks
+        val testCases = adaptiveRetryE2eTestCases.deserialize(E2eTestCase.serializer())
+        val config = AdaptiveClientRateLimiter.Config.Default
+        val rateMeasurer = AdaptiveRateMeasurer(config, timeSource)
+        val rateCalculator = CubicRateCalculator(config, timeSource)
+        val rateLimiter = AdaptiveClientRateLimiter(config, timeSource, rateMeasurer, rateCalculator)
+
+        testCases.forEach { (name, tc) ->
+            val start = timeSource.markNow()
+            val tsSecondsToTimeMark = { timestamp: Double -> start + timestamp.seconds }
+
+            tc.cases.forEachIndexed { idx, case ->
+                val caseTimeMark = tsSecondsToTimeMark(case.tsSeconds)
+                val delayDuration = caseTimeMark - timeSource.markNow()
+                delay(delayDuration)
+
+                rateLimiter.update(case.response.errorType)
+
+                assertEquals(
+                    case.newTokenBucketRate,
+                    rateLimiter.refillUnitsPerSecond,
+                    TOLERANCE,
+                    "Expected matching refill rate for test $name, index $idx",
+                )
+
+                assertEquals(
+                    case.measuredTxRate,
+                    rateMeasurer.measuredTxRate,
+                    TOLERANCE,
+                    "Expected matching refill rate for test $name, index $idx",
+                )
+            }
+        }
+    }
+}

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTest.kt
@@ -4,7 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.retries.impl
 
-import aws.smithy.kotlin.runtime.retries.delay.AdaptiveClientRateLimiter
+import aws.smithy.kotlin.runtime.retries.delay.AdaptiveRateLimiter
 import aws.smithy.kotlin.runtime.retries.delay.AdaptiveRateMeasurer
 import aws.smithy.kotlin.runtime.retries.delay.CubicRateCalculator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,14 +24,14 @@ class AdaptiveRetryIntegrationTest {
     @Test
     fun testCubicCases() = runTest {
         val timeSource = testTimeSource as TimeSource.WithComparableMarks
-        val testCases = adaptiveRetryCubicTestCases.deserialize(CubicTestCase.serializer())
+        val testCases = adaptiveRetryCubicTestCases.deserializeYaml(CubicTestCase.serializer())
 
         testCases.forEach { (name, tc) ->
             val start = timeSource.markNow()
             val tsSecondsToTimeMark = { timestamp: Double -> start + timestamp.seconds }
 
             val rateCalculator = CubicRateCalculator(
-                AdaptiveClientRateLimiter.Config.Default,
+                AdaptiveRateLimiter.Config.Default,
                 timeSource,
                 lastMaxRate = tc.given.lastMaxRate,
                 lastThrottleTime = tsSecondsToTimeMark(tc.given.lastThrottleTimeSeconds),
@@ -69,11 +69,11 @@ class AdaptiveRetryIntegrationTest {
     @Test
     fun testE2eCases() = runTest {
         val timeSource = testTimeSource as TimeSource.WithComparableMarks
-        val testCases = adaptiveRetryE2eTestCases.deserialize(E2eTestCase.serializer())
-        val config = AdaptiveClientRateLimiter.Config.Default
+        val testCases = adaptiveRetryE2eTestCases.deserializeYaml(E2eTestCase.serializer())
+        val config = AdaptiveRateLimiter.Config.Default
         val rateMeasurer = AdaptiveRateMeasurer(config, timeSource)
         val rateCalculator = CubicRateCalculator(config, timeSource)
-        val rateLimiter = AdaptiveClientRateLimiter(config, timeSource, rateMeasurer, rateCalculator)
+        val rateLimiter = AdaptiveRateLimiter(config, timeSource, rateMeasurer, rateCalculator)
 
         testCases.forEach { (name, tc) ->
             val start = timeSource.markNow()

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTestResources.kt
@@ -8,6 +8,7 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// Test cases sourced from "new-retries" specification.
 val adaptiveRetryCubicTestCases = mapOf(
     "Cubic success #1" to // language=YAML
         """
@@ -71,6 +72,7 @@ val adaptiveRetryCubicTestCases = mapOf(
         """.trimIndent(),
 )
 
+// Test cases sourced from "new-retries" specification.
 val adaptiveRetryE2eTestCases = mapOf(
     "End-to-end test for client sending rates" to // language=YAML
         """

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/AdaptiveRetryIntegrationTestResources.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries.impl
+
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+val adaptiveRetryCubicTestCases = mapOf(
+    "Cubic success #1" to // language=YAML
+        """
+            given:
+              last_max_rate: 10
+              last_throttle_time: 5
+            cases:
+              - response: success
+                timestamp: 5
+                calculated_rate: 7.0
+              - response: success
+                timestamp: 6
+                calculated_rate: 9.64893600966
+              - response: success
+                timestamp: 7
+                calculated_rate: 10.000030849917364
+              - response: success
+                timestamp: 8
+                calculated_rate: 10.453284520772092
+              - response: success
+                timestamp: 9
+                calculated_rate: 13.408697022224185
+              - response: success
+                timestamp: 10
+                calculated_rate: 21.26626835427364
+              - response: success
+                timestamp: 11
+                calculated_rate: 36.425998516920465
+        """.trimIndent(),
+
+    "Cubic success #2" to // language=YAML
+        """
+            given:
+              last_max_rate: 10
+              last_throttle_time: 5
+            cases:
+              - response: success
+                timestamp: 5
+                calculated_rate: 7
+              - response: success
+                timestamp: 6
+                calculated_rate: 9.64893600966
+              - response: throttle
+                timestamp: 7
+                calculated_rate: 6.754255206761999
+              - response: throttle
+                timestamp: 8
+                calculated_rate: 4.727978644733399
+              - response: success
+                timestamp: 9
+                calculated_rate: 6.606547753887045
+              - response: success
+                timestamp: 10
+                calculated_rate: 6.763279816944947
+              - response: success
+                timestamp: 11
+                calculated_rate: 7.598174833907107
+              - response: success
+                timestamp: 12
+                calculated_rate: 11.511232804773524
+        """.trimIndent(),
+)
+
+val adaptiveRetryE2eTestCases = mapOf(
+    "End-to-end test for client sending rates" to // language=YAML
+        """
+            cases:
+              - response: success
+                timestamp: 0.2
+                measured_tx_rate: 0.000000
+                new_token_bucket_rate: 0.500000
+              - response: success
+                timestamp: 0.4
+                measured_tx_rate: 0.000000
+                new_token_bucket_rate: 0.500000
+              - response: success
+                timestamp: 0.6
+                measured_tx_rate: 4.800000
+                new_token_bucket_rate: 0.500000
+              - response: success
+                timestamp: 0.8
+                measured_tx_rate: 4.800000
+                new_token_bucket_rate: 0.500000
+              - response: success
+                timestamp: 1.0
+                measured_tx_rate: 4.160000
+                new_token_bucket_rate: 0.500000
+              - response: success
+                timestamp: 1.2
+                measured_tx_rate: 4.160000
+                new_token_bucket_rate: 0.691200
+              - response: success
+                timestamp: 1.4
+                measured_tx_rate: 4.160000
+                new_token_bucket_rate: 1.097600
+              - response: success
+                timestamp: 1.6
+                measured_tx_rate: 5.632000
+                new_token_bucket_rate: 1.638400
+              - response: success
+                timestamp: 1.8
+                measured_tx_rate: 5.632000
+                new_token_bucket_rate: 2.332800
+              - response: throttle
+                timestamp: 2.0
+                measured_tx_rate: 4.326400
+                new_token_bucket_rate: 3.028480
+              - response: success
+                timestamp: 2.2
+                measured_tx_rate: 4.326400
+                new_token_bucket_rate: 3.486639
+              - response: success
+                timestamp: 2.4
+                measured_tx_rate: 4.326400
+                new_token_bucket_rate: 3.821874
+              - response: success
+                timestamp: 2.6
+                measured_tx_rate: 5.665280
+                new_token_bucket_rate: 4.053386
+              - response: success
+                timestamp: 2.8
+                measured_tx_rate: 5.665280
+                new_token_bucket_rate: 4.200373
+              - response: success
+                timestamp: 3.0
+                measured_tx_rate: 4.333056
+                new_token_bucket_rate: 4.282037
+              - response: throttle
+                timestamp: 3.2
+                measured_tx_rate: 4.333056
+                new_token_bucket_rate: 2.997426
+              - response: success
+                timestamp: 3.4
+                measured_tx_rate: 4.333056
+                new_token_bucket_rate: 3.452226
+        """.trimIndent(),
+)
+
+/* ktlint-disable annotation spacing-between-declarations-with-annotations */
+
+@Serializable
+enum class ResponseType(val errorType: RetryErrorType?) {
+    @SerialName("success") Success(null),
+    @SerialName("throttle") Throttle(RetryErrorType.Throttling),
+}
+
+@Serializable
+data class CubicTestCase(val given: Given, val cases: List<Case>) {
+    @Serializable
+    data class Given(
+        @SerialName("last_max_rate") val lastMaxRate: Double,
+        @SerialName("last_throttle_time") val lastThrottleTimeSeconds: Double,
+    )
+
+    @Serializable
+    data class Case(
+        @SerialName("response") val response: ResponseType,
+        @SerialName("timestamp") val tsSeconds: Double,
+        @SerialName("calculated_rate") val calculatedRate: Double,
+    )
+}
+
+@Serializable
+data class E2eTestCase(val cases: List<Case>) {
+    @Serializable
+    data class Case(
+        @SerialName("response") val response: ResponseType,
+        @SerialName("timestamp") val tsSeconds: Double,
+        @SerialName("measured_tx_rate") val measuredTxRate: Double,
+        @SerialName("new_token_bucket_rate") val newTokenBucketRate: Double,
+    )
+}
+
+/* ktlint-enable annotation spacing-between-declarations-with-annotations */

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -22,7 +22,7 @@ class StandardRetryIntegrationTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testIntegrationCases() = runTest {
-        val testCases = standardRetryIntegrationTestCases.deserialize(StandardRetryTestCase.serializer())
+        val testCases = standardRetryIntegrationTestCases.deserializeYaml(StandardRetryTestCase.serializer())
         testCases.forEach { (name, tc) ->
             val tokenBucket = StandardRetryTokenBucket { maxCapacity = tc.given.initialRetryTokens }
             val retryer = StandardRetryStrategy {

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -5,11 +5,10 @@
 
 package aws.smithy.kotlin.runtime.retries.impl
 
-import aws.smithy.kotlin.runtime.retries.*
-import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
-import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitterOptions
+import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.TooManyAttemptsException
 import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucketOptions
+import aws.smithy.kotlin.runtime.retries.getOrThrow
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
@@ -29,23 +28,17 @@ class StandardRetryIntegrationTest {
         val testCases = standardRetryIntegrationTestCases
             .mapValues { Yaml.default.decodeFromString(TestCase.serializer(), it.value) }
         testCases.forEach { (name, tc) ->
-            val options = StandardRetryStrategyOptions(maxAttempts = tc.given.maxAttempts)
-            val tokenBucket = StandardRetryTokenBucket(
-                StandardRetryTokenBucketOptions.Default.copy(
-                    maxCapacity = tc.given.initialRetryTokens,
-                    circuitBreakerMode = true,
-                    refillUnitsPerSecond = 0, // None of the tests use refill
-                ),
-            )
-            val delayer = ExponentialBackoffWithJitter(
-                ExponentialBackoffWithJitterOptions(
-                    initialDelay = tc.given.exponentialBase.milliseconds,
-                    scaleFactor = tc.given.exponentialPower,
-                    jitter = 0.0, // None of the tests use jitter
-                    maxBackoff = tc.given.maxBackoffTime.milliseconds,
-                ),
-            )
-            val retryer = StandardRetryStrategy(options, tokenBucket, delayer)
+            val tokenBucket = StandardRetryTokenBucket { maxCapacity = tc.given.initialRetryTokens }
+            val retryer = StandardRetryStrategy {
+                maxAttempts = tc.given.maxAttempts
+                this.tokenBucket = tokenBucket
+                delayProvider {
+                    initialDelay = tc.given.exponentialBase.milliseconds
+                    scaleFactor = tc.given.exponentialPower
+                    jitter = 0.0 // None of the tests use jitter
+                    maxBackoff = tc.given.maxBackoffTime.milliseconds
+                }
+            }
 
             val block = object {
                 var index = 0
@@ -64,7 +57,7 @@ class StandardRetryIntegrationTest {
                 else -> fail("Unexpected outcome for $name: ${finalState.outcome}")
             }
 
-            val expectedDelayMs = tc.responses.map { it.expected.delay ?: 0 }.sum()
+            val expectedDelayMs = tc.responses.mapNotNull { it.expected.delay }.sum()
             if (finalState.outcome == TestOutcome.RetryQuotaExceeded) {
                 // The retry quota exceeded tests assume that the delayer won't be called when the bucket's out of
                 // capacity but that assumes no refill which is not the case most of the time. Rather than add

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTestResources.kt
@@ -5,6 +5,9 @@
 
 package aws.smithy.kotlin.runtime.retries.impl
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 val standardRetryIntegrationTestCases = mapOf(
     "Retry eventually succeeds" to // language=YAML
         """
@@ -32,7 +35,7 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: success
                   retry_quota: 495
-        """.trimMargin(),
+        """.trimIndent(),
 
     "Fail due to max attempts reached" to // language=YAML
         """
@@ -62,7 +65,7 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: max_attempts_exceeded
                   retry_quota: 490
-        """.trimMargin(),
+        """.trimIndent(),
 
     "Retry Quota reached after a single retry" to // language=YAML
         """
@@ -84,7 +87,7 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: retry_quota_exceeded
                   retry_quota: 0
-        """.trimMargin(),
+        """.trimIndent(),
 
     "No retries at all if retry quota is 0" to // language=YAML
         """
@@ -100,7 +103,7 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: retry_quota_exceeded
                   retry_quota: 0
-        """.trimMargin(),
+        """.trimIndent(),
 
     "Verifying exponential backoff timing" to //language=YAML
         """
@@ -142,7 +145,7 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: max_attempts_exceeded
                   retry_quota: 480
-        """.trimMargin(),
+        """.trimIndent(),
 
     "Verify max backoff time" to // language=YAML
         """
@@ -184,5 +187,38 @@ val standardRetryIntegrationTestCases = mapOf(
                 expected:
                   outcome: max_attempts_exceeded
                   retry_quota: 480
-        """.trimMargin(),
+        """.trimIndent(),
 )
+
+/* ktlint-disable annotation spacing-between-declarations-with-annotations */
+
+@Serializable
+data class StandardRetryTestCase(val given: Given, val responses: List<ResponseAndExpectation>)
+
+@Serializable
+data class Given(
+    @SerialName("max_attempts") val maxAttempts: Int,
+    @SerialName("initial_retry_tokens") val initialRetryTokens: Int,
+    @SerialName("exponential_base") val exponentialBase: Double,
+    @SerialName("exponential_power") val exponentialPower: Double,
+    @SerialName("max_backoff_time") val maxBackoffTime: Int,
+)
+
+@Serializable
+data class ResponseAndExpectation(val response: Response, val expected: Expectation)
+
+@Serializable
+data class Response(@SerialName("status_code") val statusCode: Int)
+
+@Serializable
+data class Expectation(val outcome: TestOutcome, @SerialName("retry_quota") val retryQuota: Int, val delay: Int? = null)
+
+@Serializable
+enum class TestOutcome {
+    @SerialName("max_attempts_exceeded") MaxAttemptsExceeded,
+    @SerialName("retry_quota_exceeded") RetryQuotaExceeded,
+    @SerialName("retry_request") RetryRequest,
+    @SerialName("success") Success,
+}
+
+/* ktlint-enable annotation spacing-between-declarations-with-annotations */

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTestResources.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.retries.impl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// Test cases sourced from "new-retries" specification.
 val standardRetryIntegrationTestCases = mapOf(
     "Retry eventually succeeds" to // language=YAML
         """

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/Utils.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/Utils.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries.impl
+
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.DeserializationStrategy
+
+fun <T> Map<String, String>.deserialize(serializer: DeserializationStrategy<T>): Map<String, T> =
+    mapValues { Yaml.default.decodeFromString(serializer, it.value) }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/Utils.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/Utils.kt
@@ -7,5 +7,5 @@ package aws.smithy.kotlin.runtime.retries.impl
 import com.charleskorn.kaml.Yaml
 import kotlinx.serialization.DeserializationStrategy
 
-fun <T> Map<String, String>.deserialize(serializer: DeserializationStrategy<T>): Map<String, T> =
+fun <T> Map<String, String>.deserializeYaml(serializer: DeserializationStrategy<T>): Map<String, T> =
     mapValues { Yaml.default.decodeFromString(serializer, it.value) }

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -145,6 +145,26 @@ public abstract interface class aws/smithy/kotlin/runtime/client/ResponseInterce
 	public abstract fun getResponse-d1pmJ48 ()Ljava/lang/Object;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryClientConfig : aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig {
+	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryClientConfig$Builder {
+	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
+	public abstract fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig {
+	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig$Builder {
+	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+	public abstract fun retryStrategy (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun retryStrategy (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient : java/io/Closeable {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/client/SdkClientConfig;
 }
@@ -156,19 +176,13 @@ public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient$Build
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig {
 	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getLogMode ()Laws/smithy/kotlin/runtime/client/LogMode;
-	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
-	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientConfig$Builder : aws/smithy/kotlin/runtime/util/Buildable {
 	public abstract fun getClientName ()Ljava/lang/String;
 	public abstract fun getLogMode ()Laws/smithy/kotlin/runtime/client/LogMode;
-	public abstract fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
-	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 	public abstract fun setClientName (Ljava/lang/String;)V
 	public abstract fun setLogMode (Laws/smithy/kotlin/runtime/client/LogMode;)V
-	public abstract fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
-	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClientFactory {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/RetryClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/RetryClientConfig.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.client
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.RetryStrategy
+import aws.smithy.kotlin.runtime.retries.RetryStrategyConfigDsl
+import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import aws.smithy.kotlin.runtime.util.DslBuilderProperty
+import aws.smithy.kotlin.runtime.util.DslFactory
+
+public interface RetryClientConfig : RetryStrategyClientConfig {
+    /**
+     * The policy to use for evaluating operation results and determining whether/how to retry.
+     */
+    public val retryPolicy: RetryPolicy<Any?>
+
+    public interface Builder {
+        /**
+         * The policy to use for evaluating operation results and determining whether/how to retry.
+         */
+        public var retryPolicy: RetryPolicy<Any?>?
+    }
+}
+
+public interface RetryStrategyClientConfig {
+    /**
+     * The [RetryStrategy] the client will use to retry failed operations.
+     */
+    public val retryStrategy: RetryStrategy
+
+    @RetryStrategyConfigDsl
+    public interface Builder {
+        public fun retryStrategy(block: StandardRetryStrategy.Config.Builder.() -> Unit)
+
+        public fun <B : RetryStrategy.Config.Builder, R : RetryStrategy> retryStrategy(
+            factory: DslFactory<B, R>,
+            block: B.() -> Unit,
+        )
+
+        /**
+         * The [RetryStrategy] the client will use to retry failed operations.
+         */
+        public var retryStrategy: RetryStrategy?
+
+        @InternalApi
+        public fun buildRetryStrategyClientConfig(): RetryStrategyClientConfig
+    }
+}
+
+@InternalApi
+public class RetryStrategyClientConfigImpl private constructor(
+    override val retryStrategy: RetryStrategy,
+) : RetryStrategyClientConfig {
+    @InternalApi
+    public class BuilderImpl : RetryStrategyClientConfig.Builder {
+        private val retryStrategyProperty = DslBuilderProperty<RetryStrategy.Config.Builder, RetryStrategy>(
+            StandardRetryStrategy,
+            { config.toBuilderApplicator() },
+        )
+
+        override var retryStrategy: RetryStrategy? by retryStrategyProperty::instance
+
+        override fun retryStrategy(block: StandardRetryStrategy.Config.Builder.() -> Unit) {
+            retryStrategyProperty.dsl(StandardRetryStrategy, block)
+        }
+
+        override fun <B : RetryStrategy.Config.Builder, R : RetryStrategy> retryStrategy(
+            factory: DslFactory<B, R>,
+            block: B.() -> Unit,
+        ) {
+            retryStrategyProperty.dsl(factory, block)
+        }
+
+        @InternalApi
+        override fun buildRetryStrategyClientConfig(): RetryStrategyClientConfig =
+            RetryStrategyClientConfigImpl(retryStrategyProperty.supply())
+    }
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/SdkClientConfig.kt
@@ -4,8 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.client
 
-import aws.smithy.kotlin.runtime.retries.RetryStrategy
-import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.util.Buildable
 
 /**
@@ -28,16 +26,6 @@ public interface SdkClientConfig {
      * debug purposes.
      */
     public val logMode: LogMode
-
-    /**
-     * The policy to use for evaluating operation results and determining whether/how to retry.
-     */
-    public val retryPolicy: RetryPolicy<Any?>
-
-    /**
-     * The [RetryStrategy] the client will use to retry failed operations.
-     */
-    public val retryStrategy: RetryStrategy
 
     /**
      * Configurable properties that all client configuration exposes.
@@ -63,15 +51,5 @@ public interface SdkClientConfig {
          * debug purposes.
          */
         public var logMode: LogMode?
-
-        /**
-         * The policy to use for evaluating operation results and determining whether/how to retry.
-         */
-        public var retryPolicy: RetryPolicy<Any?>?
-
-        /**
-         * Configure the [RetryStrategy] the client will use to retry failed operations.
-         */
-        public var retryStrategy: RetryStrategy?
     }
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -20,12 +20,17 @@ public enum class RetryMode {
     /**
      * The standard retry mode. With this, the client will use the
      * [StandardRetryStrategy][aws.smithy.kotlin.runtime.retries.StandardRetryStrategy].
+     *
+     * This is the recommended retry mode for the majority of use cases.
      */
     STANDARD,
 
     /**
      * Adaptive retry mode. With this, the client will use the
      * [AdaptiveRetryStrategy][aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy].
+     *
+     * **Note**: The adaptive retry strategy is an advanced mode. It is not recommended for typical use cases. In most
+     * cases, [STANDARD] is the preferred retry mode.
      */
     ADAPTIVE,
 }

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -18,12 +18,14 @@ public enum class RetryMode {
     LEGACY,
 
     /**
-     * The standard retry mode. With this, the client will use the [StandardRetryStrategy][aws.smithy.kotlin.runtime.retries.StandardRetryStrategy]
+     * The standard retry mode. With this, the client will use the
+     * [StandardRetryStrategy][aws.smithy.kotlin.runtime.retries.StandardRetryStrategy].
      */
     STANDARD,
 
     /**
-     * Not implemented yet. https://github.com/awslabs/aws-sdk-kotlin/issues/701
+     * Adaptive retry mode. With this, the client will use the
+     * [AdaptiveRetryStrategy][aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy].
      */
     ADAPTIVE,
 }


### PR DESCRIPTION
## Issue \#

Closes [aws-sdk-kotlin#701](https://github.com/awslabs/aws-sdk-kotlin/issues/701)

## Description of changes

This is the final feature branch merge of #873 and #870, which have already been reviewed. The main changes from previous reviews are:
* Updated description text for the changelog entry which links to the breaking discussion post
* Renamed `circuitBreakerMode` to `useCircuitBreakerMode`

**Companion PR**: [aws-sdk-kotlin#965](https://github.com/awslabs/aws-sdk-kotlin/pull/965)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
