### PR TITLE
feat: add functions (sum, avg, join, starts_with, ends_with) to JMESPath visitor

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -159,7 +159,7 @@ class KotlinJmespathExpressionVisitor(
             }
 
             val unSafeComparatorExpr = "compareTo(${right.identifier}) ${expression.comparator} 0"
-            val comparatorExpr = if (left.nullable) buildString { append("?.$unSafeComparatorExpr") } else buildString { append(".$unSafeComparatorExpr") }
+            val comparatorExpr = if (left.nullable) "?.$unSafeComparatorExpr" else ".$unSafeComparatorExpr"
 
             append("${left.identifier}$comparatorExpr")
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -214,8 +214,8 @@ class KotlinJmespathExpressionVisitor(
     }
 
     private fun VisitedExpression.dotFunction(expression: FunctionExpression, expr: String, elvisExpr: String? = null): VisitedExpression {
-        val expr = ensureNullGuard(this.shape, expr, elvisExpr)
-        val ident = addTempVar(expression.name, "${this.identifier}$expr")
+        val dotFunctionExpr = ensureNullGuard(this.shape, expr, elvisExpr)
+        val ident = addTempVar(expression.name, "${this.identifier}$dotFunctionExpr")
 
         return VisitedExpression(ident, this.shape)
     }

--- a/tests/codegen/waiter-tests/model/function-avg.smithy
+++ b/tests/codegen/waiter-tests/model/function-avg.smithy
@@ -1,0 +1,84 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@waitable(
+    ShortListAvgEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.shorts) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    IntegerListAvgEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.integers) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    LongListAvgEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.longs) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    FloatListAvgEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.floats) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    DoubleListAvgEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.doubles) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/avg/{name}", code: 200)
+operation GetFunctionAvgEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-avg.smithy
+++ b/tests/codegen/waiter-tests/model/function-avg.smithy
@@ -4,21 +4,7 @@ namespace com.test
 use smithy.waiters#waitable
 
 @waitable(
-    ShortListAvgEquals: {
-        acceptors: [
-            {
-                state: "success",
-                matcher: {
-                    output: {
-                        path: "avg(lists.shorts) == `10`",
-                        expected: "false",
-                        comparator: "booleanEquals"
-                    }
-                }
-            }
-        ]
-    },
-    IntegerListAvgEquals: {
+    EmptyIntegerListAvgNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -32,7 +18,35 @@ use smithy.waiters#waitable
             }
         ]
     },
