### PR TITLE
feat: add support for sub-expressions and list indexing in JMESPath

### DIFF
--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -193,6 +193,50 @@ service WaitersTestService {
         ]
     },
 
+    // list indexing
+    BooleanListIndexZeroEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.booleans[0]",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    BooleanListIndexOneEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.booleans[1]",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TwoDimensionalBooleanListIndexZeroZeroEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "twoDimensionalLists.booleansList[0][0]",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+
     // anyStringEquals
     StringListAnyStringEquals: {
         acceptors: [
@@ -764,6 +808,7 @@ structure GetEntityRequest {
 structure GetEntityResponse {
     primitives: EntityPrimitives,
     lists: EntityLists,
+    twoDimensionalLists: TwoDimensionalEntityLists,
     maps: EntityMaps,
 }
 
@@ -800,6 +845,10 @@ structure EntityLists {
     structs: StructList,
 }
 
+structure TwoDimensionalEntityLists {
+    booleansList: TwoDimensionalBooleanList,
+}
+
 structure EntityMaps {
     booleans: BooleanMap,
     strings: StringMap,
@@ -821,6 +870,10 @@ intEnum IntEnum {
 
 list BooleanList {
     member: Boolean,
+}
+
+list TwoDimensionalBooleanList {
+    member: BooleanList,
 }
 
 list StringList {

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -222,6 +222,20 @@ service WaitersTestService {
             }
         ]
     },
+    BooleanListIndexNegativeTwoEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.booleans[-2]",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
     TwoDimensionalBooleanListIndexZeroZeroEquals: {
         acceptors: [
             {
@@ -235,6 +249,34 @@ service WaitersTestService {
                 }
             }
         ]
+    },
+    StructListIndexOneStringsIndexZeroEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[1].strings[0]",
+                        expected: "foo",
+                        comparator: "stringEquals"
+                    }
+                }
+            }
+      ]
+    },
+    StructListIndexOneSubStructsIndexZeroSubStructPrimitivesBooleanEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[1].subStructs[0].subStructPrimitives.boolean",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+      ]
     },
 
     // anyStringEquals

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -12,7 +12,8 @@ import com.test.model.Enum
 import com.test.waiters.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WaiterTest {
@@ -105,6 +106,25 @@ class WaiterTest {
         WaitersTestClient::waitUntilIntEnumEquals,
         GetEntityResponse { primitives = EntityPrimitives { intEnum = IntEnum.Two } },
         GetEntityResponse { primitives = EntityPrimitives { intEnum = IntEnum.One } },
+    )
+
+    // list indexing
+    @Test fun testBooleanListIndexZeroEquals() = successTest(
+        WaitersTestClient::waitUntilBooleanListIndexZeroEquals,
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true) } },
+    )
+
+    @Test fun testBooleanListIndexOneEquals() = successTest(
+        WaitersTestClient::waitUntilBooleanListIndexOneEquals,
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, true) } },
+    )
+
+    @Test fun testTwoDimensionalBooleanListIndexZeroZeroEquals() = successTest(
+        WaitersTestClient::waitUntilTwoDimensionalBooleanListIndexZeroZeroEquals,
+        GetEntityResponse { twoDimensionalLists = TwoDimensionalEntityLists { booleansList = listOf(listOf(false)) } },
+        GetEntityResponse { twoDimensionalLists = TwoDimensionalEntityLists { booleansList = listOf(listOf(true)) } },
     )
 
     // anyStringEquals

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -118,13 +118,33 @@ class WaiterTest {
     @Test fun testBooleanListIndexOneEquals() = successTest(
         WaitersTestClient::waitUntilBooleanListIndexOneEquals,
         GetEntityResponse { lists = EntityLists { booleans = listOf(false, false) } },
-        GetEntityResponse { lists = EntityLists { booleans = listOf(true, true) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, true) } },
+    )
+
+    @Test fun testBooleanListIndexNegativeTwoEquals() = successTest(
+        WaitersTestClient::waitUntilBooleanListIndexNegativeTwoEquals,
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, true) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, false) } },
     )
 
     @Test fun testTwoDimensionalBooleanListIndexZeroZeroEquals() = successTest(
         WaitersTestClient::waitUntilTwoDimensionalBooleanListIndexZeroZeroEquals,
         GetEntityResponse { twoDimensionalLists = TwoDimensionalEntityLists { booleansList = listOf(listOf(false)) } },
         GetEntityResponse { twoDimensionalLists = TwoDimensionalEntityLists { booleansList = listOf(listOf(true)) } },
+    )
+
+    @Test fun testStructListIndexOneStringsIndexZeroEquals() = successTest(
+        WaitersTestClient::waitUntilStructListIndexOneStringsIndexZeroEquals,
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { strings = listOf("bar") }, Struct { strings = listOf("bar") }) } },
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { strings = listOf("bar") }, Struct { strings = listOf("foo") }) } },
+    )
+
+    @Test fun testStructListIndexOneSubStructsIndexZeroSubStructPrimitivesBooleanEquals() = successTest(
+        WaitersTestClient::waitUntilStructListIndexOneSubStructsIndexZeroSubStructPrimitivesBooleanEquals,
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { }, Struct { subStructs = listOf(SubStruct { subStructPrimitives = EntityPrimitives { boolean = false } }) }) } },
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { }, Struct { subStructs = listOf(SubStruct { subStructPrimitives = EntityPrimitives { boolean = true } }) }) } },
     )
 
     // anyStringEquals


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Implement full support for JMESPath expression types #596 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
-The sub-expression function is now recursive and will be able to visit all expressions needed
-Visiting indexes is now available


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
