### PR TITLE
fix: x-amz-content-sha256 header is expected for unsigned payload and event stream operations

### DIFF
--- a/.changes/4cc18c3e-31f4-4f70-987d-36e1ddee4a57.json
+++ b/.changes/4cc18c3e-31f4-4f70-987d-36e1ddee4a57.json
@@ -1,0 +1,8 @@
+{
+    "id": "4cc18c3e-31f4-4f70-987d-36e1ddee4a57",
+    "type": "bugfix",
+    "description": "Set X-Amz-Content-Sha256 header for unsigned payload and event stream operations by default",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1029"
+    ]
+}

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -93,6 +93,18 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
          * this parameter has no effect.
          */
         public var expiresAfter: Duration? = null
+
+        /**
+         * A predicate to control which headers are a part of the canonical request. Note that skipping auth-required
+         * headers will result in an unusable signature. Headers injected by the signing process cannot be skipped.
+         *
+         * This function does not override the internal check function (e.g., for `x-amzn-trace-id`, `user-agent`, etc.) but
+         * rather supplements it. In particular, a header will get signed if and only if it returns true to both the
+         * internal check and this function (if defined).
+         *
+         * The default predicate is to not reject signing any headers (i.e., `_ -> true`).
+         */
+        public var shouldSignHeader: ShouldSignHeaderPredicate = { _ -> true }
     }
 
     override suspend fun sign(signingRequest: SignHttpRequest) {
@@ -118,6 +130,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
             normalizeUriPath = config.normalizeUriPath
             useDoubleUriEncode = config.useDoubleUriEncode
             expiresAfter = config.expiresAfter
+            shouldSignHeader = config.shouldSignHeader
 
             signedBodyHeader = contextSignedBodyHeader ?: config.signedBodyHeader
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes https://github.com/awslabs/aws-sdk-kotlin/issues/1029

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Adds a new middleware when sigv4 is present that conditionally enables setting the `SignedBodyHeader` execution context attribute when the operation has the unsigned payload trait or is an event stream input. When set the signer will add the `x-amz-content-sha256` header to the canonical request and set the header.
* Adds the `shouldSignHeader` predicate to the `AwsHttpSigner.Config`. This was missing and allows auth scheme overrides to augment the set of signed headers. This allowed me to narrow down the issue since we include a few more headers than AWS CLI did. This should have been possible previously and I was surprised it wasn't.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