-    LongListAvgEquals: {
+    ShortListAvgNotEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.shorts) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    IntegerListAvgNotEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "avg(lists.integers) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    LongListAvgNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -46,7 +60,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    FloatListAvgEquals: {
+    FloatListAvgNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -60,7 +74,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    DoubleListAvgEquals: {
+    DoubleListAvgNotEquals: {
         acceptors: [
             {
                 state: "success",

--- a/tests/codegen/waiter-tests/model/function-ends-with.smithy
+++ b/tests/codegen/waiter-tests/model/function-ends-with.smithy
@@ -1,0 +1,29 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@suppress(["WaitableTraitJmespathProblem"])
+@waitable(
+    StringEndsWithEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "ends_with(primitives.string, 'baz')",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/ends/{name}", code: 200)
+operation GetFunctionEndsWithEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-join.smithy
+++ b/tests/codegen/waiter-tests/model/function-join.smithy
@@ -1,0 +1,42 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@waitable(
+    StringListJoinEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "join('', lists.strings)",
+                        expected: "foo",
+                        comparator: "stringEquals"
+                    }
+                }
+            }
+        ]
+    },
+    StringListSeparatorJoinEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "join(', ', lists.strings)",
+                        expected: "foo, bar",
+                        comparator: "stringEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/join/{name}", code: 200)
+operation GetFunctionJoinEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-starts-with.smithy
+++ b/tests/codegen/waiter-tests/model/function-starts-with.smithy
@@ -1,0 +1,28 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@waitable(
+    StringStartsWithEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "starts_with(primitives.string, 'foo')",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/starts/{name}", code: 200)
+operation GetFunctionStartsWithEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-sum.smithy
+++ b/tests/codegen/waiter-tests/model/function-sum.smithy
@@ -1,0 +1,84 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@waitable(
+    ShortListSumEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "sum(lists.shorts) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    IntegerListSumEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "sum(lists.integers) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    LongListSumEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "sum(lists.longs) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    FloatListSumEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "sum(lists.floats) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    DoubleListSumEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "sum(lists.doubles) == `10`",
+                        expected: "false",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/sum/{name}", code: 200)
+operation GetFunctionSumEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-sum.smithy
+++ b/tests/codegen/waiter-tests/model/function-sum.smithy
@@ -4,7 +4,7 @@ namespace com.test
 use smithy.waiters#waitable
 
 @waitable(
-    ShortListSumEquals: {
+    ShortListSumNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -18,7 +18,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    IntegerListSumEquals: {
+    IntegerListSumNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -32,7 +32,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    LongListSumEquals: {
+    LongListSumNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -46,7 +46,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    FloatListSumEquals: {
+    FloatListSumNotEquals: {
         acceptors: [
             {
                 state: "success",
@@ -60,7 +60,7 @@ use smithy.waiters#waitable
             }
         ]
     },
-    DoubleListSumEquals: {
+    DoubleListSumNotEquals: {
         acceptors: [
             {
                 state: "success",

--- a/tests/codegen/waiter-tests/model/structures.smithy
+++ b/tests/codegen/waiter-tests/model/structures.smithy
@@ -1,0 +1,165 @@
+$version: "2"
+namespace com.test
+
+use aws.protocols#restJson1
+use smithy.waiters#waitable
+
+@error("client")
+structure NotFound { }
+
+structure GetEntityRequest {
+    @required
+    @httpLabel
+    name: String
+}
+
+structure GetEntityResponse {
+    primitives: EntityPrimitives,
+    lists: EntityLists,
+    twoDimensionalLists: TwoDimensionalEntityLists,
+    maps: EntityMaps,
+}
+
+structure EntityPrimitives {
+    boolean: Boolean,
+    string: String,
+    byte: Byte,
+    short: Short,
+    integer: Integer,
+    long: Long,
+    float: Float,
+    double: Double,
+    enum: Enum,
+    intEnum: IntEnum,
+
+    // TODO: No defined comparison
+    // blob: Blob,
+    // bigInteger: BigInteger,
+    // bigDecimal: BigDecimal,
+    // timestamp: Timestamp,
+}
+
+structure EntityLists {
+    booleans: BooleanList,
+    strings: StringList,
+    shorts: ShortList
+    integers: IntegerList,
+    longs: LongList
+    floats: FloatList,
+    doubles: DoubleList,
+    enums: EnumList,
+    intEnums: IntEnumList,
+    structs: StructList,
+}
+
+structure TwoDimensionalEntityLists {
+    booleansList: TwoDimensionalBooleanList,
+}
+
+structure EntityMaps {
+    booleans: BooleanMap,
+    strings: StringMap,
+    integers: IntegerMap,
+    enums: EnumMap,
+    intEnums: IntEnumMap,
+    structs: StructMap,
+}
+
+enum Enum {
+    ONE = "one",
+    TWO = "two",
+}
+
+intEnum IntEnum {
+    ONE = 1,
+    TWO = 2,
+}
+
+list BooleanList {
+    member: Boolean,
+}
+
+list TwoDimensionalBooleanList {
+    member: BooleanList,
+}
+
+list StringList {
+    member: String,
+}
+
+list ShortList {
+    member: Short,
+}
+
+list IntegerList {
+    member: Integer,
+}
+
+list LongList {
+    member: Long,
+}
+
+list FloatList {
+    member: Float,
+}
+
+list DoubleList {
+    member: Double,
+}
+
+list EnumList {
+    member: Enum,
+}
+
+list IntEnumList {
+    member: IntEnum,
+}
+
+list StructList {
+    member: Struct,
+}
+
+map BooleanMap {
+    key: String,
+    value: Boolean,
+}
+
+map StringMap {
+    key: String,
+    value: String,
+}
+
+map IntegerMap {
+    key: String,
+    value: Integer,
+}
+
+map EnumMap {
+    key: String,
+    value: Enum,
+}
+
+map IntEnumMap {
+    key: String,
+    value: IntEnum,
+}
+
+map StructMap {
+    key: String,
+    value: Struct,
+}
+
+structure Struct {
+    primitives: EntityPrimitives,
+    strings: StringList,
+    enums: EnumList,
+    subStructs: SubStructList,
+}
+
+list SubStructList {
+    member: SubStruct,
+}
+
+structure SubStruct {
+    subStructPrimitives: EntityPrimitives,
+}

--- a/tests/codegen/waiter-tests/model/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/waiter-operations.smithy
@@ -1,9 +1,6 @@
 $version: "2"
 namespace com.test
 
-use aws.protocols#restJson1
-use smithy.waiters#waitable
-
 service WaitersTestService {
     operations: [
         GetPrimitive,
@@ -18,145 +15,10 @@ service WaitersTestService {
         GetFunctionFloor,
         GetFunctionCeil,
         GetSubFieldProjection,
+        GetFunctionSumEquals,
+        GetFunctionAvgEquals,
+        GetFunctionJoinEquals,
+        GetFunctionStartsWithEquals,
+        GetFunctionEndsWithEquals,
     ]
-}
-
-@error("client")
-structure NotFound { }
-
-structure GetEntityRequest {
-    @required
-    @httpLabel
-    name: String
-}
-
-structure GetEntityResponse {
-    primitives: EntityPrimitives,
-    lists: EntityLists,
-    twoDimensionalLists: TwoDimensionalEntityLists,
-    maps: EntityMaps,
-}
-
-structure EntityPrimitives {
-    boolean: Boolean,
-    string: String,
-    byte: Byte,
-    short: Short,
-    integer: Integer,
-    long: Long,
-    float: Float,
-    double: Double,
-    enum: Enum,
-    intEnum: IntEnum,
-
-    // TODO: No defined comparison
-    // blob: Blob,
-    // bigInteger: BigInteger,
-    // bigDecimal: BigDecimal,
-    // timestamp: Timestamp,
-}
-
-structure EntityLists {
-    booleans: BooleanList,
-    strings: StringList,
-    integers: IntegerList,
-    enums: EnumList,
-    intEnums: IntEnumList,
-    structs: StructList,
-}
-
-structure TwoDimensionalEntityLists {
-    booleansList: TwoDimensionalBooleanList,
-}
-
-structure EntityMaps {
-    booleans: BooleanMap,
-    strings: StringMap,
-    integers: IntegerMap,
-    enums: EnumMap,
-    intEnums: IntEnumMap,
-    structs: StructMap,
-}
-
-enum Enum {
-    ONE = "one",
-    TWO = "two",
-}
-
-intEnum IntEnum {
-    ONE = 1,
-    TWO = 2,
-}
-
-list BooleanList {
-    member: Boolean,
-}
-
-list TwoDimensionalBooleanList {
-    member: BooleanList,
-}
-
-list StringList {
-    member: String,
-}
-
-list IntegerList {
-    member: Integer,
-}
-
-list EnumList {
-    member: Enum,
-}
-
-list IntEnumList {
-    member: IntEnum,
-}
-
-list StructList {
-    member: Struct,
-}
-
-map BooleanMap {
-    key: String,
-    value: Boolean,
-}
-
-map StringMap {
-    key: String,
-    value: String,
-}
-
-map IntegerMap {
-    key: String,
-    value: Integer,
-}
-
-map EnumMap {
-    key: String,
-    value: Enum,
-}
-
-map IntEnumMap {
-    key: String,
-    value: IntEnum,
-}
-
-map StructMap {
-    key: String,
-    value: Struct,
-}
-
-structure Struct {
-    primitives: EntityPrimitives,
-    strings: StringList,
-    enums: EnumList,
-    subStructs: SubStructList,
-}
-
-list SubStructList {
-    member: SubStruct,
-}
-
-structure SubStruct {
-    subStructPrimitives: EntityPrimitives,
 }

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
@@ -89,4 +89,34 @@ class DefaultWaitersTestClient<T>(resultList: List<Result<T>>) : WaitersTestClie
         @Suppress("UNCHECKED_CAST")
         return if (nextResult.isSuccess) (nextResult as Result<GetSubFieldProjectionResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
     }
+
+    override suspend fun getFunctionSumEquals(input: GetFunctionSumEqualsRequest): GetFunctionSumEqualsResponse {
+        val nextResult = results.next()
+        @Suppress("UNCHECKED_CAST")
+        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionSumEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+    }
+
+    override suspend fun getFunctionAvgEquals(input: GetFunctionAvgEqualsRequest): GetFunctionAvgEqualsResponse {
+        val nextResult = results.next()
+        @Suppress("UNCHECKED_CAST")
+        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionAvgEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+    }
+
+    override suspend fun getFunctionJoinEquals(input: GetFunctionJoinEqualsRequest): GetFunctionJoinEqualsResponse {
+        val nextResult = results.next()
+        @Suppress("UNCHECKED_CAST")
+        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionJoinEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+    }
+
+    override suspend fun getFunctionStartsWithEquals(input: GetFunctionStartsWithEqualsRequest): GetFunctionStartsWithEqualsResponse {
+        val nextResult = results.next()
+        @Suppress("UNCHECKED_CAST")
+        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionStartsWithEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+    }
+
+    override suspend fun getFunctionEndsWithEquals(input: GetFunctionEndsWithEqualsRequest): GetFunctionEndsWithEqualsResponse {
+        val nextResult = results.next()
+        @Suppress("UNCHECKED_CAST")
+        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionEndsWithEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+    }
 }

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
@@ -18,105 +18,43 @@ class DefaultWaitersTestClient<T>(resultList: List<Result<T>>) : WaitersTestClie
 
     private val results = resultList.iterator()
 
-    override suspend fun getPrimitive(input: GetPrimitiveRequest): GetPrimitiveResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetPrimitiveResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getPrimitive(input: GetPrimitiveRequest): GetPrimitiveResponse = findSuccess()
 
-    override suspend fun getBooleanLogic(input: GetBooleanLogicRequest): GetBooleanLogicResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetBooleanLogicResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getBooleanLogic(input: GetBooleanLogicRequest): GetBooleanLogicResponse = findSuccess()
 
-    override suspend fun getListOperation(input: GetListOperationRequest): GetListOperationResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetListOperationResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getListOperation(input: GetListOperationRequest): GetListOperationResponse = findSuccess()
 
-    override suspend fun getStringEquals(input: GetStringEqualsRequest): GetStringEqualsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetStringEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getStringEquals(input: GetStringEqualsRequest): GetStringEqualsResponse = findSuccess()
 
-    override suspend fun getMultiSelectList(input: GetMultiSelectListRequest): GetMultiSelectListResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetMultiSelectListResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getMultiSelectList(input: GetMultiSelectListRequest): GetMultiSelectListResponse = findSuccess()
 
-    override suspend fun getMultiSelectHash(input: GetMultiSelectHashRequest): GetMultiSelectHashResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetMultiSelectHashResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getMultiSelectHash(input: GetMultiSelectHashRequest): GetMultiSelectHashResponse = findSuccess()
 
-    override suspend fun getFunctionContains(input: GetFunctionContainsRequest): GetFunctionContainsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionContainsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionContains(input: GetFunctionContainsRequest): GetFunctionContainsResponse = findSuccess()
 
-    override suspend fun getFunctionLength(input: GetFunctionLengthRequest): GetFunctionLengthResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionLengthResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionLength(input: GetFunctionLengthRequest): GetFunctionLengthResponse = findSuccess()
 
-    override suspend fun getFunctionAbs(input: GetFunctionAbsRequest): GetFunctionAbsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionAbsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionAbs(input: GetFunctionAbsRequest): GetFunctionAbsResponse = findSuccess()
 
-    override suspend fun getFunctionFloor(input: GetFunctionFloorRequest): GetFunctionFloorResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionFloorResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionFloor(input: GetFunctionFloorRequest): GetFunctionFloorResponse = findSuccess()
 
-    override suspend fun getFunctionCeil(input: GetFunctionCeilRequest): GetFunctionCeilResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionCeilResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionCeil(input: GetFunctionCeilRequest): GetFunctionCeilResponse = findSuccess()
 
-    override suspend fun getSubFieldProjection(input: GetSubFieldProjectionRequest): GetSubFieldProjectionResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetSubFieldProjectionResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getSubFieldProjection(input: GetSubFieldProjectionRequest): GetSubFieldProjectionResponse = findSuccess()
 
-    override suspend fun getFunctionSumEquals(input: GetFunctionSumEqualsRequest): GetFunctionSumEqualsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionSumEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionSumEquals(input: GetFunctionSumEqualsRequest): GetFunctionSumEqualsResponse = findSuccess()
 
-    override suspend fun getFunctionAvgEquals(input: GetFunctionAvgEqualsRequest): GetFunctionAvgEqualsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionAvgEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionAvgEquals(input: GetFunctionAvgEqualsRequest): GetFunctionAvgEqualsResponse = findSuccess()
 
-    override suspend fun getFunctionJoinEquals(input: GetFunctionJoinEqualsRequest): GetFunctionJoinEqualsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionJoinEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionJoinEquals(input: GetFunctionJoinEqualsRequest): GetFunctionJoinEqualsResponse = findSuccess()
 
-    override suspend fun getFunctionStartsWithEquals(input: GetFunctionStartsWithEqualsRequest): GetFunctionStartsWithEqualsResponse {
-        val nextResult = results.next()
-        @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionStartsWithEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
-    }
+    override suspend fun getFunctionStartsWithEquals(input: GetFunctionStartsWithEqualsRequest): GetFunctionStartsWithEqualsResponse = findSuccess()
 
-    override suspend fun getFunctionEndsWithEquals(input: GetFunctionEndsWithEqualsRequest): GetFunctionEndsWithEqualsResponse {
+    override suspend fun getFunctionEndsWithEquals(input: GetFunctionEndsWithEqualsRequest): GetFunctionEndsWithEqualsResponse = findSuccess()
+
+    private fun <Response> findSuccess(): Response {
         val nextResult = results.next()
         @Suppress("UNCHECKED_CAST")
-        return if (nextResult.isSuccess) (nextResult as Result<GetFunctionEndsWithEqualsResponse>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
+        return if (nextResult.isSuccess) (nextResult as Result<Response>).getOrNull()!! else throw nextResult.exceptionOrNull()!!
     }
 }

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionAvgTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionAvgTest.kt
@@ -28,40 +28,46 @@ class FunctionAvgTest {
     }
 
     @Test
-    fun testShortListAvgEquals() = successTest(
-        WaitersTestClient::waitUntilShortListAvgEquals,
+    fun testEmptyIntegerListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilEmptyIntegerListAvgNotEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf() } },
+    )
+
+    @Test
+    fun testShortListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilShortListAvgNotEquals,
         GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(12, 12, 10, 8, 8) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(10, 10) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(0) } },
     )
 
     @Test
-    fun testIntegerListAvgEquals() = successTest(
-        WaitersTestClient::waitUntilIntegerListAvgEquals,
+    fun testIntegerListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilIntegerListAvgNotEquals,
         GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(12, 12, 10, 8, 8) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(10, 10) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(0) } },
     )
 
     @Test
-    fun testLongListAvgEquals() = successTest(
-        WaitersTestClient::waitUntilLongListAvgEquals,
+    fun testLongListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilLongListAvgNotEquals,
         GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(12L, 12L, 10L, 8L, 8L) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(10L, 10L) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(0L) } },
     )
 
     @Test
-    fun testFloatListAvgEquals() = successTest(
-        WaitersTestClient::waitUntilFloatListAvgEquals,
+    fun testFloatListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilFloatListAvgNotEquals,
         GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(12f, 12f, 10f, 8f, 8f) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(10f, 10f) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(0f) } },
     )
 
     @Test
-    fun testDoubleListAvgEquals() = successTest(
-        WaitersTestClient::waitUntilDoubleListAvgEquals,
+    fun testDoubleListAvgNotEquals() = successTest(
+        WaitersTestClient::waitUntilDoubleListAvgNotEquals,
         GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(12.0, 12.0, 10.0, 8.0, 8.0) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(10.0, 10.0) } },
         GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(0.0) } },

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionAvgTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionAvgTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.test
+
+import aws.smithy.kotlin.runtime.retries.Outcome
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import com.test.model.EntityLists
+import com.test.model.GetFunctionAvgEqualsRequest
+import com.test.model.GetFunctionAvgEqualsResponse
+import com.test.waiters.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FunctionAvgTest {
+    private fun successTest(
+        block: suspend WaitersTestClient.(request: GetFunctionAvgEqualsRequest) -> Outcome<GetFunctionAvgEqualsResponse>,
+        vararg results: GetFunctionAvgEqualsResponse,
+    ): Unit = runTest {
+        val client = DefaultWaitersTestClient(results.map { Result.success(it) })
+        val req = GetFunctionAvgEqualsRequest { name = "test" }
+
+        val outcome = client.block(req)
+        assertEquals(results.size, outcome.attempts)
+        assertEquals(results.last(), outcome.getOrThrow())
+    }
+
+    @Test
+    fun testShortListAvgEquals() = successTest(
+        WaitersTestClient::waitUntilShortListAvgEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(12, 12, 10, 8, 8) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(10, 10) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { shorts = listOf(0) } },
+    )
+
+    @Test
+    fun testIntegerListAvgEquals() = successTest(
+        WaitersTestClient::waitUntilIntegerListAvgEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(12, 12, 10, 8, 8) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(10, 10) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { integers = listOf(0) } },
+    )
+
+    @Test
+    fun testLongListAvgEquals() = successTest(
+        WaitersTestClient::waitUntilLongListAvgEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(12L, 12L, 10L, 8L, 8L) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(10L, 10L) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { longs = listOf(0L) } },
+    )
+
+    @Test
+    fun testFloatListAvgEquals() = successTest(
+        WaitersTestClient::waitUntilFloatListAvgEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(12f, 12f, 10f, 8f, 8f) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(10f, 10f) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { floats = listOf(0f) } },
+    )
+
+    @Test
+    fun testDoubleListAvgEquals() = successTest(
+        WaitersTestClient::waitUntilDoubleListAvgEquals,
+        GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(12.0, 12.0, 10.0, 8.0, 8.0) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(10.0, 10.0) } },
+        GetFunctionAvgEqualsResponse { lists = EntityLists { doubles = listOf(0.0) } },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionEndsWithTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionEndsWithTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.test
+
+import aws.smithy.kotlin.runtime.retries.Outcome
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import com.test.model.EntityPrimitives
+import com.test.model.GetFunctionEndsWithEqualsRequest
+import com.test.model.GetFunctionEndsWithEqualsResponse
+import com.test.waiters.waitUntilStringEndsWithEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FunctionEndsWithTest {
+    private fun successTest(
+        block: suspend WaitersTestClient.(request: GetFunctionEndsWithEqualsRequest) -> Outcome<GetFunctionEndsWithEqualsResponse>,
+        vararg results: GetFunctionEndsWithEqualsResponse,
+    ): Unit = runTest {
+        val client = DefaultWaitersTestClient(results.map { Result.success(it) })
+        val req = GetFunctionEndsWithEqualsRequest { name = "test" }
+
+        val outcome = client.block(req)
+        assertEquals(results.size, outcome.attempts)
+        assertEquals(results.last(), outcome.getOrThrow())
+    }
+
+    @Test
+    fun testStringEndsWithEquals() = successTest(
+        WaitersTestClient::waitUntilStringEndsWithEquals,
+        GetFunctionEndsWithEqualsResponse { primitives = EntityPrimitives { string = "foo" } },
+        GetFunctionEndsWithEqualsResponse { primitives = EntityPrimitives { string = "foobar" } },
+        GetFunctionEndsWithEqualsResponse { primitives = EntityPrimitives { string = "foobarbaz" } },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionJoinTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionJoinTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.test
+
+import aws.smithy.kotlin.runtime.retries.Outcome
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import com.test.model.EntityLists
+import com.test.model.GetFunctionJoinEqualsRequest
+import com.test.model.GetFunctionJoinEqualsResponse
+import com.test.waiters.waitUntilStringListJoinEquals
+import com.test.waiters.waitUntilStringListSeparatorJoinEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FunctionJoinTest {
+    private fun successTest(
+        block: suspend WaitersTestClient.(request: GetFunctionJoinEqualsRequest) -> Outcome<GetFunctionJoinEqualsResponse>,
+        vararg results: GetFunctionJoinEqualsResponse,
+    ): Unit = runTest {
+        val client = DefaultWaitersTestClient(results.map { Result.success(it) })
+        val req = GetFunctionJoinEqualsRequest { name = "test" }
+
+        val outcome = client.block(req)
+        assertEquals(results.size, outcome.attempts)
+        assertEquals(results.last(), outcome.getOrThrow())
+    }
+
+    @Test
+    fun testStringListJoinEquals() = successTest(
+        WaitersTestClient::waitUntilStringListJoinEquals,
+        GetFunctionJoinEqualsResponse { lists = EntityLists { strings = listOf("f", "o", "x") } },
+        GetFunctionJoinEqualsResponse { lists = EntityLists { strings = listOf("f", "o", "o") } },
+    )
+
+    @Test
+    fun testStringListSeparatorJoinEquals() = successTest(
+        WaitersTestClient::waitUntilStringListSeparatorJoinEquals,
+        GetFunctionJoinEqualsResponse { lists = EntityLists { strings = listOf("bar", "baz") } },
+        GetFunctionJoinEqualsResponse { lists = EntityLists { strings = listOf("foo", "bar") } },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionStartsWithTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionStartsWithTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.test
+
+import aws.smithy.kotlin.runtime.retries.Outcome
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import com.test.model.EntityPrimitives
+import com.test.model.GetFunctionStartsWithEqualsRequest
+import com.test.model.GetFunctionStartsWithEqualsResponse
+import com.test.waiters.waitUntilStringStartsWithEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FunctionStartsWithTest {
+    private fun successTest(
+        block: suspend WaitersTestClient.(request: GetFunctionStartsWithEqualsRequest) -> Outcome<GetFunctionStartsWithEqualsResponse>,
+        vararg results: GetFunctionStartsWithEqualsResponse,
+    ): Unit = runTest {
+        val client = DefaultWaitersTestClient(results.map { Result.success(it) })
+        val req = GetFunctionStartsWithEqualsRequest { name = "test" }
+
+        val outcome = client.block(req)
+        assertEquals(results.size, outcome.attempts)
+        assertEquals(results.last(), outcome.getOrThrow())
+    }
+
+    @Test
+    fun testStringStartsWithEquals() = successTest(
+        WaitersTestClient::waitUntilStringStartsWithEquals,
+        GetFunctionStartsWithEqualsResponse { primitives = EntityPrimitives { string = "baz" } },
+        GetFunctionStartsWithEqualsResponse { primitives = EntityPrimitives { string = "barbaz" } },
+        GetFunctionStartsWithEqualsResponse { primitives = EntityPrimitives { string = "foobarbaz" } },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionSumTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionSumTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.test
+
+import aws.smithy.kotlin.runtime.retries.Outcome
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import com.test.model.EntityLists
+import com.test.model.GetFunctionSumEqualsRequest
+import com.test.model.GetFunctionSumEqualsResponse
+import com.test.waiters.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FunctionSumTest {
+    private fun successTest(
+        block: suspend WaitersTestClient.(request: GetFunctionSumEqualsRequest) -> Outcome<GetFunctionSumEqualsResponse>,
+        vararg results: GetFunctionSumEqualsResponse,
+    ): Unit = runTest {
+        val client = DefaultWaitersTestClient(results.map { Result.success(it) })
+        val req = GetFunctionSumEqualsRequest { name = "test" }
+
+        val outcome = client.block(req)
+        assertEquals(results.size, outcome.attempts)
+        assertEquals(results.last(), outcome.getOrThrow())
+    }
+
+    @Test
+    fun testShortListSumEquals() = successTest(
+        WaitersTestClient::waitUntilShortListSumEquals,
+        GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(1, 2, 3, 4) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(10) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(0) } },
+    )
+
+    @Test
+    fun testIntegerListSumEquals() = successTest(
+        WaitersTestClient::waitUntilIntegerListSumEquals,
+        GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(1, 2, 3, 4) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(10) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(0) } },
+    )
+
+    @Test
+    fun testLongListSumEquals() = successTest(
+        WaitersTestClient::waitUntilLongListSumEquals,
+        GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(1L, 2L, 3L, 4L) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(10L) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(0L) } },
+    )
+
+    @Test
+    fun testFloatListSumEquals() = successTest(
+        WaitersTestClient::waitUntilFloatListSumEquals,
+        GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(1f, 2f, 3f, 4f) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(10f) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(0f) } },
+    )
+
+    @Test
+    fun testDoubleListSumEquals() = successTest(
+        WaitersTestClient::waitUntilDoubleListSumEquals,
+        GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(1.0, 2.0, 3.0, 4.0) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(10.0) } },
+        GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(0.0) } },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionSumTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionSumTest.kt
@@ -28,40 +28,40 @@ class FunctionSumTest {
     }
 
     @Test
