### PR TITLE
feat: add support for multi select hash to JMESPath visitor

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGenerator.kt
@@ -89,12 +89,12 @@ private fun KotlinWriter.renderPathAcceptor(wi: WaiterInfo, directive: String, i
         val comparison = when (matcher.comparator!!) {
             PathComparator.STRING_EQUALS -> "${actual.identifier} == ${expected.dq()}"
             PathComparator.BOOLEAN_EQUALS -> "${actual.identifier} == ${expected.toBoolean()}"
-            PathComparator.ANY_STRING_EQUALS -> "${actual.identifier}?.any { it == ${expected.dq()} } ?: false"
+            PathComparator.ANY_STRING_EQUALS -> "(${actual.identifier} as List<String>?)?.any { it == ${expected.dq()} } ?: false"
 
             // NOTE: the isNotEmpty check is necessary because the waiter spec says that `allStringEquals` requires
             // at least one value unlike Kotlin's `all` which returns true if the collection is empty
             PathComparator.ALL_STRING_EQUALS ->
-                "!${actual.identifier}.isNullOrEmpty() && ${actual.identifier}.all { it == ${expected.dq()} }"
+                "!(${actual.identifier} as List<String>).isNullOrEmpty() && ${actual.identifier}.all { it == ${expected.dq()} }"
         }
         write(comparison)
     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
@@ -52,7 +52,7 @@ class AcceptorGeneratorTest {
         val expected = """
             val $acceptorListName = listOf<Acceptor<DescribeFooRequest, DescribeFooResponse>>(
                 OutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val name = it.name
+                    val name = it?.name
                     name == "foo"
                 },
             )
@@ -65,24 +65,24 @@ class AcceptorGeneratorTest {
         val expected = """
             val $acceptorListName = listOf<Acceptor<DescribeFooRequest, DescribeFooResponse>>(
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val input = it.input
-                    val id = input.id
+                    val input = it?.input
+                    val id = input?.id
                     id == "foo"
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
-                    val isDeprecated = output.isDeprecated
+                    val output = it?.output
+                    val isDeprecated = output?.isDeprecated
                     isDeprecated == false
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
-                    val tags = output.tags
-                    !tags.isNullOrEmpty() && tags.all { it == "foo" }
+                    val output = it?.output
+                    val tags = output?.tags
+                    !(tags as List<String>).isNullOrEmpty() && tags.all { it == "foo" }
                 },
                 InputOutputAcceptor(RetryDirective.TerminateAndSucceed) {
-                    val output = it.output
-                    val tags = output.tags
-                    tags?.any { it == "foo" } ?: false
+                    val output = it?.output
+                    val tags = output?.tags
+                    (tags as List<String>?)?.any { it == "foo" } ?: false
                 },
             )
         """.trimIndent()

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -525,6 +525,107 @@ service WaitersTestService {
         ]
     },
 
+    // multi select list
+    StructListStringMultiSelectList: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[].[primitives.string][0][0]",
+                        expected: "foo",
+                        comparator: "stringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StructListStringListMultiSelectList: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[].[primitives.string, primitives.string][1]",
+                        expected: "foo",
+                        comparator: "allStringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StructListSubStructPrimitivesBooleanMultiSelectList: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "lists.structs[].[subStructs][1][0][0].subStructPrimitives.boolean",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+
+    StructListStringMultiSelectHash: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "(lists.structs[].{x: primitives.string, y: strings})[0].x",
+                        expected: "foo"
+                        comparator: "stringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StructListStringsMultiSelectHash: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "(lists.structs[].{x: primitives.string, y: strings})[1].y",
+                        expected: "foo"
+                        comparator: "allStringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StructListStringsAnyMultiSelectHash: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "(lists.structs[].{x: primitives.string, y: strings})[1].y",
+                        expected: "foo"
+                        comparator: "anyStringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StructListSubStructPrimitivesBooleanMultiSelectHash: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "(lists.structs[].{x: subStructs})[0].x[0].subStructPrimitives.boolean",
+                        expected: "true"
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+
     // function: contains, list
     BooleanListContains: {
         acceptors: [

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -257,6 +257,177 @@ class WaiterTest {
         GetEntityResponse { lists = EntityLists { strings = listOf("bar", "foo", "foo", "bar") } },
     )
 
+    // multi select
+    @Test fun testStructListStringMultiSelectList() = successTest(
+        WaitersTestClient::waitUntilStructListStringMultiSelectList,
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "bar" } }, Struct { primitives = EntityPrimitives { string = "foo" } }) } },
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "foo" } }, Struct { primitives = EntityPrimitives { string = "bar" } }) } },
+    )
+
+    @Test fun testStructListStringListMultiSelectList() = successTest(
+        WaitersTestClient::waitUntilStructListStringListMultiSelectList,
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "foo" } }, Struct { primitives = EntityPrimitives { string = "bar" } }) } },
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "bar" } }, Struct { primitives = EntityPrimitives { string = "foo" } }) } },
+    )
+
+    @Test fun testStructListSubStructPrimitivesBooleanMultiSelectList() = successTest(
+        WaitersTestClient::waitUntilStructListSubStructPrimitivesBooleanMultiSelectList,
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = true }
+                            }
+                        )
+                    },
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = false }
+                            }
+                        )
+                    }
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = false }
+                            }
+                        )
+                    },
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = true }
+                            }
+                        )
+                    }
+                )
+            }
+        },
+    )
+
+    @Test fun testStructListStringMultiSelectHash() = successTest(
+        WaitersTestClient::waitUntilStructListStringMultiSelectHash,
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "bar" } }, Struct { primitives = EntityPrimitives { string = "foo" } }) } },
+        GetEntityResponse { lists = EntityLists { structs = listOf(Struct { primitives = EntityPrimitives { string = "foo" } }, Struct { primitives = EntityPrimitives { string = "bar" } }) } },
+    )
+
+    @Test fun testStructListStringsMultiSelectHash() = successTest(
+        WaitersTestClient::waitUntilStructListStringsMultiSelectHash,
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("foo")
+                    },
+                )
+            }
+        },
+    )
+
+    @Test fun testStructListStringsAnyMultiSelectHash() = successTest(
+        WaitersTestClient::waitUntilStructListStringsAnyMultiSelectHash,
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar")
+                    },
+                    Struct {
+                        primitives = EntityPrimitives { string = "bar" }
+                        strings = listOf("bar", "bar", "foo")
+                    },
+                )
+            }
+        },
+    )
+
+    @Test fun testStructListSubStructPrimitivesBooleanMultiSelectHash() = successTest(
+        WaitersTestClient::waitUntilStructListSubStructPrimitivesBooleanMultiSelectHash,
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = false }
+                            }
+                        )
+                    },
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = true }
+                            }
+                        )
+                    }
+                )
+            }
+        },
+        GetEntityResponse {
+            lists = EntityLists {
+                structs = listOf(
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = true }
+                            }
+                        )
+                    },
+                    Struct {
+                        subStructs = listOf(
+                            SubStruct {
+                                subStructPrimitives = EntityPrimitives { boolean = false }
+                            }
+                        )
+                    }
+                )
+            }
+        },
+    )
+
     // function: contains, list
     @Test fun testBooleanListContains() = successTest(
         WaitersTestClient::waitUntilBooleanListContains,

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/WaiterTest.kt
@@ -279,16 +279,16 @@ class WaiterTest {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = true }
-                            }
+                            },
                         )
                     },
                     Struct {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = false }
-                            }
+                            },
                         )
-                    }
+                    },
                 )
             }
         },
@@ -299,16 +299,16 @@ class WaiterTest {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = false }
-                            }
+                            },
                         )
                     },
                     Struct {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = true }
-                            }
+                            },
                         )
-                    }
+                    },
                 )
             }
         },
@@ -393,16 +393,16 @@ class WaiterTest {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = false }
-                            }
+                            },
                         )
                     },
                     Struct {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = true }
-                            }
+                            },
                         )
-                    }
+                    },
                 )
             }
         },
@@ -413,16 +413,16 @@ class WaiterTest {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = true }
-                            }
+                            },
                         )
                     },
                     Struct {
                         subStructs = listOf(
                             SubStruct {
                                 subStructPrimitives = EntityPrimitives { boolean = false }
-                            }
+                            },
                         )
-                    }
+                    },
                 )
             }
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
closes #930 
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Added support for multi select hash 
- Added missing list from multi select list to match JMESPath syntax
- `ensureNullGuard` is now `addNullGuard` and is added to all temporary val's
- `subField` function now allows accessing members of shapes that "are not there" (multi select hash creates anonymous objects with arbitrary attributes that don't show up in the model)
- comparator for `anyStringEquals` and `allStringEquals` now casts to a list of strings before comparing (anonymous objects have attributes of generic type)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
