### PR TITLE
misc: remove expectedHttpStatus from operation context

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -214,7 +214,6 @@ abstract class HttpProtocolClientGenerator(
 
             // execution context
             writer.openBlock("context {", "}") {
-                writer.write("expectedHttpStatus = ${httpTrait.code}")
                 // property from implementing SdkClient
                 writer.write("operationName = #S", op.id.name)
                 writer.write("serviceName = #L", "ServiceId")

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -81,7 +81,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooOperationSerializer()
             deserializer = GetFooOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFoo"
                 serviceName = ServiceId
             }
@@ -105,7 +104,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoInputOperationSerializer()
             deserializer = GetFooNoInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoInput"
                 serviceName = ServiceId
             }
@@ -129,7 +127,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoOutputOperationSerializer()
             deserializer = GetFooNoOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoOutput"
                 serviceName = ServiceId
             }
@@ -153,7 +150,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingInputOperationSerializer()
             deserializer = GetFooStreamingInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingInput"
                 serviceName = ServiceId
             }
@@ -177,7 +173,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingOutputOperationSerializer()
             deserializer = GetFooStreamingOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutput"
                 serviceName = ServiceId
             }
@@ -201,7 +196,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingOutputNoInputOperationSerializer()
             deserializer = GetFooStreamingOutputNoInputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingOutputNoInput"
                 serviceName = ServiceId
             }
@@ -225,7 +219,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooStreamingInputNoOutputOperationSerializer()
             deserializer = GetFooStreamingInputNoOutputOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooStreamingInputNoOutput"
                 serviceName = ServiceId
             }
@@ -249,7 +242,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooNoRequiredOperationSerializer()
             deserializer = GetFooNoRequiredOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooNoRequired"
                 serviceName = ServiceId
             }
@@ -273,7 +265,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetFooSomeRequiredOperationSerializer()
             deserializer = GetFooSomeRequiredOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetFooSomeRequired"
                 serviceName = ServiceId
             }
@@ -353,7 +344,6 @@ class HttpProtocolClientGeneratorTest {
             serializer = GetStatusOperationSerializer()
             deserializer = GetStatusOperationDeserializer()
             context {
-                expectedHttpStatus = 200
                 operationName = "GetStatus"
                 serviceName = ServiceId
                 hostPrefix = "$prefix"

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -22,11 +22,6 @@ public open class HttpOperationContext {
     @InternalApi
     public companion object {
         /**
-         * The expected HTTP status code of a successful response is stored under this key
-         */
-        public val ExpectedHttpStatus: AttributeKey<Int> = AttributeKey("aws.smithy.kotlin#ExpectedHttpStatus")
-
-        /**
          * A prefix to prepend the resolved hostname with.
          * See [endpointTrait](https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#endpoint-trait)
          */
@@ -82,11 +77,6 @@ public open class HttpOperationContext {
          * The name of the service the request is sent to
          */
         public var serviceName: String? by requiredOption(SdkClientOption.ServiceName)
-
-        /**
-         * The expected HTTP status code on success
-         */
-        public var expectedHttpStatus: Int? by option(ExpectedHttpStatus)
 
         /**
          * (Optional) prefix to prepend to a (resolved) hostname

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpOperationContextTest.kt
@@ -16,11 +16,9 @@ class HttpOperationContextTest {
         val op = HttpOperationContext.build {
             operationName = "operation"
             serviceName = "service"
-            expectedHttpStatus = 418
         }
 
         assertEquals("operation", op[SdkClientOption.OperationName])
-        assertEquals(418, op[HttpOperationContext.ExpectedHttpStatus])
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes `expectedHttpStatus` from the HTTP operation context. It's not used anywhere, so let's remove it!

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A but this was noticed as part of completing https://github.com/awslabs/smithy-kotlin/issues/836

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Remove `expectedHttpStatus` from operation context and update tests accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
