### PR TITLE
fix: correctly codegen defaults for enum shapes

### DIFF
--- a/.changes/855b179f-a977-459f-b7d7-fc0bccd208d7.json
+++ b/.changes/855b179f-a977-459f-b7d7-fc0bccd208d7.json
@@ -1,0 +1,5 @@
+{
+    "id": "855b179f-a977-459f-b7d7-fc0bccd208d7",
+    "type": "bugfix",
+    "description": "Correctly codegen defaults for enum shapes"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/KotlinSymbolProvider.kt
@@ -212,13 +212,28 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         }
     }
 
-    private fun DefaultTrait.getDefaultValue(targetShape: Shape): String? = when {
-        toNode().toString() == "null" || targetShape is BlobShape && toNode().toString() == "" -> null
-        toNode().isNumberNode -> getDefaultValueForNumber(targetShape, toNode().toString())
-        toNode().isArrayNode -> "listOf()"
-        toNode().isObjectNode -> "mapOf()"
-        toNode().isStringNode -> toNode().toString().dq()
-        else -> toNode().toString()
+    private fun DefaultTrait.getDefaultValue(targetShape: Shape): String? {
+        val node = toNode()
+        return when {
+            node.toString() == "null" || targetShape is BlobShape && node.toString() == "" -> null
+
+            // Check if target is an enum before treating the default like a regular number/string
+            targetShape.isEnum -> {
+                val enumSymbol = toSymbol(targetShape)
+                val arg = when {
+                    targetShape.isStringShape -> node.toString().dq()
+                    targetShape.isIntEnumShape -> getDefaultValueForNumber(ShapeType.INTEGER, node.toString())
+                    else -> throw CodegenException("Unknown enum type for $targetShape")
+                }
+                "${enumSymbol.fullName}.fromValue($arg)"
+            }
+
+            node.isNumberNode -> getDefaultValueForNumber(targetShape.type, node.toString())
+            node.isArrayNode -> "listOf()"
+            node.isObjectNode -> "mapOf()"
+            node.isStringNode -> node.toString().dq()
+            else -> node.toString()
+        }
     }
 
     override fun timestampShape(shape: TimestampShape?): Symbol {
@@ -277,12 +292,12 @@ class KotlinSymbolProvider(private val model: Model, private val settings: Kotli
         return builder
     }
 
-    private fun getDefaultValueForNumber(shape: Shape, value: String) = when (shape) {
-        is LongShape -> "${value}L"
-        is FloatShape -> "${value}f"
-        is DoubleShape -> if (value.matches("[0-9]*\\.[0-9]+".toRegex())) value else "$value.0"
-        is ShortShape -> "$value.toShort()"
-        is ByteShape -> "$value.toByte()"
+    private fun getDefaultValueForNumber(type: ShapeType, value: String) = when (type) {
+        ShapeType.LONG -> "${value}L"
+        ShapeType.FLOAT -> "${value}f"
+        ShapeType.DOUBLE -> if (value.matches("[0-9]*\\.[0-9]+".toRegex())) value else "$value.0"
+        ShapeType.SHORT -> "$value.toShort()"
+        ShapeType.BYTE -> "$value.toByte()"
         else -> value
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -246,7 +246,7 @@ class SymbolProviderTest {
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
         val member = model.expectShape<MemberShape>("com.test#MyStruct\$foo")
         val memberSymbol = provider.toSymbol(member)
-        assertEquals("\"club\"", memberSymbol.defaultValue())
+        assertEquals("""com.test.model.Suit.fromValue("club")""", memberSymbol.defaultValue())
     }
 
     @Test
@@ -268,7 +268,7 @@ class SymbolProviderTest {
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model)
         val member = model.expectShape<MemberShape>("com.test#MyStruct\$foo")
         val memberSymbol = provider.toSymbol(member)
-        assertEquals("2", memberSymbol.defaultValue())
+        assertEquals("com.test.model.Season.fromValue(2)", memberSymbol.defaultValue())
     }
 
     @ParameterizedTest(name = "{index} ==> ''can default document with {0} type''")


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Enum shapes don't have correct defaults codegenned for them. For example, in a structure's builder class:

```kotlin
public var mode: aws.sdk.kotlin.services.neptunedata.model.GraphSummaryType? = "basic" // <-- compiler error
```

This change adds handling of defaults so that they're resolved correctly from the enum's members.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
