### PR TITLE
feat: make user-supplied region available to credentials providers

### DIFF
--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -275,7 +275,7 @@ internal class AuthHandler<Input, Output>(
             "auth.scheme_id" to authScheme.schemeId.id
         }
 
-        // signing properties need to propagate from AuthOption to signer
+        // properties need to propagate from AuthOption to signer and identity provider
         request.context.merge(authOption.attributes)
 
         // resolve identity from the selected auth scheme


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
[583](https://github.com/awslabs/aws-sdk-kotlin/issues/583) - Make user-supplied region available to config resolution providers
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
There are several places where config resolution providers require bootstrapping region, which is possibly present in user-supplied client config. This fixes this issue by making region available via attributes/execution context 

Also look at: https://github.com/awslabs/aws-sdk-kotlin/pull/997


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
