### PR TITLE
fix: correctly deserialize consecutive XML flat maps 

### DIFF
--- a/.changes/a2c5037e-db65-45f5-8033-acbd3bf241ee.json
+++ b/.changes/a2c5037e-db65-45f5-8033-acbd3bf241ee.json
@@ -1,0 +1,8 @@
+{
+    "id": "a2c5037e-db65-45f5-8033-acbd3bf241ee",
+    "type": "bugfix",
+    "description": "Properly deserialize XML flat maps",
+    "issues": [
+        "https://github.com/awslabs/aws-sdk-kotlin/issues/962"
+    ]
+}

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -105,11 +105,7 @@ internal class XmlMapDeserializer(
 
     override fun hasNextEntry(): Boolean {
         val compareTo = when (descriptor.hasTrait<Flattened>()) {
-            // Prefer seeking to XmlSerialName if the trait exists
-            true -> when (descriptor.hasTrait<XmlSerialName>()) {
-                true -> descriptor.expectTrait<XmlSerialName>().name
-                false -> mapTrait.key
-            }
+            true -> descriptor.findTrait<XmlSerialName>()?.name ?: mapTrait.key // Prefer seeking to XmlSerialName if the trait exists
             false -> mapTrait.entry
         }
 

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer.kt
@@ -79,8 +79,14 @@ public class XmlDeserializer(
         return XmlListDeserializer(reader.subTreeReader(depth), descriptor)
     }
 
-    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator =
-        XmlMapDeserializer(reader.subTreeReader(XmlStreamReader.SubtreeStartDepth.CURRENT), descriptor)
+    override fun deserializeMap(descriptor: SdkFieldDescriptor): Deserializer.EntryIterator {
+        val depth = when (descriptor.hasTrait<Flattened>()) {
+            true -> XmlStreamReader.SubtreeStartDepth.CURRENT
+            else -> XmlStreamReader.SubtreeStartDepth.CHILD
+        }
+
+        return XmlMapDeserializer(reader.subTreeReader(depth), descriptor)
+    }
 }
 
 /**
@@ -98,10 +104,19 @@ internal class XmlMapDeserializer(
     private val mapTrait = descriptor.findTrait<XmlMapName>() ?: XmlMapName.Default
 
     override fun hasNextEntry(): Boolean {
-        // Seek to either the entry or key token depending on the flatness of the map
+        val compareTo = when (descriptor.hasTrait<Flattened>()) {
+            // Prefer seeking to XmlSerialName if the trait exists
+            true -> when (descriptor.hasTrait<XmlSerialName>()) {
+                true -> descriptor.expectTrait<XmlSerialName>().name
+                false -> mapTrait.key
+            }
+            false -> mapTrait.entry
+        }
+
+        // Seek to either the XML serial name, entry, or key token depending on the flatness of the map and if the name trait is present
         val nextEntryToken = when (descriptor.hasTrait<Flattened>()) {
-            true -> reader.seek<XmlToken.BeginElement> { it.name.local == mapTrait.key }
-            false -> reader.seek<XmlToken.BeginElement> { it.name.local == mapTrait.entry }
+            true -> reader.peekSeek<XmlToken.BeginElement> { it.name.local == compareTo }
+            false -> reader.seek<XmlToken.BeginElement> { it.name.local == compareTo }
         }
 
         return nextEntryToken != null

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader.kt
@@ -79,6 +79,33 @@ public inline fun <reified T : XmlToken> XmlStreamReader.seek(selectionPredicate
 }
 
 /**
+ * Peek and seek forward until a token of type [T] is found.
+ * If it matches the [selectionPredicate], consume the token and return it. Otherwise, return `null` without consuming the token.
+ *
+ * @param selectionPredicate predicate that evaluates nodes of the required type to match
+ */
+public inline fun <reified T : XmlToken> XmlStreamReader.peekSeek(selectionPredicate: (T) -> Boolean = { true }): T? {
+    var token: XmlToken? = lastToken
+
+    if (token != null && token is T) {
+        return if (selectionPredicate.invoke(token)) token else null
+    }
+
+    do {
+        if (token is T) {
+            return if (selectionPredicate.invoke(token)) {
+                nextToken() as T
+            } else {
+                null
+            }
+        } else { nextToken() }
+        token = peek()
+    } while (token != null)
+
+    return null
+}
+
+/**
  * Creates an [XmlStreamReader] instance
  */
 public fun xmlStreamReader(payload: ByteArray): XmlStreamReader {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a bug in the XML deserializer which fails to process consecutive flat maps properly. Before this change, the deserializer would seek forward until it found a matching map key. Consecutive flat maps sharing the same key names would be lumped together unintentionally. 

The fix is to seek using `XmlSerialName` as a comparator since this is the only thing distinguishing different flat maps. A new deserialize method `peekSeek` is added which seeks forward and only consumes tokens if they are a match.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/962

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This fixes a bug when deserializing consecutive flat maps. See the new "consecutive flat maps" test case for an example of an XML tree for which parsing previously failed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
