### PR TITLE
Mark TelemetryProvider API experimental

### DIFF
--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/TelemetryProvider.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -25,24 +26,29 @@ public interface TelemetryProvider {
     /**
      * Get the [TracerProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.trace.Tracer] instances
      */
+    @ExperimentalApi
     public val tracerProvider: TracerProvider
 
     /**
      * Get the [MeterProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.metrics.Meter] instances
      */
+    @ExperimentalApi
     public val meterProvider: MeterProvider
 
     /**
      * Get the [LoggerProvider] used to create new [aws.smithy.kotlin.runtime.telemetry.logging.Logger] instances
      */
+    @ExperimentalApi
     public val loggerProvider: LoggerProvider
 
     /**
      * Get the [ContextManager] used to get the current [Context]
      */
+    @ExperimentalApi
     public val contextManager: ContextManager
 }
 
+@OptIn(ExperimentalApi::class)
 private object NoOpTelemetryProvider : TelemetryProvider {
     override val meterProvider: MeterProvider = MeterProvider.None
     override val tracerProvider: TracerProvider = TracerProvider.None

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExt.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.context.telemetryContext
@@ -61,6 +62,7 @@ public suspend inline fun<R> withLogCtx(
  * @param content A lambda which provides the content of the message. This content does not need to include any data
  * from the exception (if any), which may be concatenated later based on probe behavior.
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public fun CoroutineContext.log(
     level: LogLevel,
@@ -213,6 +215,7 @@ public inline fun <reified T> CoroutineContext.trace(ex: Throwable? = null, noin
  * Get a [Logger] instance using the current [LoggerProvider] configured in this [CoroutineContext]
  * @param sourceComponent The name of the component to create a logger for
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public fun CoroutineContext.logger(sourceComponent: String): Logger {
     val logger = this.telemetryProvider.loggerProvider.getOrCreateLogger(sourceComponent)

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExt.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry.trace
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProviderContext
 import aws.smithy.kotlin.runtime.telemetry.context.TelemetryContextElement
@@ -59,6 +60,7 @@ public suspend inline fun <R> Tracer.withSpan(
  * Executes [block] within the scope of [TraceSpan]. The [block] of code is executed
  * with a new coroutine context that contains the [span] set in the context.
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public suspend inline fun <R> withSpan(
     span: TraceSpan,
@@ -107,6 +109,7 @@ public suspend inline fun <reified T, R> withSpan(
  * within the scope of the new span. The [block] of code is executed with a new coroutine
  * context that contains the newly created span set.
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public suspend inline fun <R> withSpan(
     sourceComponent: String,

--- a/runtime/observability/telemetry-defaults/common/src/aws/smithy/kotlin/runtime/telemetry/DefaultTelemetryProvider.kt
+++ b/runtime/observability/telemetry-defaults/common/src/aws/smithy/kotlin/runtime/telemetry/DefaultTelemetryProvider.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.telemetry
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.telemetry.context.ContextManager
 import aws.smithy.kotlin.runtime.telemetry.logging.DefaultLoggerProvider
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -15,6 +16,7 @@ import aws.smithy.kotlin.runtime.telemetry.trace.TracerProvider
  * A telemetry provider that uses the default logger for a platform if one exists (e.g. SLF4J on JVM) and
  * is a no-op for other telemetry signals.
  */
+@OptIn(ExperimentalApi::class)
 public object DefaultTelemetryProvider : TelemetryProvider {
     override val loggerProvider: LoggerProvider = DefaultLoggerProvider
     override val tracerProvider: TracerProvider = TracerProvider.None

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/HttpEngineEventListener.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.net.HostResolver
 import aws.smithy.kotlin.runtime.net.toHostAddress
@@ -29,7 +30,7 @@ import kotlin.time.TimeSource
 internal const val TELEMETRY_SCOPE = "aws.smithy.kotlin.runtime.http.engine.okhttp"
 
 // see https://square.github.io/okhttp/features/events/#eventlistener for example callback flow
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, ExperimentalApi::class)
 internal class HttpEngineEventListener(
     private val pool: ConnectionPool,
     private val hr: HostResolver,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.engine.internal
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
@@ -33,6 +34,7 @@ public object HttpClientMetricAttributes {
  * @param scope the instrumentation scope
  * @param provider the telemetry provider to instrument with
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public class HttpClientMetrics(
     scope: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.interceptors
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
 import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
 import aws.smithy.kotlin.runtime.client.RequestInterceptorContext
@@ -27,7 +28,7 @@ import kotlin.time.TimeSource
  * @param operation the name of the operation
  * @param timeSource the time source to use for measuring elapsed time
  */
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, ExperimentalApi::class)
 internal class OperationTelemetryInterceptor(
     private val metrics: OperationMetrics,
     private val service: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.operation
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.metrics.DoubleHistogram
@@ -16,6 +17,7 @@ import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
  * @param scope the instrumentation scope
  * @param provider the telemetry provider to instrument with
  */
+@OptIn(ExperimentalApi::class)
 @InternalApi
 public class OperationMetrics(
     scope: String,

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationTelemetry.kt
@@ -5,6 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
+import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.*
 import aws.smithy.kotlin.runtime.http.interceptors.OperationTelemetryInterceptor
@@ -51,7 +52,7 @@ public inline fun<I, O> SdkHttpOperationBuilder<I, O>.telemetry(block: SdkOperat
  * @return the span for the operation and the additional coroutine context to execute the operation with containing
  * telemetry elements.
  */
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, ExperimentalApi::class)
 internal fun<I, O> SdkHttpOperation<I, O>.instrument(): Pair<TraceSpan, CoroutineContext> {
     val serviceName = checkNotNull(context.serviceName)
     val opName = checkNotNull(context.operationName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Mark the `TelemetryProvider` API as experimental and optin where necessary. This explicitly doesn't mark the `TelemetryProvider` interface or configuration types as experimental as that would make configuring the SDK itself experimental. Instead we mark every field/method on the interface as `Experimental`. As we stabilize each telemetry signal implementation we can start to remove the annotation (e.g. once we are happy with metrics and the set of metrics exported we might remove it from `meterProvider`). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
