### PR TITLE
feat: make credentials provider chain accept list of credentials providers

### DIFF
--- a/.changes/493ccb85-b5ab-4a0b-89eb-c4ef45bfcf42.json
+++ b/.changes/493ccb85-b5ab-4a0b-89eb-c4ef45bfcf42.json
@@ -3,6 +3,6 @@
     "type": "feature",
     "description": "Make CredentialsProviderChain accept list of CredentialProviders",
     "issues": [
-        "awslabs/smithy-kotlin#1001"
+        "awslabs/aws-sdk-kotlin#1001"
     ]
 }

--- a/.changes/493ccb85-b5ab-4a0b-89eb-c4ef45bfcf42.json
+++ b/.changes/493ccb85-b5ab-4a0b-89eb-c4ef45bfcf42.json
@@ -1,0 +1,8 @@
+{
+    "id": "493ccb85-b5ab-4a0b-89eb-c4ef45bfcf42",
+    "type": "feature",
+    "description": "Make CredentialsProviderChain accept list of CredentialProviders",
+    "issues": [
+        "awslabs/smithy-kotlin#1001"
+    ]
+}

--- a/runtime/auth/aws-credentials/api/aws-credentials.api
+++ b/runtime/auth/aws-credentials/api/aws-credentials.api
@@ -39,6 +39,7 @@ public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/Cr
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain : aws/smithy/kotlin/runtime/identity/IdentityProviderChain, aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider {
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Laws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider;)V
 	public fun resolve (Laws/smithy/kotlin/runtime/util/Attributes;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChain.kt
@@ -16,5 +16,8 @@ import aws.smithy.kotlin.runtime.util.Attributes
  */
 public class CredentialsProviderChain(vararg providers: CredentialsProvider) :
     IdentityProviderChain<CredentialsProvider, Credentials>(*providers), CredentialsProvider {
+
+    public constructor(providers: List<CredentialsProvider>) : this(*providers.toTypedArray())
+
     override suspend fun resolve(attributes: Attributes): Credentials = super.resolve(attributes)
 }

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
@@ -15,11 +15,7 @@ import kotlin.test.assertEquals
 class CredentialsProviderChainTest {
     private class TestCredentialsProvider(val accessKeyId: String? = null, val secretAccessKey: String? = null) : CredentialsProvider {
         override suspend fun resolve(attributes: Attributes): Credentials =
-            accessKeyId?.let {
-                secretAccessKey?.let {
-                    return Credentials(accessKeyId = accessKeyId, secretAccessKey = secretAccessKey)
-                }
-            } ?: error("no credentials available")
+            if (accessKeyId != null && secretAccessKey != null) Credentials(accessKeyId, secretAccessKey) else error("no credentials available")
     }
 
     @Test

--- a/runtime/auth/http-auth/api/http-auth.api
+++ b/runtime/auth/http-auth/api/http-auth.api
@@ -37,6 +37,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/auth/BearerTokenP
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChain : aws/smithy/kotlin/runtime/identity/IdentityProviderChain, aws/smithy/kotlin/runtime/http/auth/BearerTokenProvider {
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Laws/smithy/kotlin/runtime/http/auth/BearerTokenProvider;)V
 	public fun resolve (Laws/smithy/kotlin/runtime/util/Attributes;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChain.kt
+++ b/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChain.kt
@@ -18,5 +18,8 @@ import aws.smithy.kotlin.runtime.util.Attributes
 public class BearerTokenProviderChain(vararg providers: BearerTokenProvider) :
     IdentityProviderChain<BearerTokenProvider, BearerToken>(*providers),
     BearerTokenProvider {
+
+    public constructor(providers: List<BearerTokenProvider>) : this(*providers.toTypedArray())
+
     override suspend fun resolve(attributes: Attributes): BearerToken = super.resolve(attributes)
 }

--- a/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChainTest.kt
+++ b/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChainTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.http.auth
+
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.util.Attributes
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BearerTokenProviderChainTest {
+    private class TestTokenProvider(val token: String? = null) : BearerTokenProvider {
+        override suspend fun resolve(attributes: Attributes): BearerToken =
+            if (token != null) Token(token) else error("no credentials available")
+    }
+
+    @Test
+    fun testVararg() = runTest {
+        val chain = BearerTokenProviderChain(TestTokenProvider(), TestTokenProvider("token"))
+        assertEquals(Token("token"), chain.resolve())
+    }
+
+    @Test
+    fun testList() = runTest {
+        val tokenProviders = listOf<BearerTokenProvider>(TestTokenProvider(), TestTokenProvider("token"))
+        val chain = BearerTokenProviderChain(tokenProviders)
+        assertEquals(Token("token"), chain.resolve())
+    }
+}
+
+private data class Token(
+    override val token: String,
+    override val attributes: Attributes = emptyAttributes(),
+    override val expiration: Instant? = null,
+) : BearerToken


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes aws-sdk-kotlin#1001

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
For configuration-driven use-cases where a list of providers is created the acceptance of a list is convenient. These changes were made by adding an additional constructor


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
