### PR TITLE
fix: make user-supplied region available to config resolution providers

### DIFF
--- a/.changes/7792482f-c9f9-4919-b230-30542334d3f7.json
+++ b/.changes/7792482f-c9f9-4919-b230-30542334d3f7.json
@@ -1,0 +1,8 @@
+{
+    "id": "7792482f-c9f9-4919-b230-30542334d3f7",
+    "type": "feature",
+    "description": "Make user-supplied region available to config resolution providers (`ProfileCredentialsProvider` and `StsAssumeRoleCredentialsProvider`) if no region is set at the time of setting credentials provider to client",
+    "issues": [
+        "awslabs/smithy-kotlin#583"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.kotlin.codegen.customization.s3
 
 import software.amazon.smithy.aws.traits.ServiceTrait
@@ -9,28 +14,32 @@ import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.kotlin.codegen.rendering.util.AbstractConfigGenerator
 import software.amazon.smithy.model.Model
 
-class UserSuppliedRegionForCredentialsProviders: KotlinIntegration {
+class UserSuppliedRegionForCredentialsProviders : KotlinIntegration {
     override val sectionWriters: List<SectionWriterBinding> = listOf(
         SectionWriterBinding(AbstractConfigGenerator.CustomConfigPropertyType) { writer, default ->
-            if(default != null && default.contains("override val credentialsProvider: CredentialsProvider")) {
+            if (default != null && default.contains("override val credentialsProvider: CredentialsProvider")) {
                 writer.withBlock(
                     "override val credentialsProvider: CredentialsProvider = when(builder.credentialsProvider) {",
-                    "} ?: DefaultChainCredentialsProvider(httpClient = httpClient, region = region).manage()")
-                {
+                    "} ?: DefaultChainCredentialsProvider(httpClient = httpClient, region = region).manage()",
+                ) {
                     withBlock(
                         "is aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider -> {",
-                        "}"
+                        "}",
                     ) {
-                        write("if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).getRegion() == null) " +
-                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).setRegion(region)")
+                        write(
+                            "if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).getRegion() == null) " +
+                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).setRegion(region)",
+                        )
                         write("builder.credentialsProvider")
                     }
                     withBlock(
                         "is aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider -> {",
-                        "}"
+                        "}",
                     ) {
-                        write("if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).getRegion() == null) " +
-                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).setRegion(region)")
+                        write(
+                            "if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).getRegion() == null) " +
+                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).setRegion(region)",
+                        )
                         write("builder.credentialsProvider")
                     }
                     write("else -> builder.credentialsProvider")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
@@ -1,0 +1,46 @@
+package software.amazon.smithy.kotlin.codegen.customization.s3
+
+import software.amazon.smithy.aws.traits.ServiceTrait
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.core.withBlock
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.integration.SectionWriterBinding
+import software.amazon.smithy.kotlin.codegen.model.getTrait
+import software.amazon.smithy.kotlin.codegen.rendering.util.AbstractConfigGenerator
+import software.amazon.smithy.model.Model
+
+class UserSuppliedRegionForCredentialsProviders: KotlinIntegration {
+    override val sectionWriters: List<SectionWriterBinding> = listOf(
+        SectionWriterBinding(AbstractConfigGenerator.CustomConfigPropertyType) { writer, default ->
+            if(default != null && default.contains("override val credentialsProvider: CredentialsProvider")) {
+                writer.withBlock(
+                    "override val credentialsProvider: CredentialsProvider = when(builder.credentialsProvider) {",
+                    "} ?: DefaultChainCredentialsProvider(httpClient = httpClient, region = region).manage()")
+                {
+                    withBlock(
+                        "is aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider -> {",
+                        "}"
+                    ) {
+                        write("if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).getRegion() == null) " +
+                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider).setRegion(region)")
+                        write("builder.credentialsProvider")
+                    }
+                    withBlock(
+                        "is aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider -> {",
+                        "}"
+                    ) {
+                        write("if ((builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).getRegion() == null) " +
+                                "(builder.credentialsProvider as aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider).setRegion(region)")
+                        write("builder.credentialsProvider")
+                    }
+                    write("else -> builder.credentialsProvider")
+                }
+            } else {
+                writer.write(default)
+            }
+        },
+    )
+
+    override fun enabledForService(model: Model, settings: KotlinSettings): Boolean =
+        model.expectShape(settings.service).getTrait<ServiceTrait>()?.sdkId.equals("s3", true)
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProviders.kt
@@ -5,12 +5,10 @@
 
 package software.amazon.smithy.kotlin.codegen.customization.s3
 
-import software.amazon.smithy.aws.traits.ServiceTrait
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.integration.SectionWriterBinding
-import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.kotlin.codegen.rendering.util.AbstractConfigGenerator
 import software.amazon.smithy.model.Model
 
@@ -51,5 +49,5 @@ class UserSuppliedRegionForCredentialsProviders : KotlinIntegration {
     )
 
     override fun enabledForService(model: Model, settings: KotlinSettings): Boolean =
-        model.expectShape(settings.service).getTrait<ServiceTrait>()?.sdkId.equals("s3", true)
+        model.expectShape(settings.service).isServiceShape
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
@@ -116,7 +116,7 @@ abstract class AbstractConfigGenerator {
                     )
                 }
                 is ConfigPropertyType.Custom -> writer.declareSection(CustomConfigPropertyType){
-                    prop.propertyType.render(prop, writer) // TODO: DO something here because this is causing something to not be imported
+                    prop.propertyType.render(prop, writer)
                 }
             }
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
@@ -115,7 +115,7 @@ abstract class AbstractConfigGenerator {
                         prop.propertyType.default,
                     )
                 }
-                is ConfigPropertyType.Custom -> writer.declareSection(CustomConfigPropertyType){
+                is ConfigPropertyType.Custom -> writer.declareSection(CustomConfigPropertyType) {
                     prop.propertyType.render(prop, writer)
                 }
             }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
@@ -9,7 +9,9 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
+import software.amazon.smithy.kotlin.codegen.core.declareSection
 import software.amazon.smithy.kotlin.codegen.core.withBlock
+import software.amazon.smithy.kotlin.codegen.integration.SectionId
 import software.amazon.smithy.kotlin.codegen.model.PropertyTypeMutability
 import software.amazon.smithy.kotlin.codegen.model.propertyTypeMutability
 
@@ -85,6 +87,7 @@ abstract class AbstractConfigGenerator {
         }
     }
 
+    object CustomConfigPropertyType : SectionId
     protected open fun renderImmutableProperties(props: Collection<ConfigProperty>, writer: KotlinWriter) {
         props.forEach { prop ->
             val override = if (prop.requiresOverride) "override" else "public"
@@ -112,7 +115,9 @@ abstract class AbstractConfigGenerator {
                         prop.propertyType.default,
                     )
                 }
-                is ConfigPropertyType.Custom -> prop.propertyType.render(prop, writer)
+                is ConfigPropertyType.Custom -> writer.declareSection(CustomConfigPropertyType){
+                    prop.propertyType.render(prop, writer) // TODO: DO something here because this is causing something to not be imported
+                }
             }
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -1,3 +1,4 @@
+software.amazon.smithy.kotlin.codegen.customization.s3.UserSuppliedRegionForCredentialsProviders
 software.amazon.smithy.kotlin.codegen.lang.BuiltinPreprocessor
 software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor
 software.amazon.smithy.kotlin.codegen.model.SetRefactorPreprocessor

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
@@ -1,0 +1,36 @@
+package software.amazon.smithy.kotlin.codegen.customization.s3
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.kotlin.codegen.test.defaultSettings
+import software.amazon.smithy.kotlin.codegen.test.prependNamespaceAndService
+import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
+import software.amazon.smithy.model.Model
+
+class UserSuppliedRegionForCredentialsProvidersTest {
+    @Test
+    fun notS3ModelIntegration(){
+        val model = sampleModel("not s3")
+        val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
+        assertFalse(isEnabledForModel)
+    }
+
+    @Test
+    fun s3ModelIntegration(){
+        val model = sampleModel("s3")
+        val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
+        assertTrue(isEnabledForModel)
+    }
+}
+
+private fun sampleModel(serviceName: String): Model =
+    """
+        @http(method: "PUT", uri: "/foo")
+        operation Foo { }
+        
+        @http(method: "POST", uri: "/bar")
+        operation Bar { }
+    """
+        .prependNamespaceAndService(operations = listOf("Foo", "Bar"), serviceName = serviceName)
+        .toSmithyModel()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.kotlin.codegen.customization.s3
 
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.kotlin.codegen.test.defaultSettings
@@ -15,15 +14,8 @@ import software.amazon.smithy.model.Model
 
 class UserSuppliedRegionForCredentialsProvidersTest {
     @Test
-    fun notS3ModelIntegration() {
-        val model = sampleModel("not s3")
-        val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
-        assertFalse(isEnabledForModel)
-    }
-
-    @Test
-    fun s3ModelIntegration() {
-        val model = sampleModel("s3")
+    fun serviceModelIntegration() {
+        val model = sampleModel("sample")
         val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
         assertTrue(isEnabledForModel)
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/customization/s3/UserSuppliedRegionForCredentialsProvidersTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.kotlin.codegen.customization.s3
 
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -10,14 +15,14 @@ import software.amazon.smithy.model.Model
 
 class UserSuppliedRegionForCredentialsProvidersTest {
     @Test
-    fun notS3ModelIntegration(){
+    fun notS3ModelIntegration() {
         val model = sampleModel("not s3")
         val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
         assertFalse(isEnabledForModel)
     }
 
     @Test
-    fun s3ModelIntegration(){
+    fun s3ModelIntegration() {
         val model = sampleModel("s3")
         val isEnabledForModel = UserSuppliedRegionForCredentialsProviders().enabledForService(model, model.defaultSettings())
         assertTrue(isEnabledForModel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \# [583](https://github.com/awslabs/aws-sdk-kotlin/issues/583)
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Make user-supplied region available to config resolution providers ( `ProfileCredentialsProvider` and `StsAssumeRoleCredentialsProvider`) if no region is set at the time of setting credentials provider to client 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
