### PR TITLE
feat: instrument operational metrics and okhttp engine

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -62,6 +62,7 @@ object RuntimeTypes {
             val HttpOperationContext = symbol("HttpOperationContext")
             val HttpSerialize = symbol("HttpSerialize")
             val OperationAuthConfig = symbol("OperationAuthConfig")
+            val OperationMetrics = symbol("OperationMetrics")
             val OperationRequest = symbol("OperationRequest")
             val roundTrip = symbol("roundTrip")
             val telemetry = symbol("telemetry")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -118,6 +118,10 @@ abstract class HttpProtocolClientGenerator(
 
             write("toMap()")
         }
+
+
+        writer.write("private val telemetryScope = #S", ctx.settings.pkg.name)
+        writer.write("private val opMetrics = #T(telemetryScope, config.telemetryProvider)", RuntimeTypes.HttpClient.Operation.OperationMetrics)
     }
 
     protected open fun importSymbols(writer: KotlinWriter) {
@@ -232,6 +236,8 @@ abstract class HttpProtocolClientGenerator(
             // telemetry
             writer.withBlock("#T {", "}", RuntimeTypes.HttpClient.Operation.telemetry) {
                 write("provider = config.telemetryProvider")
+                write("scope = telemetryScope")
+                write("metrics = opMetrics")
                 writer.declareSection(OperationTelemetryBuilder, mapOf(OperationTelemetryBuilder.Operation to op))
             }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -119,7 +119,6 @@ abstract class HttpProtocolClientGenerator(
             write("toMap()")
         }
 
-
         writer.write("private val telemetryScope = #S", ctx.settings.pkg.name)
         writer.write("private val opMetrics = #T(telemetryScope, config.telemetryProvider)", RuntimeTypes.HttpClient.Operation.OperationMetrics)
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -84,6 +84,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -106,6 +108,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -128,6 +132,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -150,6 +156,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -172,6 +180,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -194,6 +204,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -216,6 +228,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -238,6 +252,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -260,6 +276,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
@@ -339,6 +357,8 @@ class HttpProtocolClientGeneratorTest {
             }
             telemetry {
                 provider = config.telemetryProvider
+                scope = telemetryScope
+                metrics = opMetrics
             }
             execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)

--- a/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4jLoggerProvider.kt
+++ b/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4jLoggerProvider.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.telemetry.logging.slf4j
 
 import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.logging.*
-import aws.smithy.kotlin.runtime.time.Instant
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
 import org.slf4j.spi.LoggingEventBuilder

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -125,7 +125,7 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement$
 	public static synthetic fun record$default (Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurement;Ljava/lang/Number;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
-public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/GaugeHandle {
+public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle {
 	public abstract fun stop ()V
 }
 
@@ -138,18 +138,20 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/Histogram$Default
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/Meter {
-	public abstract fun createDoubleGauge (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/GaugeHandle;
+	public abstract fun createAsyncUpDownCounter (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
+	public abstract fun createDoubleGauge (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
 	public abstract fun createDoubleHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
-	public abstract fun createLongGauge (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/GaugeHandle;
+	public abstract fun createLongGauge (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
 	public abstract fun createLongHistogram (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
 	public abstract fun createMonotonicCounter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
 	public abstract fun createUpDownCounter (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/metrics/Meter$DefaultImpls {
-	public static synthetic fun createDoubleGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/GaugeHandle;
+	public static synthetic fun createAsyncUpDownCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
+	public static synthetic fun createDoubleGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
 	public static synthetic fun createDoubleHistogram$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
-	public static synthetic fun createLongGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/GaugeHandle;
+	public static synthetic fun createLongGauge$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
 	public static synthetic fun createLongHistogram$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
 	public static synthetic fun createMonotonicCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
 	public static synthetic fun createUpDownCounter$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Meter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -180,6 +180,13 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Def
 	public static synthetic fun add$default (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;JLaws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounterKt {
+	public static final fun decrement (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
+	public static synthetic fun decrement$default (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
+	public static final fun increment (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
+	public static synthetic fun increment$default (Laws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExtKt {
 }
 

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -137,6 +137,9 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/Histogram$Default
 	public static synthetic fun record$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;Ljava/lang/Number;Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/metrics/HistogramKt {
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/Meter {
 	public abstract fun createAsyncUpDownCounter (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;
 	public abstract fun createDoubleGauge (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/metrics/AsyncMeasurementHandle;

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.telemetry.logging
 
 import aws.smithy.kotlin.runtime.telemetry.context.Context
-import aws.smithy.kotlin.runtime.time.Instant
 
 /**
  * Construct a logging record that can be emitted to an underlying logger.

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.telemetry.logging
 
 import aws.smithy.kotlin.runtime.telemetry.context.Context
-import aws.smithy.kotlin.runtime.time.Instant
 
 internal object NoOpLoggerProvider : LoggerProvider {
     override fun getOrCreateLogger(name: String): Logger = NoOpLogger

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Gauge.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Gauge.kt
@@ -23,22 +23,23 @@ public interface AsyncMeasurement<T : Number> {
     public fun record(
         value: T,
         attributes: Attributes = emptyAttributes(),
-        context: Context,
+        context: Context? = null,
     )
 }
 
 public typealias LongAsyncMeasurement = AsyncMeasurement<Long>
 public typealias LongGaugeCallback = (LongAsyncMeasurement) -> Unit
+public typealias LongUpDownCounterCallback = (LongAsyncMeasurement) -> Unit
 
 public typealias DoubleAsyncMeasurement = AsyncMeasurement<Double>
 public typealias DoubleGaugeCallback = (DoubleAsyncMeasurement) -> Unit
 
 /**
- * A handle to a registered guage
+ * A handle to a registered async measurement (e.g. Gauge or AsyncUpDownCounter)
  */
-public interface GaugeHandle {
+public interface AsyncMeasurementHandle {
     /**
-     * Stop recording this gauge value. The registered callback function will
+     * Stop recording this async value. The registered callback function will
      * stop being invoked after calling this function.
      */
     public fun stop()

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Histogram.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Histogram.kt
@@ -5,9 +5,11 @@
 
 package aws.smithy.kotlin.runtime.telemetry.metrics
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
+import kotlin.time.Duration
 
 public interface Histogram<T : Number> {
     /**
@@ -25,3 +27,17 @@ public interface Histogram<T : Number> {
 }
 public typealias LongHistogram = Histogram<Long>
 public typealias DoubleHistogram = Histogram<Double>
+
+/**
+ * Record a duration in seconds using millisecond precision.
+ *
+ * @param value the duration to record
+ * @param attributes attributes to associate with this measurement
+ * @param context (Optional) trace context to associate with this measurement
+ */
+@InternalApi
+public fun DoubleHistogram.recordSeconds(value: Duration, attributes: Attributes = emptyAttributes(), context: Context? = null) {
+    val ms = value.inWholeMilliseconds.toDouble()
+    val sec = ms / 1000
+    record(sec, attributes, context)
+}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Meter.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/Meter.kt
@@ -24,6 +24,24 @@ public interface Meter {
     ): UpDownCounter
 
     /**
+     * Create a new async up down counter.
+     *
+     * @param name the instrument name
+     * @param callback the callback to invoke when reading the counter value. NOTE: Unlike synchronous counters that
+     * record delta values, async measurements record absolute/current values.
+     * @param units the unit of measure
+     * @param description the human-readable description of the measurement
+     * @return a [AsyncMeasurementHandle] which can be used for de-registering the counter
+     * and stopping the callback from being invoked.
+     */
+    public fun createAsyncUpDownCounter(
+        name: String,
+        callback: LongUpDownCounterCallback,
+        units: String? = null,
+        description: String? = null,
+    ): AsyncMeasurementHandle
+
+    /**
      * Create a new [MonotonicCounter]
      *
      * @param name the instrument name
@@ -69,7 +87,7 @@ public interface Meter {
      * @param callback the callback to invoke when reading the gauge value
      * @param units the unit of measure
      * @param description the human-readable description of the measurement
-     * @return a [GaugeHandle] which can be used for de-registering the gauge
+     * @return a [AsyncMeasurementHandle] which can be used for de-registering the gauge
      * and stopping the callback from being invoked.
      */
     public fun createLongGauge(
@@ -77,7 +95,7 @@ public interface Meter {
         callback: LongGaugeCallback,
         units: String? = null,
         description: String? = null,
-    ): GaugeHandle
+    ): AsyncMeasurementHandle
 
     /**
      * Create a new Gauge.
@@ -86,7 +104,7 @@ public interface Meter {
      * @param callback the callback to invoke when reading the gauge value
      * @param units the unit of measure
      * @param description the human-readable description of the measurement
-     * @return a [GaugeHandle] which can be used for de-registering the gauge
+     * @return a [AsyncMeasurementHandle] which can be used for de-registering the gauge
      * and stopping the callback from being invoked.
      */
     public fun createDoubleGauge(
@@ -94,5 +112,5 @@ public interface Meter {
         callback: DoubleGaugeCallback,
         units: String? = null,
         description: String? = null,
-    ): GaugeHandle
+    ): AsyncMeasurementHandle
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/NoOpMeterProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/NoOpMeterProvider.kt
@@ -18,6 +18,13 @@ internal object NoOpMeterProvider : MeterProvider {
 private object NoOpMeter : Meter {
     override fun createUpDownCounter(name: String, units: String?, description: String?): UpDownCounter = NoOpUpDownCounter
 
+    override fun createAsyncUpDownCounter(
+        name: String,
+        callback: LongUpDownCounterCallback,
+        units: String?,
+        description: String?,
+    ): AsyncMeasurementHandle = NoOpAsyncMeasurementHandle
+
     override fun createMonotonicCounter(name: String, units: String?, description: String?): MonotonicCounter = NoOpMonotonicCounter
 
     override fun createLongHistogram(name: String, units: String?, description: String?): LongHistogram = NoOpLongHistogram
@@ -29,14 +36,14 @@ private object NoOpMeter : Meter {
         callback: LongGaugeCallback,
         units: String?,
         description: String?,
-    ): GaugeHandle = NoOpGaugeHandle
+    ): AsyncMeasurementHandle = NoOpAsyncMeasurementHandle
 
     override fun createDoubleGauge(
         name: String,
         callback: DoubleGaugeCallback,
         units: String?,
         description: String?,
-    ): GaugeHandle = NoOpGaugeHandle
+    ): AsyncMeasurementHandle = NoOpAsyncMeasurementHandle
 }
 
 private object NoOpUpDownCounter : UpDownCounter {
@@ -53,6 +60,6 @@ private object NoOpDoubleHistogram : DoubleHistogram {
     override fun record(value: Double, attributes: Attributes, context: Context?) {}
 }
 
-private object NoOpGaugeHandle : GaugeHandle {
+private object NoOpAsyncMeasurementHandle : AsyncMeasurementHandle {
     override fun stop() {}
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter.kt
@@ -23,3 +23,17 @@ public interface UpDownCounter {
         context: Context? = null,
     )
 }
+
+/**
+ * Increment counter by 1 with given attributes, equivalent to `add(1, attributes, context)`
+ */
+public fun UpDownCounter.increment(attributes: Attributes = emptyAttributes(), context: Context? = null) {
+    add(1, attributes, context)
+}
+
+/**
+ * Decrement counter by 1 with given attributes, equivalent to `add(1, attributes, context)`
+ */
+public fun UpDownCounter.decrement(attributes: Attributes = emptyAttributes(), context: Context? = null) {
+    add(-1, attributes, context)
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/api/http-client-engine-okhttp.api
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/api/http-client-engine-okhttp.api
@@ -22,7 +22,9 @@ public final class aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConf
 public final class aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig$Builder : aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfigImpl$BuilderImpl {
 	public fun <init> ()V
 	public final fun getMaxConnectionsPerHost-0hXNFcg ()Lkotlin/UInt;
+	public fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 	public final fun setMaxConnectionsPerHost-ExVfyTY (Lkotlin/UInt;)V
+	public fun setTelemetryProvider (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig$Companion {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             dependencies {
                 implementation(project(":runtime:runtime-core"))
                 api(project(":runtime:protocol:http-client"))
+                implementation(project(":runtime:observability:telemetry-defaults"))
 
                 implementation("com.squareup.okhttp3:okhttp:$okHttpVersion")
                 implementation("com.squareup.okhttp3:okhttp-coroutines:$okHttpVersion")

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
@@ -12,6 +12,7 @@ import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
 import aws.smithy.kotlin.runtime.telemetry.logging.MessageSupplier
 import aws.smithy.kotlin.runtime.telemetry.logging.getLogger
 import aws.smithy.kotlin.runtime.telemetry.logging.logger
+import aws.smithy.kotlin.runtime.telemetry.metrics.recordSeconds
 import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.trace.SpanStatus
 import aws.smithy.kotlin.runtime.telemetry.trace.recordException
@@ -100,7 +101,7 @@ internal class HttpEngineEventListener(
         metrics.acquiredConnections = pool.connectionCount().toLong()
         metrics.idleConnections = pool.idleConnectionCount().toLong()
         connectStart?.let {
-            metrics.connectionAcquireDuration.record(it.elapsedNow().inWholeMilliseconds)
+            metrics.connectionAcquireDuration.recordSeconds(it.elapsedNow())
         }
 
         val connId = System.identityHashCode(connection)

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -7,10 +7,8 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.config.TlsVersion
 import aws.smithy.kotlin.runtime.http.config.EngineFactory
-import aws.smithy.kotlin.runtime.http.engine.AlpnId
-import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
-import aws.smithy.kotlin.runtime.http.engine.TlsContext
-import aws.smithy.kotlin.runtime.http.engine.callContext
+import aws.smithy.kotlin.runtime.http.engine.*
+import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
@@ -46,6 +44,8 @@ public class OkHttpEngine(
 
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         val callContext = callContext()
+
+        // FIXME - publish connection limit
 
         val engineRequest = request.toOkHttpRequest(context, callContext)
         val engineCall = client.newCall(engineRequest)

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngineConfig.kt
@@ -7,6 +7,8 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfigImpl
+import aws.smithy.kotlin.runtime.telemetry.Global
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 
 /**
  * The configuration parameters for an OkHttp HTTP client engine.
@@ -47,5 +49,7 @@ public class OkHttpEngineConfig private constructor(builder: Builder) : HttpClie
          * The maximum number of connections to open to a single host. Defaults to [maxConnections].
          */
         public var maxConnectionsPerHost: UInt? = null
+
+        override var telemetryProvider: TelemetryProvider = TelemetryProvider.Global
     }
 }

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -213,7 +213,9 @@ public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext
 	public final fun getExpectedHttpStatus ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHostPrefix ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHttpCallList ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getOperationAttributes ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getOperationInput ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getOperationMetrics ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSdkInvocationId ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
 

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -77,6 +77,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClient
 	public abstract fun getProxySelector ()Laws/smithy/kotlin/runtime/http/engine/ProxySelector;
 	public abstract fun getSocketReadTimeout-UwyO8pc ()J
 	public abstract fun getSocketWriteTimeout-UwyO8pc ()J
+	public abstract fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 	public abstract fun getTlsContext ()Laws/smithy/kotlin/runtime/http/engine/TlsContext;
 }
 
@@ -90,6 +91,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClient
 	public abstract fun getProxySelector ()Laws/smithy/kotlin/runtime/http/engine/ProxySelector;
 	public abstract fun getSocketReadTimeout-UwyO8pc ()J
 	public abstract fun getSocketWriteTimeout-UwyO8pc ()J
+	public abstract fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 	public abstract fun getTlsContext ()Laws/smithy/kotlin/runtime/http/engine/TlsContext;
 	public abstract fun setConnectTimeout-LRDsOJo (J)V
 	public abstract fun setConnectionAcquireTimeout-LRDsOJo (J)V
@@ -99,6 +101,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClient
 	public abstract fun setProxySelector (Laws/smithy/kotlin/runtime/http/engine/ProxySelector;)V
 	public abstract fun setSocketReadTimeout-LRDsOJo (J)V
 	public abstract fun setSocketWriteTimeout-LRDsOJo (J)V
+	public abstract fun setTelemetryProvider (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
 	public abstract fun setTlsContext (Laws/smithy/kotlin/runtime/http/engine/TlsContext;)V
 	public abstract fun tlsContext (Lkotlin/jvm/functions/Function1;)V
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/CoroutineUtils.kt
@@ -7,6 +7,8 @@ package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProviderContext
+import aws.smithy.kotlin.runtime.telemetry.context.TelemetryContextElement
+import aws.smithy.kotlin.runtime.telemetry.context.telemetryContext
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggingContextElement
 import aws.smithy.kotlin.runtime.telemetry.logging.loggingContext
 import aws.smithy.kotlin.runtime.telemetry.telemetryProvider
@@ -15,6 +17,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -28,7 +31,8 @@ internal fun HttpClientEngine.createCallContext(outerContext: CoroutineContext):
         requestJob +
         CoroutineName("request-context") +
         TelemetryProviderContext(outerContext.telemetryProvider) +
-        LoggingContextElement(outerContext.loggingContext)
+        LoggingContextElement(outerContext.loggingContext) +
+        (outerContext.telemetryContext?.let { TelemetryContextElement(it) } ?: EmptyCoroutineContext)
 
     // attach req to outer context, if the user cancels it will be propagated to the request
     attachToOuterJob(outerContext, requestJob)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.engine
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.http.config.HttpEngineConfigDsl
 import aws.smithy.kotlin.runtime.net.HostResolver
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -79,6 +80,11 @@ public interface HttpClientEngineConfig {
      * Settings related to TLS and secure connections
      */
     public val tlsContext: TlsContext
+
+    /**
+     * The telemetry provider that the HTTP client will be instrumented with
+     */
+    public val telemetryProvider: TelemetryProvider
 
     @InternalApi
     public fun toBuilderApplicator(): Builder.() -> Unit
@@ -163,6 +169,11 @@ public interface HttpClientEngineConfig {
         public var tlsContext: TlsContext
 
         /**
+         * The telemetry provider that the HTTP client will be instrumented with
+         */
+        public var telemetryProvider: TelemetryProvider
+
+        /**
          * Settings related to TLS and secure connections
          */
         public fun tlsContext(block: TlsContext.Builder.() -> Unit)
@@ -183,6 +194,7 @@ public open class HttpClientEngineConfigImpl(builder: HttpClientEngineConfig.Bui
     override val proxySelector: ProxySelector = builder.proxySelector
     override val hostResolver: HostResolver = builder.hostResolver
     override val tlsContext: TlsContext = builder.tlsContext
+    override val telemetryProvider: TelemetryProvider = builder.telemetryProvider
 
     override fun toBuilderApplicator(): HttpClientEngineConfig.Builder.() -> Unit = {
         socketReadTimeout = this@HttpClientEngineConfigImpl.socketReadTimeout
@@ -194,6 +206,7 @@ public open class HttpClientEngineConfigImpl(builder: HttpClientEngineConfig.Bui
         proxySelector = this@HttpClientEngineConfigImpl.proxySelector
         hostResolver = this@HttpClientEngineConfigImpl.hostResolver
         tlsContext = this@HttpClientEngineConfigImpl.tlsContext
+        telemetryProvider = this@HttpClientEngineConfigImpl.telemetryProvider
     }
 
     @InternalApi
@@ -207,6 +220,7 @@ public open class HttpClientEngineConfigImpl(builder: HttpClientEngineConfig.Bui
         override var proxySelector: ProxySelector = EnvironmentProxySelector()
         override var hostResolver: HostResolver = HostResolver.Default
         override var tlsContext: TlsContext = TlsContext.Default
+        override var telemetryProvider: TelemetryProvider = TelemetryProvider.None
         override fun tlsContext(block: TlsContext.Builder.() -> Unit) {
             tlsContext = TlsContext(tlsContext.toBuilder().apply(block))
         }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -5,30 +5,14 @@
 package aws.smithy.kotlin.runtime.http.engine.internal
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.LongAsyncMeasurement
 import aws.smithy.kotlin.runtime.telemetry.metrics.LongHistogram
-import aws.smithy.kotlin.runtime.telemetry.metrics.UpDownCounter
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.attributesOf
-
-/**
- * Container for common HTTP engine related metrics
- *
- * @param scope the instrumentation scope
- * @param provider the telemetry provider to instrument with
- */
-@InternalApi
-public class HttpClientMetrics(
-    scope: String,
-    public val provider: TelemetryProvider,
-) {
-    private val meter = provider.meterProvider.getOrCreateMeter(scope)
-
-    public val connectionLimit: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.connections.limit", "{connection}", "Max connections configured for the HTTP client")
-    public val connectionUsage: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.connections.usage", "{connection}", "Current state of connections (idle, acquired)")
-    public val connectionAcquireDuration: LongHistogram = meter.createLongHistogram("aws.smithy.http.connections.acquire_duration", "ms", "The amount of time requests take to acquire a connection from the pool")
-    public val requests: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.requests", "{request}", "The current state of requests (queued, in-flight)")
-}
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 
 /**
  * Common attributes for [HttpClientMetrics]
@@ -39,4 +23,144 @@ public object HttpClientMetricAttributes {
     public val AcquiredConnection: Attributes = attributesOf { "state" to "acquired" }
     public val QueuedRequest: Attributes = attributesOf { "state" to "queued" }
     public val InFlightRequest: Attributes = attributesOf { "state" to "in-flight" }
+}
+
+/**
+ * Container for common HTTP engine related metrics. Engine implementations can re-use this and update
+ * the various fields in whatever manner fits best (increment/decrement vs current absolute value).
+ *
+ * @param scope the instrumentation scope
+ * @param provider the telemetry provider to instrument with
+ */
+@InternalApi
+public class HttpClientMetrics(
+    scope: String,
+    public val provider: TelemetryProvider,
+) : Closeable {
+    private val meter = provider.meterProvider.getOrCreateMeter(scope)
+
+    private val _connectionsLimit = atomic(0L)
+    private val _idleConnections = atomic(0L)
+    private val _acquiredConnections = atomic(0L)
+    private val _queuedRequests = atomic(0L)
+    private val _inFlightRequests = atomic(0L)
+
+    /**
+     * The amount of time it takes to acquire a connection from the pool
+     */
+    public val connectionAcquireDuration: LongHistogram = meter.createLongHistogram("aws.smithy.http.connections.acquire_duration", "ms", "The amount of time requests take to acquire a connection from the pool")
+
+    private val connectionLimitHandle = meter.createAsyncUpDownCounter(
+        "aws.smithy.http.connections.limit",
+        { it.record(_connectionsLimit.value) },
+        "{connection}",
+        "Max connections configured for the HTTP client",
+    )
+
+    private val connectionUsageHandle = meter.createAsyncUpDownCounter(
+        "aws.smithy.http.connections.usage",
+        ::recordConnectionState,
+        "{connection}",
+        "Current state of connections (idle, acquired)",
+    )
+
+    private val requestsHandle = meter.createAsyncUpDownCounter(
+        "aws.smithy.http.requests",
+        ::recordRequestsState,
+        "{request}",
+        "The current state of requests (queued, in-flight)",
+    )
+
+    /**
+     * The maximum number of connections configured for the client
+     */
+    public var connectionsLimit: Long
+        get() = _connectionsLimit.value
+        set(value) {
+            _connectionsLimit.update { value }
+        }
+
+    /**
+     * The number of idle (warm) connections in the pool right now
+     */
+    public var idleConnections: Long
+        get() = _idleConnections.value
+        set(value) {
+            _idleConnections.update { value }
+        }
+
+    public fun incrementIdleConnections() {
+        _idleConnections += 1
+    }
+
+    public fun decrementIdleConnections() {
+        _idleConnections -= 1
+    }
+
+    /**
+     * The number of acquired (active) connections used right now
+     */
+    public var acquiredConnections: Long
+        get() = _acquiredConnections.value
+        set(value) {
+            _acquiredConnections.update { value }
+        }
+
+    public fun incrementAcquiredConnections() {
+        _acquiredConnections += 1
+    }
+
+    public fun decrementAcquiredConnections() {
+        _acquiredConnections -= 1
+    }
+
+    /**
+     * The number of requests currently queued waiting to be dispatched/executed by the client
+     */
+    public var queuedRequests: Long
+        get() = _queuedRequests.value
+        set(value) {
+            _queuedRequests.update { value }
+        }
+
+    public fun incrementQueuedRequests() {
+        _queuedRequests += 1
+    }
+
+    public fun decrementQueuedRequests() {
+        _queuedRequests -= 1
+    }
+
+    /**
+     * The number of requests currently in-flight (actively processing)
+     */
+    public var inFlightRequests: Long
+        get() = _inFlightRequests.value
+        set(value) {
+            _inFlightRequests.update { value }
+        }
+
+    public fun incrementInFlightRequests() {
+        _inFlightRequests += 1
+    }
+
+    public fun decrementInFlightRequests() {
+        _inFlightRequests -= 1
+    }
+
+    private fun recordRequestsState(measurement: LongAsyncMeasurement) {
+        measurement.record(inFlightRequests, HttpClientMetricAttributes.InFlightRequest)
+        measurement.record(queuedRequests, HttpClientMetricAttributes.QueuedRequest)
+    }
+
+    private fun recordConnectionState(measurement: LongAsyncMeasurement) {
+        measurement.record(idleConnections, HttpClientMetricAttributes.IdleConnection)
+        measurement.record(acquiredConnections, HttpClientMetricAttributes.AcquiredConnection)
+    }
+
+    override fun close() {
+        connectionLimitHandle.stop()
+        connectionUsageHandle.stop()
+        requestsHandle.stop()
+    }
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.engine.internal
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.LongHistogram
+import aws.smithy.kotlin.runtime.telemetry.metrics.UpDownCounter
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.attributesOf
+
+/**
+ * Container for common HTTP engine related metrics
+ *
+ * @param scope the instrumentation scope
+ * @param provider the telemetry provider to instrument with
+ */
+@InternalApi
+public class HttpClientMetrics(
+    scope: String,
+    public val provider: TelemetryProvider,
+) {
+    private val meter = provider.meterProvider.getOrCreateMeter(scope)
+
+    public val connectionLimit: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.connections.limit", "{connection}", "Max connections configured for the HTTP client")
+    public val connectionUsage: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.connections.usage", "{connection}", "Current state of connections (idle, acquired)")
+    public val connectionAcquireDuration: LongHistogram = meter.createLongHistogram("aws.smithy.http.connections.acquire_duration", "ms", "The amount of time requests take to acquire a connection from the pool")
+    public val requests: UpDownCounter = meter.createUpDownCounter("aws.smithy.http.requests", "{request}", "The current state of requests (queued, in-flight)")
+}
+
+/**
+ * Common attributes for [HttpClientMetrics]
+ */
+@InternalApi
+public object HttpClientMetricAttributes {
+    public val IdleConnection: Attributes = attributesOf { "state" to "idle" }
+    public val AcquiredConnection: Attributes = attributesOf { "state" to "acquired" }
+    public val QueuedRequest: Attributes = attributesOf { "state" to "queued" }
+    public val InFlightRequest: Attributes = attributesOf { "state" to "in-flight" }
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
+import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
+import aws.smithy.kotlin.runtime.client.RequestInterceptorContext
+import aws.smithy.kotlin.runtime.client.ResponseInterceptorContext
+import aws.smithy.kotlin.runtime.http.operation.OperationMetrics
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.util.attributesOf
+import kotlin.time.ExperimentalTime
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * Captures many of the common metrics associated with executing an operation
+ *
+ * @param metrics the operation metrics container
+ * @param service the name of the service
+ * @param operation the name of the operation
+ * @param timeSource the time source to use for measuring elapsed time
+ */
+@OptIn(ExperimentalTime::class)
+internal class OperationTelemetryInterceptor(
+    private val metrics: OperationMetrics,
+    private val service: String,
+    private val operation: String,
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+) : HttpInterceptor {
+
+    private var callStart: TimeMark? = null
+    private var serializeStart: TimeMark? = null
+    private var deserializeStart: TimeMark? = null
+    private var signingStart: TimeMark? = null
+    private var transmitStart: TimeMark? = null
+
+    private val perRpcAttributes = attributesOf {
+        "rpc.service" to service
+        "rpc.method" to operation
+    }
+
+    override fun readBeforeExecution(context: RequestInterceptorContext<Any>) {
+        callStart = timeSource.markNow()
+    }
+
+    override fun readAfterExecution(context: ResponseInterceptorContext<Any, Any, HttpRequest?, HttpResponse?>) {
+        val callDuration = callStart?.elapsedNow()?.inWholeMilliseconds ?: return
+
+        // TODO - total requests?
+
+        metrics.rpcCallDuration.record(callDuration, perRpcAttributes, metrics.provider.contextManager.current())
+
+        context.protocolRequest?.body?.contentLength?.let {
+            metrics.rpcRequestSize.record(it, perRpcAttributes, metrics.provider.contextManager.current())
+        }
+
+        context.protocolResponse?.body?.contentLength?.let {
+            metrics.rpcResponseSize.record(it, perRpcAttributes, metrics.provider.contextManager.current())
+        }
+    }
+
+    override fun readBeforeSerialization(context: RequestInterceptorContext<Any>) {
+        serializeStart = timeSource.markNow()
+    }
+
+    override fun readAfterSerialization(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
+        val serializeDuration = serializeStart?.elapsedNow()?.inWholeMilliseconds ?: return
+        metrics.serializationDuration.record(serializeDuration, perRpcAttributes, metrics.provider.contextManager.current())
+    }
+
+    override fun readBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
+        signingStart = timeSource.markNow()
+    }
+
+    override fun readAfterSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
+        val signingDuration = signingStart?.elapsedNow()?.inWholeMilliseconds ?: return
+        metrics.serializationDuration.record(signingDuration, perRpcAttributes, metrics.provider.contextManager.current())
+    }
+
+    override fun readBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>) {
+        deserializeStart = timeSource.markNow()
+    }
+
+    override fun readAfterDeserialization(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse>) {
+        val deserializeDuration = deserializeStart?.elapsedNow()?.inWholeMilliseconds ?: return
+        metrics.deserializationDuration.record(deserializeDuration, perRpcAttributes, metrics.provider.contextManager.current())
+    }
+
+    override fun readBeforeTransmit(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
+        transmitStart = timeSource.markNow()
+    }
+
+    override fun readAfterTransmit(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>) {
+        val serviceCallDuration = transmitStart?.elapsedNow()?.inWholeMilliseconds ?: return
+        metrics.serviceCallDuration.record(serviceCallDuration, perRpcAttributes, metrics.provider.contextManager.current())
+    }
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -72,15 +72,6 @@ internal class OperationTelemetryInterceptor(
         metrics.serializationDuration.record(serializeDuration, perRpcAttributes, metrics.provider.contextManager.current())
     }
 
-    override fun readBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
-        signingStart = timeSource.markNow()
-    }
-
-    override fun readAfterSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>) {
-        val signingDuration = signingStart?.elapsedNow()?.inWholeMilliseconds ?: return
-        metrics.serializationDuration.record(signingDuration, perRpcAttributes, metrics.provider.contextManager.current())
-    }
-
     override fun readBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>) {
         deserializeStart = timeSource.markNow()
     }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -11,6 +11,8 @@ import aws.smithy.kotlin.runtime.client.SdkClientOption
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.AttributeKey
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 
 /**
  * Common configuration for an SDK (HTTP) operation/call
@@ -50,6 +52,16 @@ public open class HttpOperationContext {
         public val OperationInput: AttributeKey<Any> = AttributeKey("aws.smithy.kotlin#OperationInput")
 
         /**
+         * The operation metrics container used by various components to record metrics
+         */
+        public val OperationMetrics: AttributeKey<OperationMetrics> = AttributeKey("aws.smithy.kotlin#OperationMetrics")
+
+        /**
+         * Cached attribute level attributes (e.g. rpc.method, rpc.service, etc)
+         */
+        public val OperationAttributes: AttributeKey<Attributes> = AttributeKey("aws.smithy.kotlin#OperationAttributes")
+
+        /**
          * Build this operation into an HTTP [ExecutionContext]
          */
         public fun build(block: Builder.() -> Unit): ExecutionContext = Builder().apply(block).build()
@@ -81,3 +93,9 @@ public open class HttpOperationContext {
         public var hostPrefix: String? by option(HostPrefix)
     }
 }
+
+internal val ExecutionContext.operationMetrics: OperationMetrics
+    get() = getOrNull(HttpOperationContext.OperationMetrics) ?: OperationMetrics.None
+
+internal val ExecutionContext.operationAttributes: Attributes
+    get() = getOrNull(HttpOperationContext.OperationAttributes) ?: emptyAttributes()

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -24,13 +24,13 @@ public class OperationMetrics(
         val None: OperationMetrics = OperationMetrics("NoOp", TelemetryProvider.None)
     }
 
-    public val rpcCallDuration: LongHistogram = meter.createLongHistogram("rpc.client.duration", "ms", "Overall call duration including retries")
-    public val rpcRequestSize: LongHistogram = meter.createLongHistogram("rpc.client.request.size", "By", "Size of RPC request message")
-    public val rpcResponseSize: LongHistogram = meter.createLongHistogram("rpc.client.response.size", "By", "Size of RPC response message")
-    public val serviceCallDuration: LongHistogram = meter.createLongHistogram("aws.smithy.service_call_duration", "ms", "The time it takes to connect to the service, send the request, and receive the HTTP status code and headers from the response")
-    public val serializationDuration: LongHistogram = meter.createLongHistogram("aws.smithy.serialization.duration", "ms", "The time it takes to serialize a request message body")
-    public val deserializationDuration: LongHistogram = meter.createLongHistogram("aws.smithy.deserialization.duration", "ms", "The time it takes to deserialize a response message body")
-    public val resolveEndpointDuration: LongHistogram = meter.createLongHistogram("aws.smithy.resolve_endpoint_duration", "ms", "The time it takes to resolve an endpoint for a request")
-    public val resolveIdentityDuration: LongHistogram = meter.createLongHistogram("aws.smithy.auth.resolve_identity_duration", "ms", "The time it takes to resolve an identity for signing a request")
-    public val signingRequestDuration: LongHistogram = meter.createLongHistogram("aws.smithy.auth.sign_request_duration", "ms", "The time it takes to sign a request")
+    public val rpcCallDuration: LongHistogram = meter.createLongHistogram("smithy.client.duration", "ms", "Overall call duration including retries")
+    public val rpcRequestSize: LongHistogram = meter.createLongHistogram("smithy.client.request.size", "By", "Size of the serialized request message")
+    public val rpcResponseSize: LongHistogram = meter.createLongHistogram("smithy.client.response.size", "By", "Size of the serialized response message")
+    public val serviceCallDuration: LongHistogram = meter.createLongHistogram("smithy.client.service_call_duration", "ms", "The time it takes to connect to the service, send the request, and receive the HTTP status code and headers from the response")
+    public val serializationDuration: LongHistogram = meter.createLongHistogram("smithy.client.serialization_duration", "ms", "The time it takes to serialize a request message body")
+    public val deserializationDuration: LongHistogram = meter.createLongHistogram("smithy.client.deserialization_duration", "ms", "The time it takes to deserialize a response message body")
+    public val resolveEndpointDuration: LongHistogram = meter.createLongHistogram("smithy.client.resolve_endpoint_duration", "ms", "The time it takes to resolve an endpoint for a request")
+    public val resolveIdentityDuration: LongHistogram = meter.createLongHistogram("smithy.client.auth.resolve_identity_duration", "ms", "The time it takes to resolve an identity for signing a request")
+    public val signingDuration: LongHistogram = meter.createLongHistogram("smithy.client.auth.signing_duration", "ms", "The time it takes to sign a request")
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -6,6 +6,7 @@ package aws.smithy.kotlin.runtime.http.operation
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.DoubleHistogram
 import aws.smithy.kotlin.runtime.telemetry.metrics.LongHistogram
 
 /**
@@ -24,13 +25,13 @@ public class OperationMetrics(
         val None: OperationMetrics = OperationMetrics("NoOp", TelemetryProvider.None)
     }
 
-    public val rpcCallDuration: LongHistogram = meter.createLongHistogram("smithy.client.duration", "ms", "Overall call duration including retries")
+    public val rpcCallDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.duration", "s", "Overall call duration including retries")
     public val rpcRequestSize: LongHistogram = meter.createLongHistogram("smithy.client.request.size", "By", "Size of the serialized request message")
     public val rpcResponseSize: LongHistogram = meter.createLongHistogram("smithy.client.response.size", "By", "Size of the serialized response message")
-    public val serviceCallDuration: LongHistogram = meter.createLongHistogram("smithy.client.service_call_duration", "ms", "The time it takes to connect to the service, send the request, and receive the HTTP status code and headers from the response")
-    public val serializationDuration: LongHistogram = meter.createLongHistogram("smithy.client.serialization_duration", "ms", "The time it takes to serialize a request message body")
-    public val deserializationDuration: LongHistogram = meter.createLongHistogram("smithy.client.deserialization_duration", "ms", "The time it takes to deserialize a response message body")
-    public val resolveEndpointDuration: LongHistogram = meter.createLongHistogram("smithy.client.resolve_endpoint_duration", "ms", "The time it takes to resolve an endpoint for a request")
-    public val resolveIdentityDuration: LongHistogram = meter.createLongHistogram("smithy.client.auth.resolve_identity_duration", "ms", "The time it takes to resolve an identity for signing a request")
-    public val signingDuration: LongHistogram = meter.createLongHistogram("smithy.client.auth.signing_duration", "ms", "The time it takes to sign a request")
+    public val serviceCallDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.service_call_duration", "s", "The time it takes to connect to the service, send the request, and receive the HTTP status code and headers from the response")
+    public val serializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.serialization_duration", "s", "The time it takes to serialize a request message body")
+    public val deserializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.deserialization_duration", "s", "The time it takes to deserialize a response message body")
+    public val resolveEndpointDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.resolve_endpoint_duration", "s", "The time it takes to resolve an endpoint for a request")
+    public val resolveIdentityDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.auth.resolve_identity_duration", "s", "The time it takes to resolve an identity for signing a request")
+    public val signingDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.auth.signing_duration", "s", "The time it takes to sign a request")
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.operation
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
+import aws.smithy.kotlin.runtime.telemetry.metrics.LongHistogram
+
+/**
+ * Container for common operation/call metrics
+ *
+ * @param scope the instrumentation scope
+ * @param provider the telemetry provider to instrument with
+ */
+@InternalApi
+public class OperationMetrics(
+    scope: String,
+    public val provider: TelemetryProvider,
+) {
+    private val meter = provider.meterProvider.getOrCreateMeter(scope)
+    internal companion object {
+        val None: OperationMetrics = OperationMetrics("NoOp", TelemetryProvider.None)
+    }
+
+    public val rpcCallDuration: LongHistogram = meter.createLongHistogram("rpc.client.duration", "ms", "Overall call duration including retries")
+    public val rpcRequestSize: LongHistogram = meter.createLongHistogram("rpc.client.request.size", "By", "Size of RPC request message")
+    public val rpcResponseSize: LongHistogram = meter.createLongHistogram("rpc.client.response.size", "By", "Size of RPC response message")
+    public val serviceCallDuration: LongHistogram = meter.createLongHistogram("aws.smithy.service_call_duration", "ms", "The time it takes to connect to the service, send the request, and receive the HTTP status code and headers from the response")
+    public val serializationDuration: LongHistogram = meter.createLongHistogram("aws.smithy.serialization.duration", "ms", "The time it takes to serialize a request message body")
+    public val deserializationDuration: LongHistogram = meter.createLongHistogram("aws.smithy.deserialization.duration", "ms", "The time it takes to deserialize a response message body")
+    public val resolveEndpointDuration: LongHistogram = meter.createLongHistogram("aws.smithy.resolve_endpoint_duration", "ms", "The time it takes to resolve an endpoint for a request")
+    public val resolveIdentityDuration: LongHistogram = meter.createLongHistogram("aws.smithy.auth.resolve_identity_duration", "ms", "The time it takes to resolve an identity for signing a request")
+    public val signingRequestDuration: LongHistogram = meter.createLongHistogram("aws.smithy.auth.sign_request_duration", "ms", "The time it takes to sign a request")
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Instrument common operation metrics
* Add an `AsyncUpDownCounter` instrument type
* Add reusable HTTP engine metrics container
* Instrument OkHttp engine



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
