### PR TITLE
fix: correctly validate response length for empty and byte array bodies

### DIFF
--- a/.changes/589535ae-bf2d-4364-b428-1700846cd8d6.json
+++ b/.changes/589535ae-bf2d-4364-b428-1700846cd8d6.json
@@ -1,0 +1,8 @@
+{
+    "id": "589535ae-bf2d-4364-b428-1700846cd8d6",
+    "type": "bugfix",
+    "description": "Correctly validate response length for empty bodies and byte array bodies",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1014"
+    ]
+}


### PR DESCRIPTION
## Issue \#

Closes https://github.com/awslabs/aws-sdk-kotlin/issues/1014

## Description of changes

Correctly validates response length for empty bodies and byte array bodies.

**Companion PR**: https://github.com/awslabs/aws-sdk-kotlin/pull/1015

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
