### PR TITLE
fix: explicitly join coroutines in failing  http client engine test

### DIFF
--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/engine/HttpClientEngineTest.kt
@@ -129,13 +129,13 @@ class HttpClientEngineTest {
     @Test
     fun testShutdownOnlyAfterInFlightDone() = runTest {
         val waiter = Channel<Unit>(1)
-        launch {
+        val job1 = launch {
             val call = client.call(SdkHttpRequest(HttpRequestBuilder()))
             waiter.receive()
             call.complete()
         }
         yield()
-        launch {
+        val job2 = launch {
             val call = client.call(SdkHttpRequest(HttpRequestBuilder()))
             waiter.receive()
             call.complete()
@@ -155,6 +155,7 @@ class HttpClientEngineTest {
         waiter.send(Unit)
         yield()
 
+        joinAll(job1, job2)
         assertFalse(engine.coroutineContext.job.isActive)
         assertTrue(engine.shutdownCalled)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Explicitly joining coroutines in test due to failing windows CI test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
