### PR TITLE
fix: lower engine concurrency to closer to what it was when test was written to fix windows issue

### DIFF
--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
@@ -10,6 +10,7 @@ import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.complete
 import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
+import aws.smithy.kotlin.runtime.http.test.util.engineConfig
 import aws.smithy.kotlin.runtime.http.test.util.test
 import aws.smithy.kotlin.runtime.http.test.util.testSetup
 import kotlinx.coroutines.*
@@ -22,6 +23,9 @@ class AsyncStressTest : AbstractEngineTest() {
     fun testConcurrentRequests() = testEngines {
         // https://github.com/awslabs/aws-sdk-kotlin/issues/170
         concurrency = 1_000
+        engineConfig {
+            maxConcurrency = 32u
+        }
 
         test { env, client ->
             val req = HttpRequest {

--- a/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/common/test/aws/smithy/kotlin/runtime/http/test/AsyncStressTest.kt
@@ -24,6 +24,7 @@ class AsyncStressTest : AbstractEngineTest() {
         // https://github.com/awslabs/aws-sdk-kotlin/issues/170
         concurrency = 1_000
         engineConfig {
+            // FIXME - investigate windows CI issue when this is removed
             maxConcurrency = 32u
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Lower the engine concurrency to closer to what it was when this test was written (16 for okhttp). This is a band aid to fix the flakiness of this test on windows CI since I haven't been able to reproduce it locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
