### PR TITLE
feat: add tests for boolean operators in JMESPath

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -287,7 +287,7 @@ class KotlinJmespathExpressionVisitor(
         writer.addImport(RuntimeTypes.Core.Utils.truthiness)
 
         val left = acceptSubexpression(expression.left)
-        val leftTruthinessName = addTempVar("${left.identifier}Truthiness", "truthiness($${left.identifier})")
+        val leftTruthinessName = addTempVar("${left.identifier}Truthiness", "truthiness(${left.identifier})")
 
         val right = acceptSubexpression(expression.right)
 

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -193,6 +193,50 @@ service WaitersTestService {
         ]
     },
 
+    // comparators
+    AndEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.booleans[0] && lists.booleans[1]",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    OrEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.booleans[0] || lists.booleans[1]",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    NotEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "!(primitives.boolean)",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+
     // list indexing
     BooleanListIndexZeroEquals: {
         acceptors: [

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -108,6 +108,29 @@ class WaiterTest {
         GetEntityResponse { primitives = EntityPrimitives { intEnum = IntEnum.One } },
     )
 
+    // comparators
+    @Test fun testAndEquals() = successTest(
+        WaitersTestClient::waitUntilAndEquals,
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, true) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, true) } },
+    )
+
+    @Test fun testOrEquals() = successTest(
+        WaitersTestClient::waitUntilOrEquals,
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, true) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(true, false) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, true) } },
+        GetEntityResponse { lists = EntityLists { booleans = listOf(false, false) } },
+    )
+
+    @Test fun testNotEquals() = successTest(
+        WaitersTestClient::waitUntilNotEquals,
+        GetEntityResponse { primitives = EntityPrimitives { boolean = true } },
+        GetEntityResponse { primitives = EntityPrimitives { boolean = false } },
+    )
+
     // list indexing
     @Test fun testBooleanListIndexZeroEquals() = successTest(
         WaitersTestClient::waitUntilBooleanListIndexZeroEquals,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #922

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
-Added some tests for the boolean operators (and, or, not)
-Fixed a small typo in the OR visitor


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
