### PR TITLE
fix: stop serializing default values for @clientOptional members

### DIFF
--- a/.changes/3b0318b9-d379-4fb4-8bcc-8dd4de6029a0.json
+++ b/.changes/3b0318b9-d379-4fb4-8bcc-8dd4de6029a0.json
@@ -1,0 +1,8 @@
+{
+    "id": "3b0318b9-d379-4fb4-8bcc-8dd4de6029a0",
+    "type": "bugfix",
+    "description": "Stop serializing default values for `@clientOptional` members",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1016"
+    ]
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.kotlin.codegen.utils.dq
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.*
+import software.amazon.smithy.model.traits.ClientOptionalTrait
 import software.amazon.smithy.model.traits.DefaultTrait
 import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.StreamingTrait
@@ -183,8 +184,10 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
             .apply {
                 if (nullableIndex.isMemberNullable(shape, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1_NO_INPUT)) nullable()
 
-                shape.getTrait<DefaultTrait>()?.let {
-                    defaultValue(it.getDefaultValue(targetShape), DefaultValueType.MODELED)
+                if (!shape.hasTrait<ClientOptionalTrait>()) { // @ClientOptional supersedes @default
+                    shape.getTrait<DefaultTrait>()?.let {
+                        defaultValue(it.getDefaultValue(targetShape), DefaultValueType.MODELED)
+                    }
                 }
             }
             .build()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -367,6 +367,27 @@ class SymbolProviderTest {
     }
 
     @Test
+    fun `@clientOptional overrides @default`() {
+        val model = """
+        structure MyStruct {
+            @required
+            @clientOptional
+            @default("Foo")
+            quux: QuuxType
+        }
+
+        string QuuxType
+        """.prependNamespaceAndService().toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
+        val member = model.expectShape<MemberShape>("com.test#MyStruct\$quux")
+        val memberSymbol = provider.toSymbol(member)
+        assertEquals("kotlin", memberSymbol.namespace)
+        assertTrue(memberSymbol.isNullable)
+        assertEquals("null", memberSymbol.defaultValue())
+    }
+
+    @Test
     fun `@input`() {
         val model = """
         @input


### PR DESCRIPTION
## Issue \#

Closes https://github.com/awslabs/aws-sdk-kotlin/issues/1016

## Description of changes

The SDK incorrectly serializes structure members' default values in requests regardless of the `@clientOptional` trait. As recently clarified in Smithy reference docs, `@clientOptional` supersedes `@default` and should cause serializers to skip recognizing/sending a default value.

This affected EC2's `DescribeVpcsRequest.MaxResults` and potentially many other structure members.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
