### PR TITLE
misc: make TestConnection request assertions more configurable

### DIFF
--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/CallAsserter.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/CallAsserter.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.httptest
 
 import aws.smithy.kotlin.runtime.http.readAll
@@ -72,7 +76,7 @@ public interface CallAsserter {
                 }
             }
         }
-        
+
         public companion object {
             /**
              * Asserter that verifies every header of the requests match

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/CallAsserter.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/CallAsserter.kt
@@ -1,0 +1,94 @@
+package aws.smithy.kotlin.runtime.httptest
+
+import aws.smithy.kotlin.runtime.http.readAll
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Asserts equality between two [HttpRequest] instances. Implementations of this interface are free to choose criteria
+ * for the equality assertion.
+ */
+public interface CallAsserter {
+    /**
+     * Verify that [expected] and [actual] are equal according to this asserter's criteria. If not, an [AssertionError]
+     * is thrown.
+     * @param msgPrefix The prefix to include in the message if an [AssertionError] is thrown
+     * @param expected The expected request
+     * @param actual The actual request
+     */
+    public suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest)
+
+    public companion object {
+        /**
+         * Asserter that verifies every part of the requests match
+         */
+        public val FullyMatching: CallAsserter = List(
+            MatchingMethods,
+            MatchingUrls,
+            MatchingHeaders.All,
+            MatchingBodies,
+        )
+    }
+
+    /**
+     * Asserter that delegates to a collection of sub-asserters
+     */
+    public class List(private vararg val asserters: CallAsserter) : CallAsserter {
+        override suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest) {
+            asserters.forEach { it.assertEquals(msgPrefix, expected, actual) }
+        }
+    }
+
+    /**
+     * Asserter that verifies the methods of the requests match
+     */
+    public object MatchingMethods : CallAsserter {
+        override suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest) {
+            assertEquals(expected.method, actual.method, "$msgPrefix: Method mismatch")
+        }
+    }
+
+    /**
+     * Asserter that verifies the URLs of the requests match
+     */
+    public object MatchingUrls : CallAsserter {
+        override suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest) {
+            assertEquals(expected.url.toString(), actual.url.toString(), "$msgPrefix: URL mismatch")
+        }
+    }
+
+    /**
+     * Asserter that verifies headers of the requests match
+     * @param shouldVerifyHeader A predicate which indicates whether a header with the given key should be verified
+     */
+    public class MatchingHeaders(private val shouldVerifyHeader: (String) -> Boolean) : CallAsserter {
+        override suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest) {
+            expected.headers.forEach { name, values ->
+                if (shouldVerifyHeader(name)) {
+                    values.forEach {
+                        assertTrue(actual.headers.contains(name, it), "$msgPrefix: header `$name` missing value `$it`")
+                    }
+                }
+            }
+        }
+        
+        public companion object {
+            /**
+             * Asserter that verifies every header of the requests match
+             */
+            public val All: MatchingHeaders = MatchingHeaders { true }
+        }
+    }
+
+    /**
+     * Asserter that verifies the bodies of the requests match
+     */
+    public object MatchingBodies : CallAsserter {
+        override suspend fun assertEquals(msgPrefix: String, expected: HttpRequest, actual: HttpRequest) {
+            val expectedBody = expected.body.readAll()?.decodeToString()
+            val actualBody = actual.body.readAll()?.decodeToString()
+            assertEquals(expectedBody, actualBody, "$msgPrefix: body mismatch")
+        }
+    }
+}

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
@@ -12,14 +12,12 @@ import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
 import aws.smithy.kotlin.runtime.http.engine.callContext
