### PR TITLE
misc: add convenience method for putting non-null values in Attributes

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -155,6 +155,8 @@ object RuntimeTypes {
             val get = symbol("get")
             val LazyAsyncValue = symbol("LazyAsyncValue")
             val length = symbol("length")
+            val putIfAbsent = symbol("putIfAbsent")
+            val putIfAbsentNotNull = symbol("putIfAbsentNotNull")
             val truthiness = symbol("truthiness")
             val urlEncodeComponent = symbol("urlEncodeComponent", "text")
         }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1519,6 +1519,7 @@ public final class aws/smithy/kotlin/runtime/util/AttributesKt {
 	public static final fun mutableAttributes ()Laws/smithy/kotlin/runtime/util/MutableAttributes;
 	public static final fun mutableAttributesOf (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/util/MutableAttributes;
 	public static final fun putIfAbsent (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/AttributeKey;Ljava/lang/Object;)V
+	public static final fun putIfAbsentNotNull (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/AttributeKey;Ljava/lang/Object;)V
 	public static final fun setIfValueNotNull (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/AttributeKey;Ljava/lang/Object;)V
 	public static final fun take (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/AttributeKey;)Ljava/lang/Object;
 	public static final fun takeOrNull (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/AttributeKey;)Ljava/lang/Object;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -73,6 +73,13 @@ public fun <T : Any> MutableAttributes.putIfAbsent(key: AttributeKey<T>, value: 
 }
 
 /**
+ * Set a value for [key] only if it is not already set and if [value] is not null.
+ */
+public fun <T : Any> MutableAttributes.putIfAbsentNotNull(key: AttributeKey<T>, value: T?) {
+    if (value != null) putIfAbsent(key, value)
+}
+
+/**
  * Set a value for [key] only if [value] is not null
  */
 public fun <T : Any> MutableAttributes.setIfValueNotNull(key: AttributeKey<T>, value: T?) {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/AttributesTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/AttributesTest.kt
@@ -40,6 +40,27 @@ class AttributesTest {
     }
 
     @Test
+    fun testPutIfAbsentNotNull() {
+        val attributes = mutableAttributes()
+        val strKey = AttributeKey<String>("string")
+        attributes[strKey] = "foo"
+
+        attributes.putIfAbsentNotNull(strKey, null)
+        assertEquals("foo", attributes[strKey])
+
+        attributes.putIfAbsentNotNull(strKey, "bar")
+        assertEquals("foo", attributes[strKey])
+
+        attributes.remove(strKey)
+
+        attributes.putIfAbsentNotNull(strKey, null)
+        assertNull(attributes.getOrNull(strKey))
+
+        attributes.putIfAbsentNotNull(strKey, "bar")
+        assertEquals("bar", attributes[strKey])
+    }
+
+    @Test
     fun testMerge() {
         val attr1 = mutableAttributes()
         val key1 = AttributeKey<String>("k1")


### PR DESCRIPTION
## Issue \#

Related to [aws-sdk-kotlin#969](https://github.com/awslabs/aws-sdk-kotlin/issues/969)

## Description of changes

Adds a new convenience extension to `Attributes` for putting a value if the key is not already present _and_ the value is nonnull.

**Companion PR**: (link coming soon)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