-    fun testShortListSumEquals() = successTest(
-        WaitersTestClient::waitUntilShortListSumEquals,
+    fun testShortListSumNotEquals() = successTest(
+        WaitersTestClient::waitUntilShortListSumNotEquals,
         GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(1, 2, 3, 4) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(10) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { shorts = listOf(0) } },
     )
 
     @Test
-    fun testIntegerListSumEquals() = successTest(
-        WaitersTestClient::waitUntilIntegerListSumEquals,
+    fun testIntegerListSumNotEquals() = successTest(
+        WaitersTestClient::waitUntilIntegerListSumNotEquals,
         GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(1, 2, 3, 4) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(10) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { integers = listOf(0) } },
     )
 
     @Test
-    fun testLongListSumEquals() = successTest(
-        WaitersTestClient::waitUntilLongListSumEquals,
+    fun testLongListSumNotEquals() = successTest(
+        WaitersTestClient::waitUntilLongListSumNotEquals,
         GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(1L, 2L, 3L, 4L) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(10L) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { longs = listOf(0L) } },
     )
 
     @Test
-    fun testFloatListSumEquals() = successTest(
-        WaitersTestClient::waitUntilFloatListSumEquals,
+    fun testFloatListSumNotEquals() = successTest(
+        WaitersTestClient::waitUntilFloatListSumNotEquals,
         GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(1f, 2f, 3f, 4f) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(10f) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { floats = listOf(0f) } },
     )
 
     @Test
-    fun testDoubleListSumEquals() = successTest(
-        WaitersTestClient::waitUntilDoubleListSumEquals,
+    fun testDoubleListSumNotEquals() = successTest(
+        WaitersTestClient::waitUntilDoubleListSumNotEquals,
         GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(1.0, 2.0, 3.0, 4.0) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(10.0) } },
         GetFunctionSumEqualsResponse { lists = EntityLists { doubles = listOf(0.0) } },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Added:
-Sum
-Avg
-Join
-Starts with
-Ends with

Refactored:
-Separated operations from structures in smithy file
-Wrote function to avoid code duplication in JMESPath visitor functions code


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
