### PR TITLE
refactor!: prefix endpoint and auth providers and make auth scheme provider public

### DIFF
--- a/.changes/01b383de-b06e-46f0-9bbe-4f8c1a8c2b9a.json
+++ b/.changes/01b383de-b06e-46f0-9bbe-4f8c1a8c2b9a.json
@@ -1,0 +1,5 @@
+{
+    "id": "01b383de-b06e-46f0-9bbe-4f8c1a8c2b9a",
+    "type": "misc",
+    "description": "**BREAKING**: prefix generated endpoint and auth scheme providers and cleanup auth scheme APIs"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -276,7 +276,7 @@ object RuntimeTypes {
         object Identity : RuntimeTypePackage(KotlinDependency.IDENTITY_API) {
             val AuthSchemeId = symbol("AuthSchemeId", "auth")
             val AuthSchemeProvider = symbol("AuthSchemeProvider", "auth")
-            val AuthSchemeOption = symbol("AuthSchemeOption", "auth")
+            val AuthOption = symbol("AuthOption", "auth")
 
             val IdentityProvider = symbol("IdentityProvider", "identity")
             val IdentityProviderConfig = symbol("IdentityProviderConfig", "identity")
@@ -303,7 +303,7 @@ object RuntimeTypes {
             val AnonymousIdentity = symbol("AnonymousIdentity")
             val AnonymousIdentityProvider = symbol("AnonymousIdentityProvider")
             val HttpAuthConfig = symbol("HttpAuthConfig")
-            val HttpAuthScheme = symbol("HttpAuthScheme")
+            val AuthScheme = symbol("AuthScheme")
 
             val BearerTokenAuthScheme = symbol("BearerTokenAuthScheme")
             val BearerTokenProviderConfig = symbol("BearerTokenProviderConfig")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -63,9 +63,11 @@ class ServiceClientConfigGenerator(
         add(
             ConfigProperty {
                 val hasRules = shape.hasTrait<EndpointRuleSetTrait>()
+                val defaultEndpointProviderSymbol = DefaultEndpointProviderGenerator.getSymbol(context.settings)
                 symbol = EndpointProviderGenerator.getSymbol(context.settings)
+                name = "endpointProvider"
                 propertyType = if (hasRules) { // if there's a ruleset, we have a usable default, otherwise caller has to provide their own
-                    ConfigPropertyType.RequiredWithDefault("DefaultEndpointProvider()")
+                    ConfigPropertyType.RequiredWithDefault("${defaultEndpointProviderSymbol.name}()")
                 } else {
                     ConfigPropertyType.Required()
                 }
@@ -80,7 +82,7 @@ class ServiceClientConfigGenerator(
                 additionalImports = buildList {
                     add(EndpointParametersGenerator.getSymbol(context.settings))
                     if (hasRules) {
-                        add(DefaultEndpointProviderGenerator.getSymbol(context.settings))
+                        add(defaultEndpointProviderSymbol)
                     }
                 }
             },

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -46,7 +46,7 @@ class ServiceClientConfigGenerator(
         if (context.protocolGenerator?.applicationProtocol?.isHttpProtocol == true) {
             add(RuntimeConfigProperty.HttpClient)
             add(RuntimeConfigProperty.HttpInterceptors)
-            add(RuntimeConfigProperty.HttpAuthSchemes)
+            add(RuntimeConfigProperty.AuthSchemes)
         }
         if (shape.hasIdempotentTokenMember(context.model)) {
             add(RuntimeConfigProperty.IdempotencyTokenProvider)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
@@ -16,6 +16,9 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerato
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
 
+// FIXME - replace with NoAuthTrait when we upgrade to a version where it exists
+public val AnonymousAuthSchemeId: ShapeId = ShapeId.from("smithy.api#noAuth")
+
 /**
  * Register support for the `smithy.api#optionalAuth` auth scheme.
  */
@@ -24,7 +27,7 @@ class AnonymousAuthSchemeIntegration : KotlinIntegration {
 }
 
 class AnonymousAuthSchemeHandler : AuthSchemeHandler {
-    override val authSchemeId: ShapeId = ShapeId.from("smithy.api#noAuth")
+    override val authSchemeId: ShapeId = AnonymousAuthSchemeId
     override val authSchemeIdSymbol: Symbol = buildSymbol {
         name = "AuthSchemeId.Anonymous"
         val ref = RuntimeTypes.Auth.Identity.AuthSchemeId

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.OptionalAuthTrait
 
 /**
  * Register support for the `smithy.api#optionalAuth` auth scheme.
@@ -25,7 +24,7 @@ class AnonymousAuthSchemeIntegration : KotlinIntegration {
 }
 
 class AnonymousAuthSchemeHandler : AuthSchemeHandler {
-    override val authSchemeId: ShapeId = OptionalAuthTrait.ID
+    override val authSchemeId: ShapeId = ShapeId.from("smithy.api#noAuth")
     override val authSchemeIdSymbol: Symbol = buildSymbol {
         name = "AuthSchemeId.Anonymous"
         val ref = RuntimeTypes.Auth.Identity.AuthSchemeId
@@ -43,7 +42,7 @@ class AnonymousAuthSchemeHandler : AuthSchemeHandler {
         op: OperationShape?,
         writer: KotlinWriter,
     ) {
-        writer.write("#T(#T.Anonymous)", RuntimeTypes.Auth.Identity.AuthSchemeOption, RuntimeTypes.Auth.Identity.AuthSchemeId)
+        writer.write("#T(#T.Anonymous)", RuntimeTypes.Auth.Identity.AuthOption, RuntimeTypes.Auth.Identity.AuthSchemeId)
     }
 
     override fun instantiateAuthSchemeExpr(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AnonymousAuthSchemeIntegration.kt
@@ -17,8 +17,6 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.OptionalAuthTrait
 
-// FIXME - TBD whether this stays as `smithy.api#optionalAuth` ID
-
 /**
  * Register support for the `smithy.api#optionalAuth` auth scheme.
  */

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
+import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
@@ -18,7 +19,6 @@ import software.amazon.smithy.kotlin.codegen.rendering.util.ConfigPropertyType
 import software.amazon.smithy.model.Model
 
 // FIXME - TBD where parameters are actually sourced from.
-// TODO - probably refactor to not use AbstractConfigGenerator (or rename and make it more flexible since it is _close_ to what we want).
 
 /**
  * Generate the input type used for resolving authentication schemes
@@ -30,14 +30,29 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }
+
+        fun getImplementationSymbol(settings: KotlinSettings): Symbol = buildSymbol {
+            name = "AuthSchemeParametersImpl"
+            namespace = "${settings.pkg.name}.auth"
+            definitionFile = "$name.kt"
+        }
     }
 
     override val visibility: String = "internal"
 
     fun render(ctx: ProtocolGenerator.GenerationContext) {
         val symbol = getSymbol(ctx.settings)
+        val implSymbol = getImplementationSymbol(ctx.settings)
+
         ctx.delegator.useSymbolWriter(symbol) { writer ->
-            writer.putContext("configClass.name", symbol.name)
+            writer.withBlock("public interface #T {", "}", symbol) {
+                dokka("The name of the operation currently being invoked.")
+                write("public val operationName: String")
+            }
+        }
+
+        ctx.delegator.useSymbolWriter(implSymbol) { writer ->
+            writer.putContext("configClass.name", implSymbol.name)
 
             val codegenCtx = object : CodegenContext {
                 override val model: Model = ctx.model
@@ -53,6 +68,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             ).toBuilder()
                 .apply {
                     propertyType = ConfigPropertyType.Required("operationName is a required auth scheme parameter")
+                    baseClass = symbol
                 }.build()
 
             val props = listOf(operationName)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
+import software.amazon.smithy.kotlin.codegen.core.clientName
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
@@ -26,13 +27,15 @@ import software.amazon.smithy.model.Model
 class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
     companion object {
         fun getSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "AuthSchemeParameters"
+            val prefix = clientName(settings.sdkId)
+            name = "${prefix}AuthSchemeParameters"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }
 
         fun getImplementationSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "AuthSchemeParametersImpl"
+            val prefix = clientName(settings.sdkId)
+            name = "${prefix}AuthSchemeParametersImpl"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.kotlin.codegen.rendering.auth
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
+import software.amazon.smithy.kotlin.codegen.core.clientName
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
@@ -19,7 +20,8 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerato
 class AuthSchemeProviderAdapterGenerator {
     companion object {
         fun getSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "AuthSchemeProviderAdapter"
+            val prefix = clientName(settings.sdkId)
+            name = "${prefix}AuthSchemeProviderAdapter"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
@@ -35,7 +35,7 @@ class AuthSchemeProviderAdapterGenerator {
                     "override suspend fun resolve(request: #T): List<#T> {",
                     "}",
                     RuntimeTypes.HttpClient.Operation.SdkHttpRequest,
-                    RuntimeTypes.Auth.Identity.AuthSchemeOption,
+                    RuntimeTypes.Auth.Identity.AuthOption,
                 ) {
                     withBlock("val params = #T {", "}", AuthSchemeParametersGenerator.getSymbol(ctx.settings)) {
                         addImport(RuntimeTypes.Core.Utils.get)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderConfigIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderConfigIntegration.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.rendering.auth
+
+import software.amazon.smithy.kotlin.codegen.core.CodegenContext
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.rendering.util.ConfigProperty
+import software.amazon.smithy.kotlin.codegen.rendering.util.ConfigPropertyType
+
+/**
+ * Integration that adds the service specific auth scheme provider type to the generated service config properties
+ */
+class AuthSchemeProviderConfigIntegration : KotlinIntegration {
+    override fun additionalServiceConfigProps(ctx: CodegenContext): List<ConfigProperty> {
+        val defaultProvider = AuthSchemeProviderGenerator.getDefaultSymbol(ctx.settings)
+        return listOf(
+            ConfigProperty {
+                name = "authSchemeProvider"
+                symbol = AuthSchemeProviderGenerator.getSymbol(ctx.settings)
+                documentation = "Configure the provider used to resolve the authentication scheme to use for a particular operation."
+                additionalImports = listOf(defaultProvider)
+                propertyType = ConfigPropertyType.RequiredWithDefault(defaultProvider.name)
+            },
+        )
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -71,7 +71,7 @@ open class AuthSchemeProviderGenerator {
                 "private val operationOverrides = mapOf<#T, List<#T>>(",
                 ")",
                 KotlinTypes.String,
-                RuntimeTypes.Auth.Identity.AuthSchemeOption,
+                RuntimeTypes.Auth.Identity.AuthOption,
             ) {
                 operationsWithOverrides.forEach { op ->
                     val authHandlersForOperation = authIndex.effectiveAuthHandlersForOperation(ctx, op)
@@ -82,7 +82,7 @@ open class AuthSchemeProviderGenerator {
             withBlock(
                 "private val serviceDefaults = listOf<#T>(",
                 ")",
-                RuntimeTypes.Auth.Identity.AuthSchemeOption,
+                RuntimeTypes.Auth.Identity.AuthOption,
             ) {
                 val defaultHandlers = authIndex.effectiveAuthHandlersForService(ctx)
 
@@ -98,7 +98,7 @@ open class AuthSchemeProviderGenerator {
                 "override suspend fun resolveAuthScheme(params: #T): List<#T> {",
                 "}",
                 paramsSymbol,
-                RuntimeTypes.Auth.Identity.AuthSchemeOption,
+                RuntimeTypes.Auth.Identity.AuthOption,
             ) {
                 withBlock("return operationOverrides.getOrElse(params.operationName) {", "}") {
                     write("serviceDefaults")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -7,10 +7,7 @@ package software.amazon.smithy.kotlin.codegen.rendering.auth
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
-import software.amazon.smithy.kotlin.codegen.core.InlineKotlinWriter
-import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
-import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
-import software.amazon.smithy.kotlin.codegen.core.withBlock
+import software.amazon.smithy.kotlin.codegen.core.*
 import software.amazon.smithy.kotlin.codegen.integration.AuthSchemeHandler
 import software.amazon.smithy.kotlin.codegen.lang.KotlinTypes
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
@@ -24,13 +21,15 @@ import software.amazon.smithy.model.shapes.OperationShape
 open class AuthSchemeProviderGenerator {
     companion object {
         fun getSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "AuthSchemeProvider"
+            val prefix = clientName(settings.sdkId)
+            name = "${prefix}AuthSchemeProvider"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }
 
         fun getDefaultSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "DefaultAuthSchemeProvider"
+            val prefix = clientName(settings.sdkId)
+            name = "Default${prefix}AuthSchemeProvider"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }
@@ -49,19 +48,21 @@ open class AuthSchemeProviderGenerator {
 
     private fun renderInterface(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
         val paramsSymbol = AuthSchemeParametersGenerator.getSymbol(ctx.settings)
+        val symbol = getSymbol(ctx.settings)
         writer.dokka {
-            write("AuthSchemeProvider is responsible for resolving the authentication scheme to use for a particular operation.")
+            write("${symbol.name} is responsible for resolving the authentication scheme to use for a particular operation.")
             write("See [#T] for the default SDK behavior of this interface.", getDefaultSymbol(ctx.settings))
         }
         writer.write(
             "public interface #T : #T<#T>",
-            getSymbol(ctx.settings),
+            symbol,
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
         )
     }
 
     private fun renderDefaultImpl(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
+        // FIXME - probably can't remain an object
         writer.withBlock(
             "public object #T : #T {",
             "}",

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -38,7 +38,7 @@ open class AuthSchemeProviderGenerator {
 
     fun render(ctx: ProtocolGenerator.GenerationContext) {
         ctx.delegator.useSymbolWriter(getSymbol(ctx.settings)) { writer ->
-            renderTypealias(ctx, writer)
+            renderInterface(ctx, writer)
         }
 
         ctx.delegator.useSymbolWriter(getDefaultSymbol(ctx.settings)) { writer ->
@@ -47,10 +47,15 @@ open class AuthSchemeProviderGenerator {
         }
     }
 
-    private fun renderTypealias(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
+    private fun renderInterface(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
         val paramsSymbol = AuthSchemeParametersGenerator.getSymbol(ctx.settings)
+        writer.dokka {
+            write("AuthSchemeProvider is responsible for resolving the authentication scheme to use for a particular operation.")
+            write("See [#T] for the default SDK behavior of this interface.", getDefaultSymbol(ctx.settings))
+        }
         writer.write(
-            "internal typealias AuthSchemeProvider = #T<#T>",
+            "public interface #T : #T<#T>",
+            getSymbol(ctx.settings),
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
         )
@@ -58,7 +63,7 @@ open class AuthSchemeProviderGenerator {
 
     private fun renderDefaultImpl(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
         writer.withBlock(
-            "internal object #T : #T {",
+            "public object #T : #T {",
             "}",
             getDefaultSymbol(ctx.settings),
             getSymbol(ctx.settings),

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/BearerTokenAuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/BearerTokenAuthSchemeIntegration.kt
@@ -76,7 +76,7 @@ class BearerTokenAuthSchemeHandler : AuthSchemeHandler {
         op: OperationShape?,
         writer: KotlinWriter,
     ) {
-        writer.write("#T(#T.HttpBearer)", RuntimeTypes.Auth.Identity.AuthSchemeOption, RuntimeTypes.Auth.Identity.AuthSchemeId)
+        writer.write("#T(#T.HttpBearer)", RuntimeTypes.Auth.Identity.AuthOption, RuntimeTypes.Auth.Identity.AuthSchemeId)
     }
 
     override fun instantiateAuthSchemeExpr(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/IdentityProviderConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/IdentityProviderConfigGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
+import software.amazon.smithy.kotlin.codegen.core.clientName
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.knowledge.AuthIndex
@@ -21,7 +22,8 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerato
 class IdentityProviderConfigGenerator {
     companion object {
         fun getSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            name = "IdentityProviderConfigAdapter"
+            val prefix = clientName(settings.sdkId)
+            name = "${prefix}IdentityProviderConfigAdapter"
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -59,17 +59,17 @@ fun interface ExpressionRenderer {
 class DefaultEndpointProviderGenerator(
     private val writer: KotlinWriter,
     private val rules: EndpointRuleSet,
+    private val defaultProviderSymbol: Symbol,
     private val interfaceSymbol: Symbol,
     private val paramsSymbol: Symbol,
     private val externalFunctions: Map<String, Symbol> = emptyMap(),
     private val propertyRenderers: Map<String, EndpointPropertyRenderer> = emptyMap(),
 ) : ExpressionRenderer {
     companion object {
-        const val CLASS_NAME = "DefaultEndpointProvider"
-
         fun getSymbol(settings: KotlinSettings): Symbol =
             buildSymbol {
-                name = CLASS_NAME
+                val prefix = clientName(settings.sdkId)
+                name = "Default${prefix}EndpointProvider"
                 namespace = "${settings.pkg.name}.endpoints"
             }
     }
@@ -78,7 +78,7 @@ class DefaultEndpointProviderGenerator(
 
     fun render() {
         renderDocumentation()
-        writer.withBlock("public class #L: #T {", "}", CLASS_NAME, interfaceSymbol) {
+        writer.withBlock("public class #T: #T {", "}", defaultProviderSymbol, interfaceSymbol) {
             renderResolve()
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
@@ -33,12 +33,12 @@ interface EndpointDelegator {
         val defaultProviderSymbol = DefaultEndpointProviderGenerator.getSymbol(ctx.settings)
 
         ctx.delegator.useFileWriter(providerSymbol) {
-            EndpointProviderGenerator(it, paramsSymbol).render()
+            EndpointProviderGenerator(it, providerSymbol, paramsSymbol).render()
         }
 
         if (rules != null) {
             ctx.delegator.useFileWriter(defaultProviderSymbol) {
-                DefaultEndpointProviderGenerator(it, rules, providerSymbol, paramsSymbol).render()
+                DefaultEndpointProviderGenerator(it, rules, defaultProviderSymbol, providerSymbol, paramsSymbol).render()
             }
         }
     }
@@ -49,7 +49,7 @@ interface EndpointDelegator {
     fun generateEndpointParameters(ctx: ProtocolGenerator.GenerationContext, rules: EndpointRuleSet?) {
         val paramsSymbol = EndpointParametersGenerator.getSymbol(ctx.settings)
         ctx.delegator.useFileWriter(paramsSymbol) {
-            EndpointParametersGenerator(it, rules).render()
+            EndpointParametersGenerator(it, rules, paramsSymbol).render()
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
+import software.amazon.smithy.kotlin.codegen.core.clientName
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 
 /**
@@ -17,21 +18,26 @@ import software.amazon.smithy.kotlin.codegen.model.buildSymbol
  */
 class EndpointProviderGenerator(
     private val writer: KotlinWriter,
+    private val providerSymbol: Symbol,
     private val paramsSymbol: Symbol,
 ) {
     companion object {
-        const val CLASS_NAME = "EndpointProvider"
-
         fun getSymbol(settings: KotlinSettings): Symbol =
             buildSymbol {
-                name = CLASS_NAME
+                val prefix = clientName(settings.sdkId)
+                name = "${prefix}EndpointProvider"
                 namespace = "${settings.pkg.name}.endpoints"
             }
     }
 
     fun render() {
         renderDocumentation()
-        writer.write("public typealias EndpointProvider = #T<#T>", RuntimeTypes.SmithyClient.Endpoints.EndpointProvider, paramsSymbol)
+        writer.write(
+            "public interface #T: #T<#T>",
+            providerSymbol,
+            RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
+            paramsSymbol,
+        )
     }
 
     private fun renderDocumentation() {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -33,7 +33,7 @@ class EndpointProviderGenerator(
     fun render() {
         renderDocumentation()
         writer.write(
-            "public interface #T: #T<#T>",
+            "public fun interface #T: #T<#T>",
             providerSymbol,
             RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
             paramsSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -120,6 +120,7 @@ abstract class HttpProtocolClientGenerator(
 
             write("toMap()")
         }
+        writer.write("private val authSchemeAdapter = #T(config.authSchemeProvider)", AuthSchemeProviderAdapterGenerator.getSymbol(ctx.settings))
 
         writer.write("private val telemetryScope = #S", ctx.settings.pkg.name)
         writer.write("private val opMetrics = #T(telemetryScope, config.telemetryProvider)", RuntimeTypes.HttpClient.Operation.OperationMetrics)
@@ -240,9 +241,8 @@ abstract class HttpProtocolClientGenerator(
             }
 
             writer.write(
-                "execution.auth = #T(#T, configuredAuthSchemes, identityProviderConfig)",
+                "execution.auth = #T(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)",
                 RuntimeTypes.HttpClient.Operation.OperationAuthConfig,
-                AuthSchemeProviderAdapterGenerator.getSymbol(ctx.settings),
             )
 
             writer.declareSection(

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -97,7 +97,7 @@ abstract class HttpProtocolClientGenerator(
         writer.withBlock(
             "private val configuredAuthSchemes = with(config.authSchemes.associateBy(#T::schemeId).toMutableMap()){",
             "}",
-            RuntimeTypes.Auth.HttpAuth.HttpAuthScheme,
+            RuntimeTypes.Auth.HttpAuth.AuthScheme,
         ) {
             val authIndex = AuthIndex()
             val allAuthHandlers = authIndex.authHandlersForService(ctx)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -163,7 +163,7 @@ object RuntimeConfigProperty {
 
     val HttpAuthSchemes = ConfigProperty {
         name = "authSchemes"
-        symbol = KotlinTypes.Collections.list(RuntimeTypes.Auth.HttpAuth.HttpAuthScheme, default = "emptyList()")
+        symbol = KotlinTypes.Collections.list(RuntimeTypes.Auth.HttpAuth.AuthScheme, default = "emptyList()")
         baseClass = RuntimeTypes.Auth.HttpAuth.HttpAuthConfig
         useNestedBuilderBaseClass()
         documentation = """

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/RuntimeConfigProperty.kt
@@ -161,13 +161,13 @@ object RuntimeConfigProperty {
         """.trimIndent()
     }
 
-    val HttpAuthSchemes = ConfigProperty {
+    val AuthSchemes = ConfigProperty {
         name = "authSchemes"
         symbol = KotlinTypes.Collections.list(RuntimeTypes.Auth.HttpAuth.AuthScheme, default = "emptyList()")
         baseClass = RuntimeTypes.Auth.HttpAuth.HttpAuthConfig
         useNestedBuilderBaseClass()
         documentation = """
-            Register new or override default [HttpAuthScheme]s configured for this client. By default, the set
+            Register new or override default [AuthScheme]s configured for this client. By default, the set
             of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
             precedence over the defaults and can be used to customize identity resolution and signing for specific
             authentication schemes.

--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -4,6 +4,7 @@ software.amazon.smithy.kotlin.codegen.model.SetRefactorPreprocessor
 software.amazon.smithy.kotlin.codegen.rendering.PaginatorGenerator
 software.amazon.smithy.kotlin.codegen.rendering.waiters.ServiceWaitersGenerator
 software.amazon.smithy.kotlin.codegen.rendering.auth.Sigv4AuthSchemeIntegration
+software.amazon.smithy.kotlin.codegen.rendering.auth.AuthSchemeProviderConfigIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.AnonymousAuthSchemeIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.BearerTokenAuthSchemeIntegration
 software.amazon.smithy.kotlin.codegen.rendering.endpoints.discovery.EndpointDiscoveryIntegration

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/AuthIndexTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/model/knowledge/AuthIndexTest.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.kotlin.codegen.integration.AuthSchemeHandler
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
 import software.amazon.smithy.kotlin.codegen.loadModelFromResource
 import software.amazon.smithy.kotlin.codegen.model.expectShape
+import software.amazon.smithy.kotlin.codegen.rendering.auth.AnonymousAuthSchemeId
 import software.amazon.smithy.kotlin.codegen.rendering.auth.AnonymousAuthSchemeIntegration
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import software.amazon.smithy.kotlin.codegen.test.newTestContext
@@ -18,7 +19,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait
 import software.amazon.smithy.model.traits.HttpBasicAuthTrait
 import software.amazon.smithy.model.traits.HttpBearerAuthTrait
-import software.amazon.smithy.model.traits.OptionalAuthTrait
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -87,8 +87,8 @@ class AuthIndexTest {
         val tests = listOf(
             "com.test#GetFooServiceDefault" to listOf(HttpApiKeyAuthTrait.ID),
             "com.test#GetFooOpOverride" to listOf(HttpBasicAuthTrait.ID, HttpBearerAuthTrait.ID),
-            "com.test#GetFooAnonymous" to listOf(OptionalAuthTrait.ID),
-            "com.test#GetFooOptionalAuth" to listOf(OptionalAuthTrait.ID),
+            "com.test#GetFooAnonymous" to listOf(AnonymousAuthSchemeId),
+            "com.test#GetFooOptionalAuth" to listOf(AnonymousAuthSchemeId),
         )
 
         tests.forEach { (opShapeId, expectedSchemes) ->
@@ -119,7 +119,7 @@ class AuthIndexTest {
 
         val handlers = authIndex.effectiveAuthHandlersForService(testCtx.generationCtx)
         val actual = handlers.map { it.authSchemeId }
-        val expected = listOf(OptionalAuthTrait.ID)
+        val expected = listOf(AnonymousAuthSchemeId)
         assertEquals(expected, actual)
     }
 
@@ -131,7 +131,7 @@ class AuthIndexTest {
 
         val handlers = authIndex.authHandlersForService(testCtx.generationCtx)
         val actual = handlers.map { it.authSchemeId }.toSet()
-        val expected = setOf(HttpApiKeyAuthTrait.ID, HttpBearerAuthTrait.ID, HttpBasicAuthTrait.ID, OptionalAuthTrait.ID)
+        val expected = setOf(HttpApiKeyAuthTrait.ID, HttpBearerAuthTrait.ID, HttpBasicAuthTrait.ID, AnonymousAuthSchemeId)
         assertEquals(expected, actual)
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -49,7 +49,7 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
         val expectedProps = """
     override val clientName: String = builder.clientName
     override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.AuthScheme> = builder.authSchemes
-    public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
+    public val endpointProvider: TestEndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.Default
@@ -81,7 +81,7 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
          *
          * The inputs to endpoint resolution are defined on a per-service basis (see [EndpointParameters]).
          */
-        public var endpointProvider: EndpointProvider? = null
+        public var endpointProvider: TestEndpointProvider? = null
 
         /**
          * Override the default idempotency token generator. SDK clients will generate tokens for members
@@ -241,7 +241,7 @@ public class Config private constructor(builder: Builder) {
     override val clientName: String = builder.clientName
     override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.AuthScheme> = builder.authSchemes
     public val customProp: Int? = builder.customProp
-    public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
+    public val endpointProvider: TestEndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
     override val logMode: LogMode = builder.logMode ?: LogMode.LogRequest

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGeneratorTest.kt
@@ -48,7 +48,7 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
 
         val expectedProps = """
     override val clientName: String = builder.clientName
-    override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = builder.authSchemes
+    override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.AuthScheme> = builder.authSchemes
     public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default
     override val interceptors: kotlin.collections.List<aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor> = builder.interceptors
@@ -66,12 +66,12 @@ public class Config private constructor(builder: Builder) : HttpAuthConfig, Http
         override var clientName: String = "Test"
 
         /**
-         * Register new or override default [HttpAuthScheme]s configured for this client. By default, the set
+         * Register new or override default [AuthScheme]s configured for this client. By default, the set
          * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
          * precedence over the defaults and can be used to customize identity resolution and signing for specific
          * authentication schemes.
          */
-        override var authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = emptyList()
+        override var authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.AuthScheme> = emptyList()
 
         /**
          * The endpoint provider used to determine where to make service requests. **This is an advanced config
@@ -239,7 +239,7 @@ public class Config private constructor(builder: Builder) {
         // Expect logMode config value to override default to LogMode.Request
         val expectedConfigValues = """
     override val clientName: String = builder.clientName
-    override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme> = builder.authSchemes
+    override val authSchemes: kotlin.collections.List<aws.smithy.kotlin.runtime.http.auth.AuthScheme> = builder.authSchemes
     public val customProp: Int? = builder.customProp
     public val endpointProvider: EndpointProvider = requireNotNull(builder.endpointProvider) { "endpointProvider is a required configuration property" }
     override val idempotencyTokenProvider: IdempotencyTokenProvider = builder.idempotencyTokenProvider ?: IdempotencyTokenProvider.Default

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -138,7 +138,11 @@ class DefaultEndpointProviderGeneratorTest {
             namespace = TestModelDefault.NAMESPACE
         }
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
-        DefaultEndpointProviderGenerator(writer, rules, interfaceSymbol, paramsSymbol).render()
+        val defaultSymbol = buildSymbol {
+            name = "DefaultEndpointProvider"
+            namespace = TestModelDefault.NAMESPACE
+        }
+        DefaultEndpointProviderGenerator(writer, rules, defaultSymbol, interfaceSymbol, paramsSymbol).render()
         generatedClass = writer.toString()
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
@@ -5,6 +5,7 @@
 package software.amazon.smithy.kotlin.codegen.rendering.endpoints
 
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
+import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.assertBalancedBracesAndParens
 import software.amazon.smithy.kotlin.codegen.test.formatForTest
@@ -78,7 +79,11 @@ class EndpointParametersGeneratorTest {
         )
 
         val writer = KotlinWriter(TestModelDefault.NAMESPACE)
-        EndpointParametersGenerator(writer, rules).render()
+        val paramsSymbol = buildSymbol {
+            name = "EndpointParameters"
+            namespace = TestModelDefault.NAMESPACE
+        }
+        EndpointParametersGenerator(writer, rules, paramsSymbol).render()
 
         generatedClass = writer.toString()
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -89,7 +89,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -112,7 +112,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -135,7 +135,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -158,7 +158,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -181,7 +181,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -204,7 +204,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -227,7 +227,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -250,7 +250,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -273,7 +273,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }
@@ -353,7 +353,7 @@ class HttpProtocolClientGeneratorTest {
                 scope = telemetryScope
                 metrics = opMetrics
             }
-            execution.auth = OperationAuthConfig(AuthSchemeProviderAdapter, configuredAuthSchemes, identityProviderConfig)
+            execution.auth = OperationAuthConfig(authSchemeAdapter, configuredAuthSchemes, identityProviderConfig)
             execution.endpointResolver = EndpointResolverAdapter(config)
             execution.retryStrategy = config.retryStrategy
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
 # SDK
-sdkVersion=0.25.2-SNAPSHOT
+sdkVersion=0.26.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.8.22

--- a/runtime/auth/http-auth-api/api/http-auth-api.api
+++ b/runtime/auth/http-auth-api/api/http-auth-api.api
@@ -1,3 +1,13 @@
+public abstract interface class aws/smithy/kotlin/runtime/http/auth/AuthScheme {
+	public abstract fun getSchemeId-DepwgT4 ()Ljava/lang/String;
+	public abstract fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
+	public abstract fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
+}
+
+public final class aws/smithy/kotlin/runtime/http/auth/AuthScheme$DefaultImpls {
+	public static fun identityProvider (Laws/smithy/kotlin/runtime/http/auth/AuthScheme;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpAuthConfig {
 	public abstract fun getAuthSchemes ()Ljava/util/List;
 }
@@ -5,16 +15,6 @@ public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpAuthConf
 public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpAuthConfig$Builder {
 	public abstract fun getAuthSchemes ()Ljava/util/List;
 	public abstract fun setAuthSchemes (Ljava/util/List;)V
-}
-
-public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpAuthScheme {
-	public abstract fun getSchemeId-DepwgT4 ()Ljava/lang/String;
-	public abstract fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
-	public abstract fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
-}
-
-public final class aws/smithy/kotlin/runtime/http/auth/HttpAuthScheme$DefaultImpls {
-	public static fun identityProvider (Laws/smithy/kotlin/runtime/http/auth/HttpAuthScheme;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/auth/HttpSigner {

--- a/runtime/auth/http-auth-api/common/src/aws/smithy/kotlin/runtime/http/auth/AuthScheme.kt
+++ b/runtime/auth/http-auth-api/common/src/aws/smithy/kotlin/runtime/http/auth/AuthScheme.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.identity.IdentityProviderConfig
 /**
  * A configured authentication scheme for HTTP protocol
  */
-public interface HttpAuthScheme {
+public interface AuthScheme {
     /**
      * The unique authentication scheme ID
      */

--- a/runtime/auth/http-auth-api/common/src/aws/smithy/kotlin/runtime/http/auth/HttpAuthConfig.kt
+++ b/runtime/auth/http-auth-api/common/src/aws/smithy/kotlin/runtime/http/auth/HttpAuthConfig.kt
@@ -10,20 +10,20 @@ package aws.smithy.kotlin.runtime.http.auth
  */
 public interface HttpAuthConfig {
     /**
-     * New or overridden [HttpAuthScheme]'s configured for this client. By default, the set
+     * New or overridden [AuthScheme]'s configured for this client. By default, the set
      * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
      * precedence over the defaults and can be used to customize identity resolution and signing for specific
      * authentication schemes.
      */
-    public val authSchemes: List<HttpAuthScheme>
+    public val authSchemes: List<AuthScheme>
 
     public interface Builder {
         /**
-         * Register new or override default [HttpAuthScheme]'s configured for this client. By default, the set
+         * Register new or override default [AuthScheme]'s configured for this client. By default, the set
          * of auth schemes configured comes from the service model. An auth scheme configured explicitly takes
          * precedence over the defaults and can be used to customize identity resolution and signing for specific
          * authentication schemes.
          */
-        public var authSchemes: List<HttpAuthScheme>
+        public var authSchemes: List<AuthScheme>
     }
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.http.auth
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
 import aws.smithy.kotlin.runtime.auth.awssigning.HashSpecification
@@ -47,5 +46,5 @@ public fun sigv4(unsignedPayload: Boolean = false): AuthOption {
     } else {
         emptyAttributes()
     }
-    return AuthSchemeOption(AuthSchemeId.AwsSigV4, attrs)
+    return AuthOption(AuthSchemeId.AwsSigV4, attrs)
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.http.auth
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
@@ -20,7 +21,7 @@ import aws.smithy.kotlin.runtime.util.emptyAttributes
 @InternalApi
 public class SigV4AuthScheme(
     config: AwsHttpSigner.Config,
-) : HttpAuthScheme {
+) : AuthScheme {
     public constructor(awsSigner: AwsSigner, serviceName: String) : this(
         AwsHttpSigner.Config().apply {
             signer = awsSigner
@@ -33,12 +34,12 @@ public class SigV4AuthScheme(
 }
 
 /**
- * Create a new [AuthSchemeOption] for the [SigV4AuthScheme]
+ * Create a new [AuthOption] for the [SigV4AuthScheme]
  * @param unsignedPayload set the signing attribute to indicate the signer should use unsigned payload.
  * @return auth scheme option representing the [SigV4AuthScheme]
  */
 @InternalApi
-public fun sigv4(unsignedPayload: Boolean = false): AuthSchemeOption {
+public fun sigv4(unsignedPayload: Boolean = false): AuthOption {
     val attrs = if (unsignedPayload) {
         attributesOf {
             AwsSigningAttributes.HashSpecification to HashSpecification.UnsignedPayload

--- a/runtime/auth/http-auth/api/http-auth.api
+++ b/runtime/auth/http-auth/api/http-auth.api
@@ -1,4 +1,4 @@
-public final class aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme : aws/smithy/kotlin/runtime/http/auth/HttpAuthScheme {
+public final class aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme;
 	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
 	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
@@ -25,7 +25,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/auth/BearerToken 
 	public abstract fun getToken ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/http/auth/BearerTokenAuthScheme : aws/smithy/kotlin/runtime/http/auth/HttpAuthScheme {
+public final class aws/smithy/kotlin/runtime/http/auth/BearerTokenAuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
 	public fun <init> ()V
 	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
 	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;

--- a/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
+++ b/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/AnonymousAuthScheme.kt
@@ -35,7 +35,7 @@ public object AnonymousIdentityProvider : IdentityProvider {
 /**
  * A no-op auth scheme
  */
-public object AnonymousAuthScheme : HttpAuthScheme {
+public object AnonymousAuthScheme : AuthScheme {
     override val schemeId: AuthSchemeId = AuthSchemeId.Anonymous
     override val signer: HttpSigner = AnonymousHttpSigner
     override fun identityProvider(identityProviderConfig: IdentityProviderConfig): IdentityProvider = AnonymousIdentityProvider

--- a/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/BearerTokenAuthScheme.kt
+++ b/runtime/auth/http-auth/common/src/aws/smithy/kotlin/runtime/http/auth/BearerTokenAuthScheme.kt
@@ -10,7 +10,7 @@ import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 /**
  * HTTP auth scheme for HTTP Bearer authentication as defined in [RFC 6750](https://tools.ietf.org/html/rfc6750.html)
  */
-public class BearerTokenAuthScheme : HttpAuthScheme {
+public class BearerTokenAuthScheme : AuthScheme {
     override val schemeId: AuthSchemeId = AuthSchemeId.HttpBearer
     override val signer: HttpSigner = BearerTokenSigner()
 }

--- a/runtime/auth/identity-api/api/identity-api.api
+++ b/runtime/auth/identity-api/api/identity-api.api
@@ -1,3 +1,13 @@
+public abstract interface class aws/smithy/kotlin/runtime/auth/AuthOption {
+	public abstract fun getAttributes ()Laws/smithy/kotlin/runtime/util/Attributes;
+	public abstract fun getSchemeId-DepwgT4 ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/AuthOptionKt {
+	public static final fun AuthOption-Jh0Pmzk (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/AuthOption;
+	public static synthetic fun AuthOption-Jh0Pmzk$default (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/AuthOption;
+}
+
 public final class aws/smithy/kotlin/runtime/auth/AuthSchemeId {
 	public static final field Companion Laws/smithy/kotlin/runtime/auth/AuthSchemeId$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Laws/smithy/kotlin/runtime/auth/AuthSchemeId;
@@ -17,26 +27,10 @@ public final class aws/smithy/kotlin/runtime/auth/AuthSchemeId$Companion {
 	public final fun getAnonymous-DepwgT4 ()Ljava/lang/String;
 	public final fun getAwsSigV4-DepwgT4 ()Ljava/lang/String;
 	public final fun getAwsSigV4Asymmetric-DepwgT4 ()Ljava/lang/String;
-	public final fun getAwsSigV4Query-DepwgT4 ()Ljava/lang/String;
-	public final fun getAwsX509-DepwgT4 ()Ljava/lang/String;
 	public final fun getHttpApiKey-DepwgT4 ()Ljava/lang/String;
 	public final fun getHttpBasic-DepwgT4 ()Ljava/lang/String;
 	public final fun getHttpBearer-DepwgT4 ()Ljava/lang/String;
 	public final fun getHttpDigest-DepwgT4 ()Ljava/lang/String;
-}
-
-public final class aws/smithy/kotlin/runtime/auth/AuthSchemeOption {
-	public synthetic fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-DepwgT4 ()Ljava/lang/String;
-	public final fun component2 ()Laws/smithy/kotlin/runtime/util/Attributes;
-	public final fun copy-Jh0Pmzk (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/AuthSchemeOption;
-	public static synthetic fun copy-Jh0Pmzk$default (Laws/smithy/kotlin/runtime/auth/AuthSchemeOption;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/AuthSchemeOption;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAttributes ()Laws/smithy/kotlin/runtime/util/Attributes;
-	public final fun getSchemeId-DepwgT4 ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/auth/AuthSchemeProvider {

--- a/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthOption.kt
+++ b/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthOption.kt
@@ -12,14 +12,22 @@ import aws.smithy.kotlin.runtime.util.emptyAttributes
  * A tuple of [AuthSchemeId] and typed properties. AuthSchemeOption represents a candidate
  * authentication scheme.
  */
-public data class AuthSchemeOption(
+public interface AuthOption {
     /**
      * The ID of the authentication scheme
      */
-    public val schemeId: AuthSchemeId,
+    public val schemeId: AuthSchemeId
 
     /**
      * Identity or signer attributes to use with this resolved authentication scheme
      */
-    public val attributes: Attributes = emptyAttributes(),
-)
+    public val attributes: Attributes
+}
+
+public fun AuthOption(id: AuthSchemeId, attributes: Attributes = emptyAttributes()): AuthOption =
+    AuthOptionImpl(id, attributes)
+
+private data class AuthOptionImpl(
+    override val schemeId: AuthSchemeId,
+    override val attributes: Attributes,
+) : AuthOption

--- a/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeId.kt
+++ b/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeId.kt
@@ -15,7 +15,7 @@ public value class AuthSchemeId(public val id: String) {
         /**
          * Indicates that an operation MAY be invoked without authentication
          */
-        public val Anonymous: AuthSchemeId = AuthSchemeId("smithy.api#optionalAuth")
+        public val Anonymous: AuthSchemeId = AuthSchemeId("smithy.api#noAuth")
 
         /**
          * HTTP Basic Authentication as defined in [RFC 2617](https://tools.ietf.org/html/rfc2617.html)
@@ -46,15 +46,5 @@ public value class AuthSchemeId(public val id: String) {
          * AWS Signature Version 4 asymmetric authentication
          */
         public val AwsSigV4Asymmetric: AuthSchemeId = AuthSchemeId("aws.auth#sigv4a")
-
-        /**
-         * AWS Signature Version 4 query authentication
-         */
-        public val AwsSigV4Query: AuthSchemeId = AuthSchemeId("aws.auth#sigv4Query")
-
-        /**
-         * AWS Signature Version 4 X.509 authentication
-         */
-        public val AwsX509: AuthSchemeId = AuthSchemeId("aws.auth#sigv4x509")
     }
 }

--- a/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeProvider.kt
+++ b/runtime/auth/identity-api/common/src/aws/smithy/kotlin/runtime/auth/AuthSchemeProvider.kt
@@ -12,7 +12,7 @@ public interface AuthSchemeProvider<in T> {
     /**
      * Resolve the candidate set of authentication schemes for an operation
      * @param params The input context for the resolver function
-     * @return a list of candidate [AuthSchemeOption] that can be used for an operation
+     * @return a list of candidate [AuthOption] that can be used for an operation
      */
-    public suspend fun resolveAuthScheme(params: T): List<AuthSchemeOption>
+    public suspend fun resolveAuthScheme(params: T): List<AuthOption>
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
@@ -6,12 +6,13 @@
 package aws.smithy.kotlin.runtime.http.operation
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider
 import aws.smithy.kotlin.runtime.http.auth.AnonymousAuthScheme
 import aws.smithy.kotlin.runtime.http.auth.AnonymousIdentityProvider
-import aws.smithy.kotlin.runtime.http.auth.HttpAuthScheme
+import aws.smithy.kotlin.runtime.http.auth.AuthScheme
 import aws.smithy.kotlin.runtime.identity.IdentityProviderConfig
 import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 
@@ -29,7 +30,7 @@ private val AnonymousAuthConfig = OperationAuthConfig.from(
 @InternalApi
 public data class OperationAuthConfig(
     val authSchemeResolver: AuthSchemeResolver,
-    val configuredAuthSchemes: Map<AuthSchemeId, HttpAuthScheme>,
+    val configuredAuthSchemes: Map<AuthSchemeId, AuthScheme>,
     val identityProviderConfig: IdentityProviderConfig,
 ) {
     @InternalApi
@@ -42,10 +43,10 @@ public data class OperationAuthConfig(
          */
         public fun from(
             identityProviderConfig: IdentityProviderConfig,
-            vararg authSchemes: HttpAuthScheme,
+            vararg authSchemes: AuthScheme,
         ): OperationAuthConfig {
             val resolver = AuthSchemeResolver { authSchemes.map { AuthSchemeOption(it.schemeId) } }
-            return OperationAuthConfig(resolver, authSchemes.associateBy(HttpAuthScheme::schemeId), identityProviderConfig)
+            return OperationAuthConfig(resolver, authSchemes.associateBy(AuthScheme::schemeId), identityProviderConfig)
         }
     }
 }
@@ -60,5 +61,5 @@ public fun interface AuthSchemeResolver {
      * Resolve the candidate authentication schemes for an operation
      * @return a prioritized list of candidate auth schemes to use for the current operation
      */
-    public suspend fun resolve(request: SdkHttpRequest): List<AuthSchemeOption>
+    public suspend fun resolve(request: SdkHttpRequest): List<AuthOption>
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationAuth.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.http.operation
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider
 import aws.smithy.kotlin.runtime.http.auth.AnonymousAuthScheme
 import aws.smithy.kotlin.runtime.http.auth.AnonymousIdentityProvider
@@ -45,7 +44,7 @@ public data class OperationAuthConfig(
             identityProviderConfig: IdentityProviderConfig,
             vararg authSchemes: AuthScheme,
         ): OperationAuthConfig {
-            val resolver = AuthSchemeResolver { authSchemes.map { AuthSchemeOption(it.schemeId) } }
+            val resolver = AuthSchemeResolver { authSchemes.map { AuthOption(it.schemeId) } }
             return OperationAuthConfig(resolver, authSchemes.associateBy(AuthScheme::schemeId), identityProviderConfig)
         }
     }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -45,7 +45,7 @@ class HttpAuthHandlerTest {
         interceptorExec.readBeforeExecution(Unit)
 
         val idpConfig = AnonymousIdentityProvider.asIdentityProviderConfig()
-        val scheme = object : HttpAuthScheme {
+        val scheme = object : AuthScheme {
             override val schemeId: AuthSchemeId = AuthSchemeId.Anonymous
             override fun identityProvider(identityProviderConfig: IdentityProviderConfig): IdentityProvider = object : IdentityProvider {
                 override suspend fun resolve(attributes: Attributes): Identity {
@@ -69,7 +69,7 @@ class HttpAuthHandlerTest {
             listOf(AuthSchemeOption(AuthSchemeId.Anonymous, attrs))
         }
 
-        val schemes = listOf(scheme).associateBy(HttpAuthScheme::schemeId)
+        val schemes = listOf(scheme).associateBy(AuthScheme::schemeId)
         val authConfig = OperationAuthConfig(resolver, schemes, idpConfig)
         val op = AuthHandler<Unit, Unit>(inner, interceptorExec, authConfig)
         val request = SdkHttpRequest(ctx, HttpRequestBuilder())

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -5,8 +5,8 @@
 
 package aws.smithy.kotlin.runtime.http.operation
 
+import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.auth.AuthSchemeOption
 import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.auth.*
 import aws.smithy.kotlin.runtime.http.interceptors.InterceptorExecutor
@@ -66,7 +66,7 @@ class HttpAuthHandlerTest {
             val attrs = attributesOf {
                 testAttrKey to "testing"
             }
-            listOf(AuthSchemeOption(AuthSchemeId.Anonymous, attrs))
+            listOf(AuthOption(AuthSchemeId.Anonymous, attrs))
         }
 
         val schemes = listOf(scheme).associateBy(AuthScheme::schemeId)

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecutionTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecutionTest.kt
@@ -57,7 +57,7 @@ class SdkOperationExecutionTest {
                 assertFalse(request.headers.contains("receive-header"))
             }
         }
-        val authScheme = object : HttpAuthScheme {
+        val authScheme = object : AuthScheme {
             override val schemeId: AuthSchemeId = AuthSchemeId.Anonymous
             override val signer: HttpSigner = httpSigner
         }

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/DefaultLambdaAuthSchemeProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/DefaultLambdaAuthSchemeProvider.kt
@@ -1,0 +1,9 @@
+package smithy.kotlin.traits.auth
+
+import aws.smithy.kotlin.runtime.auth.AuthOption
+
+object DefaultLambdaAuthSchemeProvider : LambdaAuthSchemeProvider {
+    override suspend fun resolveAuthScheme(params: LambdaAuthSchemeParameters): List<AuthOption> {
+        error("not needed for paginator integration tests")
+    }
+}

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/DefaultLambdaAuthSchemeProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/DefaultLambdaAuthSchemeProvider.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package smithy.kotlin.traits.auth
 
 import aws.smithy.kotlin.runtime.auth.AuthOption

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/LambdaAuthSchemeProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/LambdaAuthSchemeProvider.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package smithy.kotlin.traits.auth
 
 import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/LambdaAuthSchemeProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/auth/LambdaAuthSchemeProvider.kt
@@ -1,0 +1,8 @@
+package smithy.kotlin.traits.auth
+
+import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider
+
+// Without a protocol generator there are certain components expected to exist that aren't getting generated.
+// Fill in the types manually so that the generated code compiles. None of these are needed for the tests at hand.
+interface LambdaAuthSchemeParameters
+interface LambdaAuthSchemeProvider : AuthSchemeProvider<LambdaAuthSchemeParameters>

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/endpoints/LambdaEndpointParameters.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/endpoints/LambdaEndpointParameters.kt
@@ -2,6 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.test.endpoints
+package smithy.kotlin.traits.endpoints
 
-class EndpointParameters
+class LambdaEndpointParameters

--- a/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/endpoints/LambdaEndpointProvider.kt
+++ b/tests/codegen/paginator-tests/src/main/kotlin/smithy/kotlin/traits/endpoints/LambdaEndpointProvider.kt
@@ -7,4 +7,4 @@ package smithy.kotlin.traits.endpoints
 /**
  * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
  */
-typealias EndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<smithy.kotlin.traits.endpoints.EndpointParameters>
+typealias LambdaEndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<smithy.kotlin.traits.endpoints.LambdaEndpointParameters>

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/DefaultWaitersTestAuthSchemeProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/DefaultWaitersTestAuthSchemeProvider.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.test.auth
 
 import aws.smithy.kotlin.runtime.auth.AuthOption

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/DefaultWaitersTestAuthSchemeProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/DefaultWaitersTestAuthSchemeProvider.kt
@@ -1,0 +1,9 @@
+package com.test.auth
+
+import aws.smithy.kotlin.runtime.auth.AuthOption
+
+object DefaultWaitersTestAuthSchemeProvider : WaitersTestAuthSchemeProvider {
+    override suspend fun resolveAuthScheme(params: WaitersTestAuthSchemeParameters): List<AuthOption> {
+        error("not needed for waiter integration tests")
+    }
+}

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/WaitersTestAuthSchemeProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/WaitersTestAuthSchemeProvider.kt
@@ -1,7 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.test.auth
 
 import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider
-
 
 // Without a protocol generator there are certain components expected to exist that aren't getting generated.
 // Fill in the types manually so that the generated code compiles. None of these are needed for the tests at hand.

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/WaitersTestAuthSchemeProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/auth/WaitersTestAuthSchemeProvider.kt
@@ -1,0 +1,9 @@
+package com.test.auth
+
+import aws.smithy.kotlin.runtime.auth.AuthSchemeProvider
+
+
+// Without a protocol generator there are certain components expected to exist that aren't getting generated.
+// Fill in the types manually so that the generated code compiles. None of these are needed for the tests at hand.
+interface WaitersTestAuthSchemeParameters
+interface WaitersTestAuthSchemeProvider : AuthSchemeProvider<WaitersTestAuthSchemeParameters>

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/EndpointProvider.kt
@@ -7,4 +7,4 @@ package com.test.endpoints
 /**
  * Stubbed EndpointProvider since we don't use a concrete protocol generator for this test.
  */
-typealias EndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<EndpointParameters>
+typealias WaitersTestEndpointProvider = aws.smithy.kotlin.runtime.client.endpoints.EndpointProvider<WaitersTestEndpointParameters>

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/WaitersTestEndpointParameters.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/endpoints/WaitersTestEndpointParameters.kt
@@ -2,6 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package smithy.kotlin.traits.endpoints
+package com.test.endpoints
 
-class EndpointParameters
+class WaitersTestEndpointParameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* **BREAKING**: prefix generated endpoint provider and parameters with the service client name (e.g. `EndpointProvider` -> `S3EndpointProvider`)
* **refactor**: minor cleanup and alignment to latest SRA auth APIs (e.g. `AuthSchemOption` -> `AuthOption`)
* **refactor**: make generated auth scheme provider type(s) public and part of service client config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
