### PR TITLE
fix: event streams deserialization using `HttpCall` scope

### DIFF
--- a/.changes/9b8a79bf-8d89-481f-b671-4aba9c3b5250.json
+++ b/.changes/9b8a79bf-8d89-481f-b671-4aba9c3b5250.json
@@ -1,0 +1,8 @@
+{
+    "id": "9b8a79bf-8d89-481f-b671-4aba9c3b5250",
+    "type": "bugfix",
+    "description": "Fix closing an event stream causing an IllegalStateException",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/935"
+    ]
+}

--- a/.changes/9b8a79bf-8d89-481f-b671-4aba9c3b5250.json
+++ b/.changes/9b8a79bf-8d89-481f-b671-4aba9c3b5250.json
@@ -1,8 +1,0 @@
-{
-    "id": "9b8a79bf-8d89-481f-b671-4aba9c3b5250",
-    "type": "bugfix",
-    "description": "Fix closing an event stream causing an IllegalStateException",
-    "issues": [
-        "https://github.com/awslabs/smithy-kotlin/issues/935"
-    ]
-}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -669,7 +669,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         writer: KotlinWriter,
     ) {
         val eventStreamDeserializerFn = eventStreamResponseHandler(ctx, op)
-        writer.write("#T(builder, response.body)", eventStreamDeserializerFn)
+        writer.write("#T(builder, call)", eventStreamDeserializerFn)
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR finalizes fixing a bug (#935) by passing the entire `HttpCall` to the deserializer. The accompanying PR in **aws-sdk-kotlin** uses the call to launch a new coroutine within its scope.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
#935 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