-import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * An expected HttpRequest with the response that should be returned by the engine

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/TestConnection.kt
@@ -31,23 +31,13 @@ public data class MockRoundTrip(public val expected: HttpRequest?, public val re
 /**
  * Actual and expected [HttpRequest] pair
  */
-public data class CallAssertion(public val expected: HttpRequest?, public val actual: HttpRequest) {
+public data class RequestComparands(public val expected: HttpRequest?, public val actual: HttpRequest) {
     /**
-     * Assert that all of the components set on [expected] are also the same on [actual]. The actual request
-     * may have additional headers, only the ones set in [expected] are compared.
+     * Assert that [expected] matches [actual] according to [asserter].
+     * @param msgPrefix The prefix to include in the message if an [AssertionError] is thrown
      */
-    internal suspend fun assertRequest(idx: Int) {
-        if (expected == null) return
-        assertEquals(expected.url.toString(), actual.url.toString(), "[request#$idx]: URL mismatch")
-        expected.headers.forEach { name, values ->
-            values.forEach {
-                assertTrue(actual.headers.contains(name, it), "[request#$idx]: header `$name` missing value `$it`")
-            }
-        }
-
-        val expectedBody = expected.body.readAll()?.decodeToString()
-        val actualBody = actual.body.readAll()?.decodeToString()
-        assertEquals(expectedBody, actualBody, "[request#$idx]: body mismatch")
+    internal suspend fun assertRequest(msgPrefix: String, asserter: CallAsserter) {
+        expected?.let { asserter.assertEquals(msgPrefix, it, actual) }
     }
 }
 
@@ -67,7 +57,7 @@ public class TestConnection(private val expected: List<MockRoundTrip> = emptyLis
 
     // expected is mutated in-flight, store original size
     private val iter = expected.iterator()
-    private var calls = mutableListOf<CallAssertion>()
+    private var requests = mutableListOf<RequestComparands>()
 
     override val config: HttpClientEngineConfig = HttpClientEngineConfig.Default
 
@@ -121,7 +111,7 @@ public class TestConnection(private val expected: List<MockRoundTrip> = emptyLis
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
         check(iter.hasNext()) { "TestConnection has no remaining expected requests" }
         val next = iter.next()
-        calls.add(CallAssertion(next.expected, request))
+        requests.add(RequestComparands(next.expected, request))
 
         val response = next.respondWith ?: HttpResponse(HttpStatusCode.OK, Headers.Empty, HttpBody.Empty)
         val now = Instant.now()
@@ -131,15 +121,15 @@ public class TestConnection(private val expected: List<MockRoundTrip> = emptyLis
     /**
      * Get the list of captured HTTP requests so far
      */
-    public fun requests(): List<CallAssertion> = calls
+    public fun requests(): List<RequestComparands> = requests
 
     /**
      * Assert that each captured request matches the expected
      */
-    public suspend fun assertRequests() {
-        assertEquals(expected.size, calls.size)
-        calls.forEachIndexed { idx, captured ->
-            captured.assertRequest(idx)
+    public suspend fun assertRequests(asserter: CallAsserter = CallAsserter.FullyMatching) {
+        assertEquals(expected.size, requests.size)
+        requests.forEachIndexed { idx, captured ->
+            captured.assertRequest("[request#$idx]", asserter)
         }
     }
 }

--- a/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
+++ b/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
@@ -5,11 +5,8 @@
 
 package aws.smithy.kotlin.runtime.httptest
 
-import aws.smithy.kotlin.runtime.http.HttpStatusCode
-import aws.smithy.kotlin.runtime.http.SdkHttpClient
-import aws.smithy.kotlin.runtime.http.complete
+import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
-import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.net.Host
 import io.kotest.matchers.string.shouldContain
@@ -204,6 +201,7 @@ class TestConnectionTest {
         val client = SdkHttpClient(engine)
 
         val req = HttpRequestBuilder().apply {
+            method = HttpMethod.POST
             url.host = Host.Domain("test.aws.com")
             url.path = "/turtles-all-the-way-down"
             url.parameters.append("q1", "v1")


### PR DESCRIPTION
## Issue \#

Related to https://github.com/awslabs/aws-sdk-kotlin/issues/1000

## Description of changes

This change makes `TestConnection` more configurable in how it verifies `HttpRequest` instances. Specifically, it introduces a `CallAsserter` type, various implementations of which can be chosen when ready to verify an engine's inputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
