### PR TITLE
feat: add content length validation interceptor

### DIFF
--- a/.changes/ee74d8c0-697e-4ca2-95c9-d0285876c71a.json
+++ b/.changes/ee74d8c0-697e-4ca2-95c9-d0285876c71a.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e8e536e-a39c-41a8-acfb-3877528a321f",
+  "type": "feature",
+  "description": "Validate returned content length on S3 `GetObject` responses.",
+  "issues": [
+    "awslabs/aws-sdk-kotlin#745"
+  ]
+}

--- a/.changes/ee74d8c0-697e-4ca2-95c9-d0285876c71a.json
+++ b/.changes/ee74d8c0-697e-4ca2-95c9-d0285876c71a.json
@@ -1,7 +1,7 @@
 {
   "id": "4e8e536e-a39c-41a8-acfb-3877528a321f",
   "type": "feature",
-  "description": "Validate returned content length on S3 `GetObject` responses.",
+  "description": "Add a response length validation interceptor",
   "issues": [
     "awslabs/aws-sdk-kotlin#745"
   ]

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -87,6 +87,7 @@ object RuntimeTypes {
             val Md5ChecksumInterceptor = symbol("Md5ChecksumInterceptor")
             val FlexibleChecksumsRequestInterceptor = symbol("FlexibleChecksumsRequestInterceptor")
             val FlexibleChecksumsResponseInterceptor = symbol("FlexibleChecksumsResponseInterceptor")
+            val ResponseLengthValidationInterceptor = symbol("ResponseLengthValidationInterceptor")
         }
     }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
