### PR TITLE
fix: make connection resets retryable in OkHttp engine

### DIFF
--- a/.changes/d50afb27-0e5c-46b3-9c9c-865a3c75dd21.json
+++ b/.changes/d50afb27-0e5c-46b3-9c9c-865a3c75dd21.json
@@ -1,0 +1,8 @@
+{
+    "id": "d50afb27-0e5c-46b3-9c9c-865a3c75dd21",
+    "type": "bugfix",
+    "description": "Retry connection reset errors in OkHttp engine",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#905"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
+import java.io.EOFException
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -33,6 +34,8 @@ class OkHttpExceptionTest {
             ExceptionTest(SocketTimeoutException("read timeout"), expectedError = HttpErrorCode.SOCKET_TIMEOUT),
             ExceptionTest(IOException(SSLHandshakeException("negotiate error")), expectedError = HttpErrorCode.TLS_NEGOTIATION_ERROR),
             ExceptionTest(ConnectException("test connect error"), expectedError = HttpErrorCode.SDK_UNKNOWN, true),
+            // see https://github.com/awslabs/aws-sdk-kotlin/issues/905
+            ExceptionTest(IOException("unexpected end of stream on https://test.aws.com", EOFException("\\n not found: limit=0 content=...")), expectedError = HttpErrorCode.CONNECTION_CLOSED, expectedRetryable = true),
         )
 
         for (test in tests) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes aws-sdk-kotlin#905

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

https://github.com/awslabs/smithy-kotlin/pull/829 disabled the OkHttp engine setting `retryOnConnectionFailure`. The reason for this was sound, we don't want an "inner" retry loop running inside an HTTP engine as it will retry outside the scope of the retry strategy/policy (e.g. not respecting backoffs, etc). 

This increases the chance we hit a connection/network related error though. In particular S3 seems to aggressively reset connections under load. The logs show a connection is grabbed from the pool that was used previously for a successful request and fails on getting the response headers (it sends the request at which point S3 closes the connection). 


This manifest with an exception like the following:

```
    java.io.IOException: unexpected end of stream on https://mybucket.s3.us-west-2.amazonaws.com/...                                 at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:209)                                                                     
        at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:111)                                                                                            at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:95)                                                                           
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)                                                                           
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)                                                                                    
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:84)                                                                                   
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:65)                                                               
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at aws.smithy.kotlin.runtime.http.engine.okhttp.MetricsInterceptor.intercept(MetricsInterceptor.kt:30)                                                          
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)                                                                                      at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:205)                                                                         at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:537)                                                                                                  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)                                                                    
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)                                                                            at java.base/java.lang.Thread.run(Thread.java:829)                                                                                                              
    Caused by: java.io.EOFException: \n not found: limit=0 content=…                                                                                                    
        at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:332)                                                                                                at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)                                                                                           
        at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:179)                                                                     
        ... 18 more   
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
