### PR TITLE
fix: cancel `HttpCall` if closing the response body fails

### DIFF
--- a/.changes/7b65c6c4-92fc-4435-b453-bac245f8ae43.json
+++ b/.changes/7b65c6c4-92fc-4435-b453-bac245f8ae43.json
@@ -1,0 +1,8 @@
+{
+    "id": "7b65c6c4-92fc-4435-b453-bac245f8ae43",
+    "type": "bugfix",
+    "description": "Fix an IllegalStateException thrown when closing an event stream",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/935"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -51,7 +51,8 @@ public class OkHttpEngine(
         val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         callContext.job.invokeOnCompletion {
-            engineResponse.body.close()
+            engineCall.cancel()
+            runCatching { engineResponse.body.close() }
         }
 
         val response = engineResponse.toSdkResponse()

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import okhttp3.*
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.microseconds
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toJavaDuration
 import aws.smithy.kotlin.runtime.config.TlsVersion as SdkTlsVersion

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -54,6 +54,7 @@ public class OkHttpEngine(
         val engineResponse = mapOkHttpExceptions { engineCall.executeAsync() }
 
         callContext.job.invokeOnCompletion {
+            // FIXME: https://github.com/awslabs/smithy-kotlin/issues/935
             val closeResult = runCatching { engineResponse.body.close() }
 
             if (closeResult.isFailure) {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import okhttp3.*
+import java.lang.IllegalStateException
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toJavaDuration
@@ -57,7 +58,7 @@ public class OkHttpEngine(
             // FIXME: https://github.com/awslabs/smithy-kotlin/issues/935
             val closeResult = runCatching { engineResponse.body.close() }
 
-            if (closeResult.isFailure) {
+            if (closeResult.isFailure && closeResult.exceptionOrNull() is IllegalStateException) {
                 engineCall.cancel()
                 runBlocking { delay(1.nanoseconds) }
                 engineResponse.body.close()

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -58,7 +58,7 @@ public class OkHttpEngine(
             // FIXME: https://github.com/awslabs/smithy-kotlin/issues/935
             val closeResult = runCatching { engineResponse.body.close() }
 
-            if (closeResult.isFailure && closeResult.exceptionOrNull() is IllegalStateException) {
+            if (closeResult.exceptionOrNull() is IllegalStateException) {
                 engineCall.cancel()
                 runBlocking { delay(1.nanoseconds) }
                 engineResponse.body.close()

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/io/internal/JobChannel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Job
  * Ties the lifetime of the channel and a Job together. Channel failures (closed with exception) will
  * cause the underlying [Job] to fail with the channel exception.
  *
- * This is useful for launching coroutines with the soul purpose of reading/writing data to the channel where
+ * This is useful for launching coroutines with the sole purpose of reading/writing data to the channel where
  * the coroutine should only continue if the channel hasn't failed.
  */
 @InternalApi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
See https://github.com/awslabs/smithy-kotlin/issues/935 for the full context.

This PR fixes an `IllegalStateException` that's thrown when trying to close the `engineResponse.body` while a different coroutine is blocked trying to `read()` the body. 

The fix works by checking if closing the response body fails (throwing `IllegalStateException`). If it fails, then we can first cancel the `Call` (as [recommended by OkHttp devs](https://github.com/square/okhttp/issues/4110#issuecomment-402436150)), wait a short period of time, and *then* close the response body successfully.


## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/awslabs/smithy-kotlin/issues/935

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required to support closing event streams before they have been fully consumed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