@@ -19,8 +19,8 @@ public class ResponseLengthValidationInterceptor: HttpInterceptor {
     override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
         val response = context.protocolResponse
 
-        return response.body.contentLength?.let {
-            response.copy(body = response.body.toLengthValidatingBody(it))
+        return response.headers["Content-Length"]?.let {
+            response.copy(body = response.body.toLengthValidatingBody(it.toLong()))
         } ?: response
     }
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
@@ -2,13 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package aws.smthy.kotlin.runtime.http.interceptors
+package aws.smithy.kotlin.runtime.http.interceptors
 
 import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
 import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.http.toHttpBody

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
@@ -15,7 +15,7 @@ import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.*
 
 @InternalApi
-public class ResponseLengthValidationInterceptor: HttpInterceptor {
+public class ResponseLengthValidationInterceptor : HttpInterceptor {
     override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
         val response = context.protocolResponse
 
@@ -34,7 +34,7 @@ private fun HttpBody.toLengthValidatingBody(expectedContentLength: Long): HttpBo
 
 private class LengthValidatingSource(
     private val source: SdkSource,
-    private val expectedContentLength: Long
+    private val expectedContentLength: Long,
 ) : SdkSource by source {
     var bytesReceived = 0L
     override fun read(sink: SdkBuffer, limit: Long): Long = source.read(sink, limit).also {
@@ -48,7 +48,7 @@ private class LengthValidatingSource(
 
 private class LengthValidatingByteReadChannel(
     private val chan: SdkByteReadChannel,
-    private val expectedContentLength: Long
+    private val expectedContentLength: Long,
 ) : SdkByteReadChannel by chan {
     var bytesReceived = 0L
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
@@ -80,5 +80,11 @@ private class LengthValidatingByteReadChannel(
 }
 
 private fun validateContentLength(expected: Long, actual: Long) {
-    check(expected == actual) { "Total bytes consumed ($actual) does not match expected ($expected)." }
+    if (expected != actual) {
+        if (expected > actual) {
+            throw EOFException("Expected $expected bytes but received $actual bytes. The connection may have been closed prematurely.")
+        } else {
+            throw EOFException("Expected $expected bytes but received $actual bytes.")
+        }
+    }
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smthy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.ClientException
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.http.toHttpBody
+import aws.smithy.kotlin.runtime.io.*
+
+@InternalApi
+public class ResponseLengthValidationInterceptor: HttpInterceptor {
+    override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
+        val response = context.protocolResponse
+
+        return response.body.contentLength?.let {
+            response.copy(body = response.body.toLengthValidatingBody(it))
+        } ?: response
+    }
+}
+
+@InternalApi
+private fun HttpBody.toLengthValidatingBody(expectedContentLength: Long): HttpBody = when (this) {
+    is HttpBody.SourceContent -> LengthValidatingSource(readFrom(), expectedContentLength).toHttpBody(contentLength)
+    is HttpBody.ChannelContent -> LengthValidatingByteReadChannel(readFrom(), expectedContentLength).toHttpBody(contentLength)
+    else -> throw ClientException("HttpBody type is not supported")
+}
+
+private class LengthValidatingSource(
+    private val source: SdkSource,
+    private val expectedContentLength: Long
+) : SdkSource by source {
+    var bytesReceived = 0L
+    override fun read(sink: SdkBuffer, limit: Long): Long = source.read(sink, limit).also {
+        if (it == -1L) {
+            validateContentLength(expectedContentLength, bytesReceived)
+        } else {
+            bytesReceived += it
+        }
+    }
+}
+
+private class LengthValidatingByteReadChannel(
+    private val chan: SdkByteReadChannel,
+    private val expectedContentLength: Long
+) : SdkByteReadChannel by chan {
+    var bytesReceived = 0L
+
+    override suspend fun read(sink: SdkBuffer, limit: Long): Long = chan.read(sink, limit).also {
+        if (it == -1L) {
+            validateContentLength(bytesReceived, expectedContentLength)
+        } else {
+            bytesReceived += it
+        }
+    }
+}
+
+private fun validateContentLength(expected: Long, actual: Long) {
+    check(expected == actual) { "Total bytes consumed ($actual) does not match expected ($expected)." }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.http.*
+import aws.smithy.kotlin.runtime.http.operation.*
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.response.HttpCall
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.httptest.TestEngine
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smthy.kotlin.runtime.http.interceptors.ResponseLengthValidationInterceptor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+data class ResponseLengthValidationTestInput(val value: String)
+data class ResponseLengthValidationTestOutput(val body: HttpBody)
+
+inline fun <reified I> newResponseLengthValidationTestOperation(serialized: HttpRequestBuilder): SdkHttpOperation<I, ResponseLengthValidationTestOutput> =
+    SdkHttpOperation.build {
+        serializer = HttpSerialize { context, input -> serialized }
+
+        deserializer = HttpDeserialize { context, response -> ResponseLengthValidationTestOutput(response.body) }
+
+        context {
+            // required operation context
+            operationName = "TestOperation"
+            serviceName = "TestService"
+        }
+    }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResponseLengthValidationInterceptorTest {
+    val contentLengthHeaderName = "Content-Length"
+    val response = "a".repeat(500).toByteArray()
+
+    private fun getMockClient(response: ByteArray, responseHeaders: Headers = Headers.Empty): SdkHttpClient {
+        val mockEngine = TestEngine { _, request ->
+            val body = object : HttpBody.SourceContent() {
+                override val contentLength: Long = response.size.toLong()
+                override fun readFrom(): SdkSource = response.source()
+                override val isOneShot: Boolean get() = false
+            }
+
+            val resp = HttpResponse(HttpStatusCode.OK, responseHeaders, body)
+
+            HttpCall(request, resp, Instant.now(), Instant.now())
+        }
+        return SdkHttpClient(mockEngine)
+    }
+
+    @Test
+    fun testCorrectLengthReturned() = runTest {
+        val req = HttpRequestBuilder()
+        val op = newResponseLengthValidationTestOperation<ResponseLengthValidationTestInput>(req)
+
+        op.interceptors.add(ResponseLengthValidationInterceptor())
+
+        val responseHeaders = Headers {
+            append(contentLengthHeaderName, "${response.size}")
+        }
+
+        val client = getMockClient(response, responseHeaders)
+
+        val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
+        output.body.readAll()
+    }
+
+    @Test
+    fun testIncorrectLengthReturned() = runTest {
+        val req = HttpRequestBuilder()
+        val op = newResponseLengthValidationTestOperation<ResponseLengthValidationTestInput>(req)
+
+        op.interceptors.add(ResponseLengthValidationInterceptor())
+
+        val responseHeaders = Headers {
+            append(contentLengthHeaderName, "${response.size * 2}") // expect double the actual content length
+        }
+        val client = getMockClient(response, responseHeaders)
+
+        assertFailsWith<IllegalStateException> {
+            val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
+            output.body.readAll()
+        }
+    }
+
+    @Test
+    fun testNoContentLengthSkipsValidation() = runTest {
+        val req = HttpRequestBuilder()
+        val op = newResponseLengthValidationTestOperation<ResponseLengthValidationTestInput>(req)
+
+        op.interceptors.add(ResponseLengthValidationInterceptor())
+        val responseHeaders = Headers {}
+
+        val client = getMockClient(response, responseHeaders)
+
+        val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
+        output.body.readAll()
+    }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package aws.smithy.kotlin.runtime.http.interceptors
 
 import aws.smithy.kotlin.runtime.http.*

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpCall
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
+import aws.smithy.kotlin.runtime.io.EOFException
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.source
@@ -103,7 +104,7 @@ class ResponseLengthValidationInterceptorTest {
             getMockClientWithSourceBody(response, responseHeaders),
             getMockClientWithChannelBody(response, responseHeaders),
         ).forEach { client ->
-            assertFailsWith<IllegalStateException> {
+            assertFailsWith<EOFException> {
                 val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
                 output.body.readAll()
             }
@@ -125,7 +126,7 @@ class ResponseLengthValidationInterceptorTest {
             getMockClientWithChannelBody(response, responseHeaders),
             getMockClientWithSourceBody(response, responseHeaders),
         ).forEach { client ->
-            assertFailsWith<IllegalStateException> {
+            assertFailsWith<EOFException> {
                 val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
                 output.body.readAll()
             }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -23,9 +23,9 @@ data class ResponseLengthValidationTestOutput(val body: HttpBody)
 
 inline fun <reified I> newResponseLengthValidationTestOperation(serialized: HttpRequestBuilder): SdkHttpOperation<I, ResponseLengthValidationTestOutput> =
     SdkHttpOperation.build {
-        serializer = HttpSerialize { context, input -> serialized }
+        serializer = HttpSerialize { _, _ -> serialized }
 
-        deserializer = HttpDeserialize { context, response -> ResponseLengthValidationTestOutput(response.body) }
+        deserializer = HttpDeserialize { _, response -> ResponseLengthValidationTestOutput(response.body) }
 
         context {
             // required operation context

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -83,7 +83,7 @@ class ResponseLengthValidationInterceptorTest {
 
         listOf(
             getMockClientWithChannelBody(response, responseHeaders),
-            getMockClientWithSourceBody(response, responseHeaders)
+            getMockClientWithSourceBody(response, responseHeaders),
         ).forEach { client ->
             val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
             output.body.readAll()
@@ -124,7 +124,7 @@ class ResponseLengthValidationInterceptorTest {
 
         listOf(
             getMockClientWithChannelBody(response, responseHeaders),
-            getMockClientWithSourceBody(response, responseHeaders)
+            getMockClientWithSourceBody(response, responseHeaders),
         ).forEach { client ->
             assertFailsWith<IllegalStateException> {
                 val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
@@ -143,7 +143,7 @@ class ResponseLengthValidationInterceptorTest {
 
         listOf(
             getMockClientWithChannelBody(response, responseHeaders),
-            getMockClientWithSourceBody(response, responseHeaders)
+            getMockClientWithSourceBody(response, responseHeaders),
         ).forEach { client ->
             val output = op.roundTrip(client, ResponseLengthValidationTestInput("input"))
             output.body.readAll()

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -14,7 +14,6 @@ import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.source
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smthy.kotlin.runtime.http.interceptors.ResponseLengthValidationInterceptor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds an interceptor which validates the `Content-Length` response header against the response body. If the lengths don't match, an `IllegalStateException` is thrown.

This interceptor is currently only used for S3 `GetObject` responses.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/745

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR is required to support validating `Content-Length` response headers for S3 `GetObject` responses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
