### PR TITLE
fix: model test utils serviceName bug

### DIFF
--- a/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
+++ b/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
@@ -1,5 +1,5 @@
 {
     "id": "adfc6461-c39c-4dc2-bc55-ef00b16c13a5",
     "type": "bugfix",
-    "description": "Fix issue with  utility. SDK ID requires space but service name can't have space."
+    "description": "Fix issue with `ModelTestUtils` utility. SDK ID requires space but service name can't have space."
 }

--- a/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
+++ b/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
@@ -1,5 +1,0 @@
-{
-    "id": "adfc6461-c39c-4dc2-bc55-ef00b16c13a5",
-    "type": "bugfix",
-    "description": "Fix issue with `ModelTestUtils` utility. SDK ID requires space but service name can't have space."
-}

--- a/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
+++ b/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
@@ -1,0 +1,5 @@
+{
+    "id": "adfc6461-c39c-4dc2-bc55-ef00b16c13a5",
+    "type": "bugfix",
+    "description": "Fix issue with  utility. SDK ID requires space but service name can't have space."
+}

--- a/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
+++ b/.changes/adfc6461-c39c-4dc2-bc55-ef00b16c13a5.json
@@ -1,0 +1,5 @@
+{
+    "id": "adfc6461-c39c-4dc2-bc55-ef00b16c13a5",
+    "type": "bugfix",
+    "description": "Fix issue with `ModelTestUtils` utility. SDK ID requires space but service name can't have space."
+}

--- a/codegen/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
+++ b/codegen/smithy-kotlin-codegen-testutils/src/main/kotlin/software/amazon/smithy/kotlin/codegen/test/ModelTestUtils.kt
@@ -8,7 +8,7 @@ import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
-import software.amazon.smithy.kotlin.codegen.core.*
+import software.amazon.smithy.kotlin.codegen.core.KotlinDelegator
 import software.amazon.smithy.kotlin.codegen.inferService
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.model.OperationNormalizer
@@ -205,7 +205,7 @@ fun String.generateTestModel(
         use aws.protocols#$protocol
 
         @$protocol
-        service $serviceName {
+        service ${serviceName.filter { !it.isWhitespace() }} {
             version: "${TestModelDefault.MODEL_VERSION}",
             operations: [
                 ${operations.joinToString(separator = ", ")}
@@ -252,7 +252,7 @@ fun String.prependNamespaceAndService(
         $importExpr
         $modelProtocol
         @service(sdkId: "$serviceName")
-        service $serviceName { 
+        service ${serviceName.filter { !it.isWhitespace() }} { 
             version: "${TestModelDefault.MODEL_VERSION}",
             operations: $operations
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed an issue with utility. SDK ID for `route 53` requires space but service name can't have space, i.e. `route53`
## Issue \#
No Issue available (Will make one if required)
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes

<!--- Why is this change required? What problem does it solve? -->
It solves the problem if the utility not working when it comes to route 53
<br>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
