### PR TITLE
feat(rt): add InputStream adapter for ByteStream

### DIFF
--- a/.changes/d47756d3-1127-4ed0-a71f-44ca2daebf9a.json
+++ b/.changes/d47756d3-1127-4ed0-a71f-44ca2daebf9a.json
@@ -1,0 +1,8 @@
+{
+    "id": "d47756d3-1127-4ed0-a71f-44ca2daebf9a",
+    "type": "feature",
+    "description": "Add conversion to InputStream from ByteStream",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#617"
+    ]
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -122,6 +122,7 @@ public final class aws/smithy/kotlin/runtime/content/ByteStreamJVMKt {
 	public static synthetic fun asByteStream$default (Ljava/io/File;JJILjava/lang/Object;)Laws/smithy/kotlin/runtime/content/ByteStream;
 	public static synthetic fun asByteStream$default (Ljava/nio/file/Path;JJILjava/lang/Object;)Laws/smithy/kotlin/runtime/content/ByteStream;
 	public static final fun fromFile (Laws/smithy/kotlin/runtime/content/ByteStream$Companion;Ljava/io/File;)Laws/smithy/kotlin/runtime/content/ByteStream;
+	public static final fun toInputStream (Laws/smithy/kotlin/runtime/content/ByteStream;)Ljava/io/InputStream;
 	public static final fun writeToFile (Laws/smithy/kotlin/runtime/content/ByteStream;Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun writeToFile (Laws/smithy/kotlin/runtime/content/ByteStream;Ljava/nio/file/Path;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -510,6 +511,10 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel 
 	public abstract fun isClosedForRead ()Z
 	public abstract fun isClosedForWrite ()Z
 	public abstract fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVMKt {
+	public static final fun toInputStream (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;)Ljava/io/InputStream;
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelKt {

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/content/ByteStreamJVM.kt
@@ -8,7 +8,9 @@ package aws.smithy.kotlin.runtime.content
 import aws.smithy.kotlin.runtime.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.InputStream
 import java.nio.file.Path
 import kotlin.io.use
 
@@ -86,3 +88,12 @@ private suspend fun File.writeAll(chan: SdkByteReadChannel): Long =
  * @return the number of bytes written
  */
 public suspend fun ByteStream.writeToFile(path: Path): Long = writeToFile(path.toFile())
+
+/**
+ * Create a blocking [InputStream] that reads from the underlying [ByteStream].
+ */
+public fun ByteStream.toInputStream(): InputStream = when (this) {
+    is ByteStream.Buffer -> ByteArrayInputStream(bytes())
+    is ByteStream.ChannelStream -> readFrom().toInputStream()
+    is ByteStream.SourceStream -> readFrom().buffer().inputStream()
+}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferedSourceJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkBufferedSourceJVM.kt
@@ -109,7 +109,7 @@ public actual sealed interface SdkBufferedSource : SdkSource, ReadableByteChanne
     public actual fun readUtf8(byteCount: Long): String
 
     /**
-     * Get an input stream that writes to this source
+     * Get an input stream that reads from this source
      */
     public fun inputStream(): InputStream
 

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.io
+
+import kotlinx.coroutines.runBlocking
+import java.io.InputStream
+import java.util.*
+
+/**
+ * Create a blocking [InputStream] that blocks everytime the channel suspends at [SdkByteReadChannel.read]
+ */
+public fun SdkByteReadChannel.toInputStream(): InputStream = InputAdapter(this)
+
+private const val DEFAULT_READ_BYTES = 8192L
+private class InputAdapter(private val ch: SdkByteReadChannel) : InputStream() {
+
+    private val buffer = SdkBuffer()
+
+    override fun read(): Int {
+        if (ch.isClosedForRead && buffer.size == 0L) return -1
+
+        if (buffer.size == 0L) {
+            val rc = readBlocking()
+            if (rc == -1L) return -1
+        }
+
+        return buffer.readByte().toInt() and 0xff
+    }
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        Objects.checkFromIndexSize(off, len, b.size)
+        if (ch.isClosedForRead && buffer.size == 0L) return -1
+        if (buffer.size == 0L) {
+            val rc = readBlocking()
+            if (rc == -1L) return -1
+        }
+
+        return buffer.read(b, off, len)
+    }
+
+    private fun readBlocking(): Long =
+        runBlocking {
+            ch.read(buffer, DEFAULT_READ_BYTES)
+        }
+
+    override fun available(): Int = ch.availableForRead
+
+    override fun close() {
+        super.close()
+        ch.cancel(null)
+    }
+}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
@@ -28,6 +28,7 @@ private class InputAdapter(private val ch: SdkByteReadChannel) : InputStream() {
 
         return buffer.readByte().toInt() and 0xff
     }
+
     override fun read(b: ByteArray, off: Int, len: Int): Int {
         if (off < 0 || len < 0 || len > b.size - off) {
             throw IndexOutOfBoundsException()

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVM.kt
@@ -29,7 +29,12 @@ private class InputAdapter(private val ch: SdkByteReadChannel) : InputStream() {
         return buffer.readByte().toInt() and 0xff
     }
     override fun read(b: ByteArray, off: Int, len: Int): Int {
-        Objects.checkFromIndexSize(off, len, b.size)
+        if (off < 0 || len < 0 || len > b.size - off) {
+            throw IndexOutOfBoundsException()
+        } else if (len == 0) {
+            return 0
+        }
+
         if (ch.isClosedForRead && buffer.size == 0L) return -1
         if (buffer.size == 0L) {
             val rc = readBlocking()

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.content
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+import java.io.InputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+fun interface ByteStreamFactory {
+    fun inputStream(input: ByteArray): InputStream
+    companion object {
+        val BYTE_ARRAY: ByteStreamFactory = ByteStreamFactory { input -> ByteStream.fromBytes(input).toInputStream() }
+
+        val SDK_SOURCE: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.SourceStream() {
+                override fun readFrom(): SdkSource = input.source()
+                override val contentLength: Long = input.size.toLong()
+            }.toInputStream()
+        }
+
+        val SDK_CHANNEL: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.ChannelStream() {
+                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(input)
+                override val contentLength: Long = input.size.toLong()
+            }.toInputStream()
+        }
+    }
+}
+
+class ByteStreamBufferInputStreamTest : ByteStreamInputStreamTest(ByteStreamFactory.BYTE_ARRAY)
+class ByteStreamSourceStreamInputStreamTest : ByteStreamInputStreamTest(ByteStreamFactory.SDK_SOURCE)
+class ByteStreamChannelSourceInputStreamTest : ByteStreamInputStreamTest(ByteStreamFactory.SDK_CHANNEL)
+
+abstract class ByteStreamInputStreamTest(
+    private val factory: ByteStreamFactory,
+) {
+    @Test
+    fun testReadOneByteAtATime() {
+        val expected = "a lep is a ball".repeat(1024).encodeToByteArray()
+        val istream = factory.inputStream(expected)
+        val bytes = mutableListOf<Byte>()
+        do {
+            val next = istream.read()
+            if (next >= 0) {
+                bytes.add(next.toByte())
+            }
+        } while (next >= 0)
+
+        val actual = bytes.toByteArray()
+        assertEquals(0, istream.available())
+        assertEquals(-1, istream.read())
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun testReadFully() {
+        val expected = "a tay is a hammer".repeat(768).encodeToByteArray()
+        val istream = factory.inputStream(expected)
+        val actual = istream.readBytes()
+        assertEquals(0, istream.available())
+        assertEquals(-1, istream.read())
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun testReadOffset() {
+        val expected = "a flix is a comb".repeat(1024).encodeToByteArray()
+        val istream = factory.inputStream(expected)
+        var offset = 0
+        val actual = ByteArray(expected.size)
+        while (true) {
+            val len = minOf(16, actual.size - offset)
+            val rc = istream.read(actual, offset, len)
+            if (rc == -1) break
+            offset += rc
+        }
+
+        assertEquals(0, istream.available())
+        assertEquals(-1, istream.read())
+        assertContentEquals(expected, actual)
+    }
+}

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
@@ -74,7 +74,7 @@ abstract class ByteStreamInputStreamTest(
         val istream = factory.inputStream(expected)
         var offset = 0
         val actual = ByteArray(expected.size)
-        while (true) {
+        while (offset < actual.size) {
             val len = minOf(16, actual.size - offset)
             val rc = istream.read(actual, offset, len)
             if (rc == -1) break

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamJVMTest.kt
@@ -6,15 +6,13 @@
 package aws.smithy.kotlin.runtime.content
 
 import aws.smithy.kotlin.runtime.testing.RandomTempFile
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import java.nio.file.Files
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ByteStreamJVMTest {
     @Test
-    fun `file as byte stream validates start`() = runTest {
+    fun testFileAsByteStreamValidatesStart() = runTest {
         val file = RandomTempFile(1024)
         val e = assertFailsWith<Throwable> {
             file.asByteStream(-1)
@@ -23,7 +21,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `file as byte stream validates end`() = runTest {
+    fun testFileAsAByteStreamValidatesEnd() = runTest {
         val file = RandomTempFile(1024)
         val e = assertFailsWith<Throwable> {
             file.asByteStream(endInclusive = 1024)
@@ -32,7 +30,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `file as byte stream validates start and end`() = runTest {
+    fun testFileAsByteStreamValidatesStartAndEnd() = runTest {
         val file = RandomTempFile(1024)
         val e = assertFailsWith<Throwable> {
             file.asByteStream(5, 1)
@@ -41,7 +39,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `file as byte stream has contentLength`() = runTest {
+    fun testFileAsByteStreamHasContentLength() = runTest {
         val file = RandomTempFile(1024)
         val stream = file.asByteStream()
 
@@ -49,7 +47,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial file as byte stream has contentLength`() = runTest {
+    fun testPartialFileAsByteStreamHasContentLength() = runTest {
         val file = RandomTempFile(1024)
         val stream = file.asByteStream(1, 1023)
 
@@ -57,7 +55,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial file as byte stream has contentLength with implicit end`() = runTest {
+    fun testPartialFileAsByteStreamHasImplicitEnd() = runTest {
         val file = RandomTempFile(1024)
         val stream = file.asByteStream(1)
 
@@ -65,7 +63,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `file as byte stream matches read`() = runTest {
+    fun testFileAsByteStreamRead() = runTest {
         val file = RandomTempFile(1024)
 
         val expected = file.readBytes()
@@ -75,7 +73,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial file as byte stream matches read`() = runTest {
+    fun testPartialFileAsByteStreamRead() = runTest {
         val file = RandomTempFile(1024)
 
         val expected = file.readBytes()
@@ -87,7 +85,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial file as byte stream using range`() = runTest {
+    fun testPartialFileRangeAsByteStreamRead() = runTest {
         val file = RandomTempFile(1024)
 
         val expected = file.readBytes()
@@ -99,7 +97,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial path as byte stream`() = runTest {
+    fun testPartialPathAsByteStreamRead() = runTest {
         val file = RandomTempFile(1024)
         val path = file.toPath()
 
@@ -112,7 +110,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `partial path as byte stream using range`() = runTest {
+    fun testPartialPathRangeAsByteStreamRead() = runTest {
         val file = RandomTempFile(1024)
         val path = file.toPath()
 
@@ -125,7 +123,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `path as byte stream has contentLength`() = runTest {
+    fun testPathAsByteStreamHasContentLength() = runTest {
         val path = RandomTempFile(1024).toPath()
         val stream = path.asByteStream()
 
@@ -133,7 +131,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `can create byte stream from empty file and path using createTempFile`() = runTest {
+    fun testCanCreateByteStreamFromEmptyFileAndPathUsingTempFile() = runTest {
         val file = Files.createTempFile(null, null)
         val byteStream = file.asByteStream()
         assertEquals(0, byteStream.contentLength)
@@ -143,7 +141,7 @@ class ByteStreamJVMTest {
     }
 
     @Test
-    fun `can create byte stream from empty file and path using RandomTempFile`() = runTest {
+    fun testCanCreateByteStreamFromEmptyFileAndPathUsingRandomFile() = runTest {
         val file = RandomTempFile(sizeInBytes = 0)
         val byteStream = file.asByteStream()
         assertEquals(0, byteStream.contentLength)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes https://github.com/awslabs/aws-sdk-kotlin/issues/617

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds a conversion to go from `ByteStream` to `java.io.InputStream`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
