### PR TITLE
fix: correct URL encoding in endpoint resolution

### DIFF
--- a/.changes/f8716e6a-24e2-41fb-96b9-3e9e5593867a.json
+++ b/.changes/f8716e6a-24e2-41fb-96b9-3e9e5593867a.json
@@ -1,0 +1,8 @@
+{
+    "id": "f8716e6a-24e2-41fb-96b9-3e9e5593867a",
+    "type": "bugfix",
+    "description": "Correct URL encoding in endpoint resolution",
+    "issues": [
+        "awslabs/smithy-kotlin#888"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -166,7 +166,7 @@ object RuntimeTypes {
             val splitAsQueryParameters = symbol("splitAsQueryParameters")
             val toQueryParameters = symbol("toQueryParameters")
             val Url = symbol("Url")
-            val UrlDecodingBehavior = symbol("UrlDecodingBehavior")
+            val UrlDecoding = symbol("UrlDecoding")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -166,6 +166,7 @@ object RuntimeTypes {
             val splitAsQueryParameters = symbol("splitAsQueryParameters")
             val toQueryParameters = symbol("toQueryParameters")
             val Url = symbol("Url")
+            val UrlDecodingBehavior = symbol("UrlDecodingBehavior")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -148,7 +148,7 @@ class DefaultEndpointProviderGenerator(
             writer.withBlock("return #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
                 writeInline("#T.parse(", RuntimeTypes.Core.Net.Url)
                 renderExpression(rule.endpoint.url)
-                write(", #T.DO_NOT_DECODE),", RuntimeTypes.Core.Net.UrlDecodingBehavior)
+                write(", #T.DO_NOT_DECODE_PATH),", RuntimeTypes.Core.Net.UrlDecodingBehavior)
 
                 if (rule.endpoint.headers.isNotEmpty()) {
                     withBlock("headers = #T {", "},", RuntimeTypes.Http.Headers) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -148,7 +148,7 @@ class DefaultEndpointProviderGenerator(
             writer.withBlock("return #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
                 writeInline("#T.parse(", RuntimeTypes.Core.Net.Url)
                 renderExpression(rule.endpoint.url)
-                write("),")
+                write(", #T.DO_NOT_DECODE),", RuntimeTypes.Core.Net.UrlDecodingBehavior)
 
                 if (rule.endpoint.headers.isNotEmpty()) {
                     withBlock("headers = #T {", "},", RuntimeTypes.Http.Headers) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -148,7 +148,7 @@ class DefaultEndpointProviderGenerator(
             writer.withBlock("return #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
                 writeInline("#T.parse(", RuntimeTypes.Core.Net.Url)
                 renderExpression(rule.endpoint.url)
-                write(", #T.DO_NOT_DECODE_PATH),", RuntimeTypes.Core.Net.UrlDecodingBehavior)
+                write(", #1T.DecodeAll - #1T.DecodePath),", RuntimeTypes.Core.Net.UrlDecoding)
 
                 if (rule.endpoint.headers.isNotEmpty()) {
                     withBlock("headers = #T {", "},", RuntimeTypes.Http.Headers) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -107,10 +107,10 @@ class DefaultEndpointProviderTestGenerator(
 
         writer.withBlock("val expected = #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
             write(
-                "uri = #T.parse(#S, #T.DO_NOT_DECODE_PATH),",
+                "uri = #1T.parse(#2S, #3T.DecodeAll - #3T.DecodePath),",
                 RuntimeTypes.Core.Net.Url,
                 endpoint.url,
-                RuntimeTypes.Core.Net.UrlDecodingBehavior,
+                RuntimeTypes.Core.Net.UrlDecoding,
             )
 
             if (endpoint.headers.isNotEmpty()) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -107,7 +107,7 @@ class DefaultEndpointProviderTestGenerator(
 
         writer.withBlock("val expected = #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
             write(
-                "uri = #T.parse(#S, #T.DO_NOT_DECODE),",
+                "uri = #T.parse(#S, #T.DO_NOT_DECODE_PATH),",
                 RuntimeTypes.Core.Net.Url,
                 endpoint.url,
                 RuntimeTypes.Core.Net.UrlDecodingBehavior,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -106,7 +106,12 @@ class DefaultEndpointProviderTestGenerator(
         }
 
         writer.withBlock("val expected = #T(", ")", RuntimeTypes.SmithyClient.Endpoints.Endpoint) {
-            write("uri = #T.parse(#S),", RuntimeTypes.Core.Net.Url, endpoint.url)
+            write(
+                "uri = #T.parse(#S, #T.DO_NOT_DECODE),",
+                RuntimeTypes.Core.Net.Url,
+                endpoint.url,
+                RuntimeTypes.Core.Net.UrlDecodingBehavior,
+            )
 
             if (endpoint.headers.isNotEmpty()) {
                 withBlock("headers = #T {", "},", RuntimeTypes.Http.Headers) {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -158,7 +158,7 @@ class DefaultEndpointProviderGeneratorTest {
                 params.bazName == "gov"
             ) {
                 return Endpoint(
-                    Url.parse("https://basic.condition", UrlDecodingBehavior.DO_NOT_DECODE),
+                    Url.parse("https://basic.condition", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
                 )
             }
         """.formatForTest(indent = "        ")
@@ -175,7 +175,7 @@ class DefaultEndpointProviderGeneratorTest {
                     resourceIdPrefix == "gov.${'$'}{params.resourceId}"
                 ) {
                     return Endpoint(
-                        Url.parse("https://assignment.condition", UrlDecodingBehavior.DO_NOT_DECODE),
+                        Url.parse("https://assignment.condition", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
                     )
                 }
             }
@@ -200,7 +200,7 @@ class DefaultEndpointProviderGeneratorTest {
     fun testEndpointFields() {
         val expected = """
             return Endpoint(
-                Url.parse("https://global.api", UrlDecodingBehavior.DO_NOT_DECODE),
+                Url.parse("https://global.api", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
                 headers = Headers {
                     append("fooheader", "barheader")
                 },

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -158,7 +158,7 @@ class DefaultEndpointProviderGeneratorTest {
                 params.bazName == "gov"
             ) {
                 return Endpoint(
-                    Url.parse("https://basic.condition", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
+                    Url.parse("https://basic.condition", UrlDecoding.DecodeAll - UrlDecoding.DecodePath),
                 )
             }
         """.formatForTest(indent = "        ")
@@ -175,7 +175,7 @@ class DefaultEndpointProviderGeneratorTest {
                     resourceIdPrefix == "gov.${'$'}{params.resourceId}"
                 ) {
                     return Endpoint(
-                        Url.parse("https://assignment.condition", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
+                        Url.parse("https://assignment.condition", UrlDecoding.DecodeAll - UrlDecoding.DecodePath),
                     )
                 }
             }
@@ -200,7 +200,7 @@ class DefaultEndpointProviderGeneratorTest {
     fun testEndpointFields() {
         val expected = """
             return Endpoint(
-                Url.parse("https://global.api", UrlDecodingBehavior.DO_NOT_DECODE_PATH),
+                Url.parse("https://global.api", UrlDecoding.DecodeAll - UrlDecoding.DecodePath),
                 headers = Headers {
                     append("fooheader", "barheader")
                 },

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -158,7 +158,7 @@ class DefaultEndpointProviderGeneratorTest {
                 params.bazName == "gov"
             ) {
                 return Endpoint(
-                    Url.parse("https://basic.condition"),
+                    Url.parse("https://basic.condition", UrlDecodingBehavior.DO_NOT_DECODE),
                 )
             }
         """.formatForTest(indent = "        ")
@@ -175,7 +175,7 @@ class DefaultEndpointProviderGeneratorTest {
                     resourceIdPrefix == "gov.${'$'}{params.resourceId}"
                 ) {
                     return Endpoint(
-                        Url.parse("https://assignment.condition"),
+                        Url.parse("https://assignment.condition", UrlDecodingBehavior.DO_NOT_DECODE),
                     )
                 }
             }
@@ -200,7 +200,7 @@ class DefaultEndpointProviderGeneratorTest {
     fun testEndpointFields() {
         val expected = """
             return Endpoint(
-                Url.parse("https://global.api"),
+                Url.parse("https://global.api", UrlDecodingBehavior.DO_NOT_DECODE),
                 headers = Headers {
                     append("fooheader", "barheader")
                 },

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -871,7 +871,7 @@ public final class aws/smithy/kotlin/runtime/net/Url {
 
 public final class aws/smithy/kotlin/runtime/net/Url$Companion {
 	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/Url;
-	public final fun parse (Ljava/lang/String;Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;)Laws/smithy/kotlin/runtime/net/Url;
+	public final fun parse (Ljava/lang/String;Laws/smithy/kotlin/runtime/net/UrlDecoding;)Laws/smithy/kotlin/runtime/net/Url;
 }
 
 public final class aws/smithy/kotlin/runtime/net/UrlBuilder : aws/smithy/kotlin/runtime/util/CanDeepCopy {
@@ -903,11 +903,40 @@ public final class aws/smithy/kotlin/runtime/net/UrlBuilder$Companion {
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/net/Url;
 }
 
-public final class aws/smithy/kotlin/runtime/net/UrlDecodingBehavior : java/lang/Enum {
-	public static final field DECODE_COMPONENTS Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
-	public static final field DO_NOT_DECODE_PATH Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
-	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
-	public static fun values ()[Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
+public abstract class aws/smithy/kotlin/runtime/net/UrlDecoding {
+	public static final field Companion Laws/smithy/kotlin/runtime/net/UrlDecoding$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun contains (Laws/smithy/kotlin/runtime/net/UrlDecoding;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun minus (Laws/smithy/kotlin/runtime/net/UrlDecoding;)Laws/smithy/kotlin/runtime/net/UrlDecoding;
+	public final fun plus (Laws/smithy/kotlin/runtime/net/UrlDecoding;)Laws/smithy/kotlin/runtime/net/UrlDecoding;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecoding$Companion {
+	public final fun getDecodeAll ()Laws/smithy/kotlin/runtime/net/UrlDecoding;
+	public final fun getEntries ()Ljava/util/Set;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecoding$DecodeFragment : aws/smithy/kotlin/runtime/net/UrlDecoding {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/net/UrlDecoding$DecodeFragment;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecoding$DecodeNone : aws/smithy/kotlin/runtime/net/UrlDecoding {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/net/UrlDecoding$DecodeNone;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecoding$DecodePath : aws/smithy/kotlin/runtime/net/UrlDecoding {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/net/UrlDecoding$DecodePath;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecoding$DecodeQueryParameters : aws/smithy/kotlin/runtime/net/UrlDecoding {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/net/UrlDecoding$DecodeQueryParameters;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/net/UrlKt {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -905,7 +905,7 @@ public final class aws/smithy/kotlin/runtime/net/UrlBuilder$Companion {
 
 public final class aws/smithy/kotlin/runtime/net/UrlDecodingBehavior : java/lang/Enum {
 	public static final field DECODE_COMPONENTS Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
-	public static final field DO_NOT_DECODE Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
+	public static final field DO_NOT_DECODE_PATH Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
 	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
 	public static fun values ()[Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -871,6 +871,7 @@ public final class aws/smithy/kotlin/runtime/net/Url {
 
 public final class aws/smithy/kotlin/runtime/net/Url$Companion {
 	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/Url;
+	public final fun parse (Ljava/lang/String;Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;)Laws/smithy/kotlin/runtime/net/Url;
 }
 
 public final class aws/smithy/kotlin/runtime/net/UrlBuilder : aws/smithy/kotlin/runtime/util/CanDeepCopy {
@@ -900,6 +901,13 @@ public final class aws/smithy/kotlin/runtime/net/UrlBuilder : aws/smithy/kotlin/
 
 public final class aws/smithy/kotlin/runtime/net/UrlBuilder$Companion {
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/net/Url;
+}
+
+public final class aws/smithy/kotlin/runtime/net/UrlDecodingBehavior : java/lang/Enum {
+	public static final field DECODE_COMPONENTS Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
+	public static final field DO_NOT_DECODE Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
+	public static fun values ()[Laws/smithy/kotlin/runtime/net/UrlDecodingBehavior;
 }
 
 public final class aws/smithy/kotlin/runtime/net/UrlKt {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
@@ -110,7 +110,7 @@ public data class UserInfo(public val username: String, public val password: Str
  */
 public enum class UrlDecodingBehavior {
     /**
-     * Identifies that a URL string does not its path component need to be URL-decoded.
+     * Identifies that a URL string does not need its path component need to be URL-decoded.
      */
     DO_NOT_DECODE_PATH,
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
@@ -108,16 +108,16 @@ public data class UserInfo(public val username: String, public val password: Str
 /**
  * Identifies the type of decoding behavior desired when parsing a URL.
  */
-public enum class UrlDecodingBehavior(internal val maybeDecode: (String) -> String) {
+public enum class UrlDecodingBehavior {
     /**
-     * Identifies that a URL string does not need to be URL-decoded.
+     * Identifies that a URL string does not its path component need to be URL-decoded.
      */
-    DO_NOT_DECODE({ it }),
+    DO_NOT_DECODE_PATH,
 
     /**
      * Identifies that a URL string needs to be URL-decoded.
      */
-    DECODE_COMPONENTS(String::urlDecodeComponent),
+    DECODE_COMPONENTS,
 }
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
@@ -39,8 +39,8 @@ public data class Url(
     }
 
     public companion object {
-        public fun parse(url: String): Url = parse(url, UrlDecodingBehavior.DECODE_COMPONENTS)
-        public fun parse(url: String, decodingBehavior: UrlDecodingBehavior): Url = urlParseImpl(url, decodingBehavior)
+        public fun parse(url: String): Url = parse(url, UrlDecoding.DecodeAll)
+        public fun parse(url: String, decodingBehavior: UrlDecoding): Url = urlParseImpl(url, decodingBehavior)
     }
 
     override fun toString(): String = buildString {
@@ -104,21 +104,6 @@ private fun encodePath(
  * URL username and password
  */
 public data class UserInfo(public val username: String, public val password: String)
-
-/**
- * Identifies the type of decoding behavior desired when parsing a URL.
- */
-public enum class UrlDecodingBehavior {
-    /**
-     * Identifies that a URL string does not need its path component need to be URL-decoded.
-     */
-    DO_NOT_DECODE_PATH,
-
-    /**
-     * Identifies that a URL string needs to be URL-decoded.
-     */
-    DECODE_COMPONENTS,
-}
 
 /**
  * Construct a URL by its individual components

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/Url.kt
@@ -39,7 +39,8 @@ public data class Url(
     }
 
     public companion object {
-        public fun parse(url: String): Url = urlParseImpl(url)
+        public fun parse(url: String): Url = parse(url, UrlDecodingBehavior.DECODE_COMPONENTS)
+        public fun parse(url: String, decodingBehavior: UrlDecodingBehavior): Url = urlParseImpl(url, decodingBehavior)
     }
 
     override fun toString(): String = buildString {
@@ -103,6 +104,21 @@ private fun encodePath(
  * URL username and password
  */
 public data class UserInfo(public val username: String, public val password: String)
+
+/**
+ * Identifies the type of decoding behavior desired when parsing a URL.
+ */
+public enum class UrlDecodingBehavior(internal val maybeDecode: (String) -> String) {
+    /**
+     * Identifies that a URL string does not need to be URL-decoded.
+     */
+    DO_NOT_DECODE({ it }),
+
+    /**
+     * Identifies that a URL string needs to be URL-decoded.
+     */
+    DECODE_COMPONENTS(String::urlDecodeComponent),
+}
 
 /**
  * Construct a URL by its individual components

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlDecoding.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlDecoding.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.net
+
+/**
+ * Identifies the type of decoding behavior desired when parsing a URL.
+ */
+public sealed class UrlDecoding(private val mask: Int) {
+    /**
+     * Do not URL-decode any part of the given URL string
+     */
+    public object DecodeNone : UrlDecoding(0) {
+        override fun toString(): String = "DecodeNone"
+    }
+
+    /**
+     * URL-decode the path of the given URL string
+     */
+    public object DecodePath : UrlDecoding(1) {
+        override fun toString(): String = "DecodePath"
+    }
+
+    /**
+     * URL-decode the query parameters of the given URL string
+     */
+    public object DecodeQueryParameters : UrlDecoding(2) {
+        override fun toString(): String = "DecodeQueryParameters"
+    }
+
+    /**
+     * URL-decode the fragment of the given URL string
+     */
+    public object DecodeFragment : UrlDecoding(4) {
+        override fun toString(): String = "DecodeFragment"
+    }
+
+    private class Composite(mask: Int) : UrlDecoding(mask)
+
+    public operator fun plus(other: UrlDecoding): UrlDecoding = Composite(mask or other.mask)
+    public operator fun minus(other: UrlDecoding): UrlDecoding = Composite(mask and other.mask.inv())
+
+    override fun equals(other: Any?): Boolean = other is UrlDecoding && mask == other.mask
+    override fun hashCode(): Int = mask
+    override fun toString(): String = entries.filter(::contains).joinToString("|")
+
+    public operator fun contains(item: UrlDecoding): Boolean = mask and item.mask != 0
+
+    public companion object {
+        /**
+         * Gets a collection of all the individual URL decoding behaviors
+         */
+        public val entries: Set<UrlDecoding> = setOf(DecodePath, DecodeQueryParameters, DecodeFragment)
+
+        /**
+         * URL-decode all parts of the given URL string
+         */
+        public val DecodeAll: UrlDecoding = Composite(entries.sumOf { it.mask })
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
@@ -37,7 +37,7 @@ internal fun urlParseImpl(url: String, decodingBehavior: UrlDecodingBehavior): U
         if (next.startsWith("?")) {
             next = next.capture(1 until next.firstIndexOrEnd("#")) {
                 it.splitAsQueryString().entries.forEach { (k, v) ->
-                    parameters.appendAll(k.urlEncodeComponent(), v.map(String::urlDecodeComponent))
+                    parameters.appendAll(k.urlDecodeComponent(), v.map(String::urlDecodeComponent))
                 }
             }
         }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.net
 import aws.smithy.kotlin.runtime.util.text.splitAsQueryString
 import aws.smithy.kotlin.runtime.util.text.urlDecodeComponent
 
-internal fun urlParseImpl(url: String): Url =
+internal fun urlParseImpl(url: String, decodingBehavior: UrlDecodingBehavior): Url =
     UrlBuilder {
         var next = url
             .captureUntilAndSkip("://") {
@@ -25,20 +25,20 @@ internal fun urlParseImpl(url: String): Url =
 
         if (next.startsWith("/")) {
             next = next.capture(1 until next.firstIndexOrEnd("?", "#")) {
-                path = "/${it.urlDecodeComponent()}"
+                path = "/${decodingBehavior.maybeDecode(it)}"
             }
         }
 
         if (next.startsWith("?")) {
             next = next.capture(1 until next.firstIndexOrEnd("#")) {
                 it.splitAsQueryString().entries.forEach { (k, v) ->
-                    parameters.appendAll(k.urlDecodeComponent(), v.map(String::urlDecodeComponent))
+                    parameters.appendAll(decodingBehavior.maybeDecode(k), v.map { decodingBehavior.maybeDecode(it) })
                 }
             }
         }
 
         if (next.startsWith('#') && next.length > 1) {
-            fragment = next.substring(1).urlDecodeComponent()
+            fragment = decodingBehavior.maybeDecode(next.substring(1))
         }
     }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/UrlParser.kt
@@ -6,7 +6,6 @@ package aws.smithy.kotlin.runtime.net
 
 import aws.smithy.kotlin.runtime.util.text.splitAsQueryString
 import aws.smithy.kotlin.runtime.util.text.urlDecodeComponent
-import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent
 
 internal fun urlParseImpl(url: String, decodingBehavior: UrlDecodingBehavior): Url =
     UrlBuilder {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlDecodingTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlDecodingTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.net
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UrlDecodingTest {
+    @Test
+    fun testDecodeAll() {
+        assertTrue(UrlDecoding.DecodePath in UrlDecoding.DecodeAll)
+        assertTrue(UrlDecoding.DecodeQueryParameters in UrlDecoding.DecodeAll)
+        assertTrue(UrlDecoding.DecodeFragment in UrlDecoding.DecodeAll)
+        assertFalse(UrlDecoding.DecodeNone in UrlDecoding.DecodeAll)
+    }
+
+    @Test
+    fun testPlus() {
+        val test = UrlDecoding.DecodePath + UrlDecoding.DecodeFragment
+        assertTrue(UrlDecoding.DecodePath in test)
+        assertFalse(UrlDecoding.DecodeQueryParameters in test)
+        assertTrue(UrlDecoding.DecodeFragment in test)
+    }
+
+    @Test
+    fun testMinus() {
+        val test = UrlDecoding.DecodeAll - UrlDecoding.DecodeFragment
+        assertTrue(UrlDecoding.DecodePath in test)
+        assertTrue(UrlDecoding.DecodeQueryParameters in test)
+        assertFalse(UrlDecoding.DecodeFragment in test)
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
@@ -159,7 +159,7 @@ class UrlParserTest {
         assertEquals("/path/suffix", Url.parse("https://host:80/path%2Fsuffix").path)
         assertEquals(
             "/path%2Fsuffix",
-            Url.parse("https://host:80/path%2Fsuffix", UrlDecodingBehavior.DO_NOT_DECODE_PATH).path,
+            Url.parse("https://host:80/path%2Fsuffix", UrlDecoding.DecodeAll - UrlDecoding.DecodePath).path,
         )
     }
 
@@ -202,6 +202,18 @@ class UrlParserTest {
             },
             Url.parse("https://host/path?k=v&k=v&k2=v%202&k2=v%262&k%203=v3#fragment").parameters,
         )
+
+        assertEquals(
+            QueryParameters {
+                appendAll("k", listOf("v", "v"))
+                appendAll("k2", listOf("v%202", "v%262"))
+                appendAll("k%203", listOf("v3"))
+            },
+            Url.parse(
+                "https://host/path?k=v&k=v&k2=v%202&k2=v%262&k%203=v3#fragment",
+                UrlDecoding.DecodeAll - UrlDecoding.DecodeQueryParameters,
+            ).parameters,
+        )
     }
 
     @Test
@@ -227,6 +239,14 @@ class UrlParserTest {
         assertEquals("frag&5ment", Url.parse("https://host?k=v#frag%265ment").fragment)
         assertEquals("frag&5ment", Url.parse("https://host/?k=v#frag%265ment").fragment)
         assertEquals("frag&5ment", Url.parse("https://host/path?k=v#frag%265ment").fragment)
+
+        assertEquals(
+            "frag%265ment",
+            Url.parse(
+                "https://host/path?k=v#frag%265ment",
+                UrlDecoding.DecodeAll - UrlDecoding.DecodeFragment,
+            ).fragment,
+        )
     }
 
     @Test

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
@@ -156,6 +156,11 @@ class UrlParserTest {
     fun testPath() {
         assertEquals("/path", Url.parse("https://host/path").path)
         assertEquals("/path", Url.parse("https://host:80/path").path)
+        assertEquals("/path/suffix", Url.parse("https://host:80/path%2Fsuffix").path)
+        assertEquals(
+            "/path%2Fsuffix",
+            Url.parse("https://host:80/path%2Fsuffix", UrlDecodingBehavior.DO_NOT_DECODE).path,
+        )
     }
 
     @Test
@@ -195,6 +200,17 @@ class UrlParserTest {
                 appendAll("k2", listOf("v 2", "v&2"))
             },
             Url.parse("https://host/path?k=v&k=v&k2=v%202&k2=v%262#fragment").parameters,
+        )
+
+        assertEquals(
+            QueryParameters {
+                appendAll("k", listOf("v", "v"))
+                appendAll("k2", listOf("v%202", "v%262"))
+            },
+            Url.parse(
+                "https://host/path?k=v&k=v&k2=v%202&k2=v%262#fragment",
+                UrlDecodingBehavior.DO_NOT_DECODE,
+            ).parameters,
         )
     }
 

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
@@ -159,7 +159,7 @@ class UrlParserTest {
         assertEquals("/path/suffix", Url.parse("https://host:80/path%2Fsuffix").path)
         assertEquals(
             "/path%2Fsuffix",
-            Url.parse("https://host:80/path%2Fsuffix", UrlDecodingBehavior.DO_NOT_DECODE).path,
+            Url.parse("https://host:80/path%2Fsuffix", UrlDecodingBehavior.DO_NOT_DECODE_PATH).path,
         )
     }
 
@@ -200,17 +200,6 @@ class UrlParserTest {
                 appendAll("k2", listOf("v 2", "v&2"))
             },
             Url.parse("https://host/path?k=v&k=v&k2=v%202&k2=v%262#fragment").parameters,
-        )
-
-        assertEquals(
-            QueryParameters {
-                appendAll("k", listOf("v", "v"))
-                appendAll("k2", listOf("v%202", "v%262"))
-            },
-            Url.parse(
-                "https://host/path?k=v&k=v&k2=v%202&k2=v%262#fragment",
-                UrlDecodingBehavior.DO_NOT_DECODE,
-            ).parameters,
         )
     }
 

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/UrlParserTest.kt
@@ -198,8 +198,9 @@ class UrlParserTest {
             QueryParameters {
                 appendAll("k", listOf("v", "v"))
                 appendAll("k2", listOf("v 2", "v&2"))
+                appendAll("k 3", listOf("v3"))
             },
-            Url.parse("https://host/path?k=v&k=v&k2=v%202&k2=v%262#fragment").parameters,
+            Url.parse("https://host/path?k=v&k=v&k2=v%202&k2=v%262&k%203=v3#fragment").parameters,
         )
     }
 


### PR DESCRIPTION
## Issue \#

Closes #888 

## Description of changes

This change corrects a bug in URL encoding in endpoint resolution which caused parsing to URL-_decode_ strings which were already properly encoded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
