### PR TITLE
feat(rt): add conversions to and from ByteStream and Flow<ByteArray>

### DIFF
--- a/.changes/f82c0433-30f9-4246-8f18-91402c5ac0ab.json
+++ b/.changes/f82c0433-30f9-4246-8f18-91402c5ac0ab.json
@@ -1,0 +1,8 @@
+{
+    "id": "f82c0433-30f9-4246-8f18-91402c5ac0ab",
+    "type": "feature",
+    "description": "Add conversion to `Flow<ByteArray>` from `ByteStream`",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#612"
+    ]
+}

--- a/.changes/f82c0433-30f9-4246-8f18-91402c5ac0ab.json
+++ b/.changes/f82c0433-30f9-4246-8f18-91402c5ac0ab.json
@@ -1,7 +1,7 @@
 {
     "id": "f82c0433-30f9-4246-8f18-91402c5ac0ab",
     "type": "feature",
-    "description": "Add conversion to `Flow<ByteArray>` from `ByteStream`",
+    "description": "Add conversions to and from `Flow<ByteArray>` and `ByteStream`",
     "issues": [
         "awslabs/aws-sdk-kotlin#612"
     ]

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -131,6 +131,8 @@ public final class aws/smithy/kotlin/runtime/content/ByteStreamKt {
 	public static final fun cancel (Laws/smithy/kotlin/runtime/content/ByteStream;)V
 	public static final fun decodeToString (Laws/smithy/kotlin/runtime/content/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toByteArray (Laws/smithy/kotlin/runtime/content/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toFlow (Laws/smithy/kotlin/runtime/content/ByteStream;J)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun toFlow$default (Laws/smithy/kotlin/runtime/content/ByteStream;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class aws/smithy/kotlin/runtime/content/Document {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -131,6 +131,8 @@ public final class aws/smithy/kotlin/runtime/content/ByteStreamKt {
 	public static final fun cancel (Laws/smithy/kotlin/runtime/content/ByteStream;)V
 	public static final fun decodeToString (Laws/smithy/kotlin/runtime/content/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toByteArray (Laws/smithy/kotlin/runtime/content/ByteStream;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toByteStream (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Ljava/lang/Long;)Laws/smithy/kotlin/runtime/content/ByteStream;
+	public static synthetic fun toByteStream$default (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Ljava/lang/Long;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/content/ByteStream;
 	public static final fun toFlow (Laws/smithy/kotlin/runtime/content/ByteStream;J)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun toFlow$default (Laws/smithy/kotlin/runtime/content/ByteStream;JILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
@@ -513,10 +515,6 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel 
 	public abstract fun isClosedForRead ()Z
 	public abstract fun isClosedForWrite ()Z
 	public abstract fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVMKt {
-	public static final fun toInputStream (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;)Ljava/io/InputStream;
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelKt {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -517,6 +517,10 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel 
 	public abstract fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelJVMKt {
+	public static final fun toInputStream (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;)Ljava/io/InputStream;
+}
+
 public final class aws/smithy/kotlin/runtime/io/SdkByteReadChannelKt {
 	public static final fun readAll (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Laws/smithy/kotlin/runtime/io/SdkSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun readFully (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
@@ -4,10 +4,12 @@
  */
 package aws.smithy.kotlin.runtime.content
 
-import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import aws.smithy.kotlin.runtime.io.SdkSource
-import aws.smithy.kotlin.runtime.io.readToBuffer
-import aws.smithy.kotlin.runtime.io.readToByteArray
+import aws.smithy.kotlin.runtime.io.*
+import aws.smithy.kotlin.runtime.io.internal.SdkDispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Represents an abstract read-only stream of bytes
@@ -104,5 +106,51 @@ public fun ByteStream.cancel() {
         is ByteStream.Buffer -> stream.bytes()
         is ByteStream.ChannelStream -> stream.readFrom().cancel(null)
         is ByteStream.SourceStream -> stream.readFrom().close()
+    }
+}
+
+/**
+ * Return a [Flow] that consumes the underlying [ByteStream] when collected.
+ *
+ * @param bufferSizeHint the size of the buffers to emit from the flow. All buffers emitted
+ * will be of this size except for the last one which may be less than the requested buffer size.
+ * This parameter has no effect for the [ByteStream.Buffer] variant. The emitted [ByteArray]
+ * will be whatever size the in-memory buffer already is in that case.
+ */
+public fun ByteStream.toFlow(bufferSizeHint: Long = 8192): Flow<ByteArray> = when (this) {
+    is ByteStream.Buffer -> flowOf(bytes())
+    is ByteStream.ChannelStream -> readFrom().toFlow(bufferSizeHint)
+    is ByteStream.SourceStream -> readFrom().toFlow(bufferSizeHint).flowOn(SdkDispatchers.IO)
+}
+
+private fun SdkByteReadChannel.toFlow(bufferSize: Long): Flow<ByteArray> = flow {
+    val chan = this@toFlow
+    val sink = SdkBuffer()
+    while (!chan.isClosedForRead) {
+        val rc = chan.read(sink, bufferSize)
+        if (rc == -1L) break
+        if (sink.size >= bufferSize) {
+            val bytes = sink.readByteArray(bufferSize)
+            emit(bytes)
+        }
+    }
+    if (sink.size > 0L) {
+        emit(sink.readByteArray())
+    }
+}
+
+private fun SdkSource.toFlow(bufferSize: Long): Flow<ByteArray> = flow {
+    val source = this@toFlow
+    val sink = SdkBuffer()
+    while (true) {
+        val rc = source.read(sink, bufferSize)
+        if (rc == -1L) break
+        if (sink.size >= bufferSize) {
+            val bytes = sink.readByteArray(bufferSize)
+            emit(bytes)
+        }
+    }
+    if (sink.size > 0L) {
+        emit(sink.readByteArray())
     }
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteStream.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.io.internal.SdkDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 
 /**
@@ -112,19 +111,19 @@ public fun ByteStream.cancel() {
 /**
  * Return a [Flow] that consumes the underlying [ByteStream] when collected.
  *
- * @param bufferSizeHint the size of the buffers to emit from the flow. All buffers emitted
+ * @param bufferSize the size of the buffers to emit from the flow. All buffers emitted
  * will be of this size except for the last one which may be less than the requested buffer size.
  * This parameter has no effect for the [ByteStream.Buffer] variant. The emitted [ByteArray]
  * will be whatever size the in-memory buffer already is in that case.
  */
-public fun ByteStream.toFlow(bufferSizeHint: Long = 8192): Flow<ByteArray> = when (this) {
+public fun ByteStream.toFlow(bufferSize: Long = 8192): Flow<ByteArray> = when (this) {
     is ByteStream.Buffer -> flowOf(bytes())
-    is ByteStream.ChannelStream -> readFrom().toFlow(bufferSizeHint)
-    is ByteStream.SourceStream -> readFrom().toFlow(bufferSizeHint).flowOn(SdkDispatchers.IO)
+    is ByteStream.ChannelStream -> readFrom().toFlow(bufferSize)
+    is ByteStream.SourceStream -> readFrom().toFlow(bufferSize).flowOn(SdkDispatchers.IO)
 }
 
 /**
- * Create a [ByteStream] from a [Flow] of individual [ByteArray]'s.
+ * Create a [ByteStream] from a [Flow] of byte arrays.
  *
  * @param scope the [CoroutineScope] to use for launching a coroutine to do the collection in.
  * @param contentLength the overall content length of the [Flow] (if known). If set this will be

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFactory.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFactory.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.content
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+
+fun interface ByteStreamFactory {
+    fun byteStream(input: ByteArray): ByteStream
+    companion object {
+        val BYTE_ARRAY: ByteStreamFactory = ByteStreamFactory { input -> ByteStream.fromBytes(input) }
+
+        val SDK_SOURCE: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.SourceStream() {
+                override fun readFrom(): SdkSource = input.source()
+                override val contentLength: Long = input.size.toLong()
+            }
+        }
+
+        val SDK_CHANNEL: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.ChannelStream() {
+                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(input)
+                override val contentLength: Long = input.size.toLong()
+            }
+        }
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.content
+
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+fun interface ByteStreamFactory {
+    fun byteStream(input: ByteArray): ByteStream
+    companion object {
+        val BYTE_ARRAY: ByteStreamFactory = ByteStreamFactory { input -> ByteStream.fromBytes(input) }
+
+        val SDK_SOURCE: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.SourceStream() {
+                override fun readFrom(): SdkSource = input.source()
+                override val contentLength: Long = input.size.toLong()
+            }
+        }
+
+        val SDK_CHANNEL: ByteStreamFactory = ByteStreamFactory { input ->
+            object : ByteStream.ChannelStream() {
+                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(input)
+                override val contentLength: Long = input.size.toLong()
+            }
+        }
+    }
+}
+
+class ByteStreamBufferFlowTest : ByteStreamFlowTest(ByteStreamFactory.BYTE_ARRAY)
+class ByteStreamSourceStreamFlowTest : ByteStreamFlowTest(ByteStreamFactory.SDK_SOURCE)
+class ByteStreamChannelSourceFlowTest : ByteStreamFlowTest(ByteStreamFactory.SDK_CHANNEL)
+
+abstract class ByteStreamFlowTest(
+    private val factory: ByteStreamFactory,
+) {
+    @Test
+    fun testToFlowWithSizeHint() = runTest {
+        val data = "a korf is a tiger".repeat(1024).encodeToByteArray()
+        val bufferSize = 8182 * 2
+        val byteStream = factory.byteStream(data)
+        val flow = byteStream.toFlow(bufferSize.toLong())
+        val buffers = mutableListOf<ByteArray>()
+        flow.toList(buffers)
+
+        val totalCollected = buffers.fold(0) { acc, bytes -> acc + bytes.size }
+        assertEquals(data.size, totalCollected)
+
+        if (byteStream is ByteStream.Buffer) {
+            assertEquals(1, buffers.size)
+            assertContentEquals(data, buffers.first())
+        } else {
+            val expectedFullBuffers = data.size / bufferSize
+            for (i in 0 until expectedFullBuffers) {
+                val b = buffers[i]
+                val expected = data.sliceArray((i * bufferSize)until (i * bufferSize + bufferSize))
+                assertEquals(bufferSize, b.size)
+                assertContentEquals(expected, b)
+            }
+
+            val last = buffers.last()
+            val expected = data.sliceArray(((buffers.size - 1) * bufferSize) until data.size)
+            assertContentEquals(expected, last)
+        }
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
@@ -4,9 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.content
 
-import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import aws.smithy.kotlin.runtime.io.SdkSource
-import aws.smithy.kotlin.runtime.io.source
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -14,27 +11,6 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
 import java.lang.RuntimeException
 import kotlin.test.*
-
-fun interface ByteStreamFactory {
-    fun byteStream(input: ByteArray): ByteStream
-    companion object {
-        val BYTE_ARRAY: ByteStreamFactory = ByteStreamFactory { input -> ByteStream.fromBytes(input) }
-
-        val SDK_SOURCE: ByteStreamFactory = ByteStreamFactory { input ->
-            object : ByteStream.SourceStream() {
-                override fun readFrom(): SdkSource = input.source()
-                override val contentLength: Long = input.size.toLong()
-            }
-        }
-
-        val SDK_CHANNEL: ByteStreamFactory = ByteStreamFactory { input ->
-            object : ByteStream.ChannelStream() {
-                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(input)
-                override val contentLength: Long = input.size.toLong()
-            }
-        }
-    }
-}
 
 class ByteStreamBufferFlowTest : ByteStreamFlowTest(ByteStreamFactory.BYTE_ARRAY)
 class ByteStreamSourceStreamFlowTest : ByteStreamFlowTest(ByteStreamFactory.SDK_SOURCE)

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
@@ -7,11 +7,13 @@ package aws.smithy.kotlin.runtime.content
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.source
-import kotlinx.coroutines.flow.toList
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
+import java.lang.RuntimeException
+import kotlin.test.*
 
 fun interface ByteStreamFactory {
     fun byteStream(input: ByteArray): ByteStream
@@ -68,6 +70,123 @@ abstract class ByteStreamFlowTest(
             val last = buffers.last()
             val expected = data.sliceArray(((buffers.size - 1) * bufferSize) until data.size)
             assertContentEquals(expected, last)
+        }
+    }
+
+    class FlowToByteStreamTest {
+        private fun randomByteArray(size: Int): ByteArray = ByteArray(size) { i -> i.toByte() }
+
+        val data = listOf(
+            randomByteArray(576),
+            randomByteArray(9172),
+            randomByteArray(3278),
+        )
+
+        @Test
+        fun testFlowToByteStreamReadAll() = runTest {
+            val flow = data.asFlow()
+            val scope = CoroutineScope(coroutineContext)
+            val byteStream = flow.toByteStream(scope)
+
+            assertNull(byteStream.contentLength)
+
+            val actual = byteStream.toByteArray()
+            val expected = data.reduce { acc, bytes -> acc + bytes }
+            assertContentEquals(expected, actual)
+        }
+
+        @Test
+        fun testContentLengthOverflow() = runTest {
+            val advertisedContentLength = 1024L
+            testInvalidContentLength(advertisedContentLength, "9748 bytes collected from flow exceeds reported content length of 1024")
+        }
+
+        @Test
+        fun testContentLengthUnderflow() = runTest {
+            val advertisedContentLength = data.fold(0L) { acc, bytes -> acc + bytes.size } + 100L
+            testInvalidContentLength(advertisedContentLength, "expected 13126 bytes collected from flow, got 13026")
+        }
+
+        private suspend fun testInvalidContentLength(advertisedContentLength: Long, expectedMessage: String) {
+            val job = Job()
+            val uncaughtExceptions = mutableListOf<Throwable>()
+            val exHandler = CoroutineExceptionHandler { _, throwable -> uncaughtExceptions.add(throwable) }
+            val scope = CoroutineScope(job + exHandler)
+            val byteStream = data
+                .asFlow()
+                .toByteStream(scope, advertisedContentLength)
+
+            assertEquals(advertisedContentLength, byteStream.contentLength)
+
+            val ex = assertFailsWith<IllegalStateException> {
+                byteStream.toByteArray()
+            }
+
+            ex.message?.shouldContain(expectedMessage)
+            assertTrue(job.isCancelled)
+            job.join()
+
+            assertEquals(1, uncaughtExceptions.size)
+        }
+
+        @Test
+        fun testScopeCancellation() = runTest {
+            // cancelling the scope should close/cancel the channel
+            val waiter = Channel<Unit>(1)
+            val flow = flow {
+                emit(randomByteArray(128))
+                emit(randomByteArray(277))
+                waiter.receive()
+                emit(randomByteArray(97))
+            }
+
+            val job = Job()
+            val scope = CoroutineScope(job)
+            val byteStream = flow.toByteStream(scope)
+            assertIs<ByteStream.ChannelStream>(byteStream)
+            assertNull(byteStream.contentLength)
+            yield()
+
+            job.cancel("scope cancelled")
+            waiter.send(Unit)
+            job.join()
+
+            val ch = byteStream.readFrom()
+            assertTrue(ch.isClosedForRead)
+            assertTrue(ch.isClosedForWrite)
+            assertIs<CancellationException>(ch.closedCause)
+            ch.closedCause?.message.shouldContain("scope cancelled")
+        }
+
+        @Test
+        fun testChannelCancellation() = runTest {
+            // cancelling the channel should cancel the scope (via write failing)
+            val waiter = Channel<Unit>(1)
+            val flow = flow {
+                emit(randomByteArray(128))
+                emit(randomByteArray(277))
+                waiter.receive()
+                emit(randomByteArray(97))
+            }
+
+            val uncaughtExceptions = mutableListOf<Throwable>()
+            val exHandler = CoroutineExceptionHandler { _, throwable -> uncaughtExceptions.add(throwable) }
+            val job = Job()
+            val scope = CoroutineScope(job + exHandler)
+            val byteStream = flow.toByteStream(scope)
+            assertIs<ByteStream.ChannelStream>(byteStream)
+
+            val ch = byteStream.readFrom()
+            val cause = RuntimeException("chan cancelled")
+            ch.cancel(cause)
+
+            // unblock the flow
+            waiter.send(Unit)
+
+            job.join()
+            assertTrue(job.isCancelled)
+            assertEquals(1, uncaughtExceptions.size)
+            uncaughtExceptions.first().message.shouldContain("chan cancelled")
         }
     }
 }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/content/ByteStreamFlowTest.kt
@@ -28,7 +28,7 @@ abstract class ByteStreamFlowTest(
         val buffers = mutableListOf<ByteArray>()
         flow.toList(buffers)
 
-        val totalCollected = buffers.fold(0) { acc, bytes -> acc + bytes.size }
+        val totalCollected = buffers.sumOf { it.size }
         assertEquals(data.size, totalCollected)
 
         if (byteStream is ByteStream.Buffer) {
@@ -50,12 +50,12 @@ abstract class ByteStreamFlowTest(
     }
 
     class FlowToByteStreamTest {
-        private fun randomByteArray(size: Int): ByteArray = ByteArray(size) { i -> i.toByte() }
+        private fun testByteArray(size: Int): ByteArray = ByteArray(size) { i -> i.toByte() }
 
         val data = listOf(
-            randomByteArray(576),
-            randomByteArray(9172),
-            randomByteArray(3278),
+            testByteArray(576),
+            testByteArray(9172),
+            testByteArray(3278),
         )
 
         @Test
@@ -79,7 +79,7 @@ abstract class ByteStreamFlowTest(
 
         @Test
         fun testContentLengthUnderflow() = runTest {
-            val advertisedContentLength = data.fold(0L) { acc, bytes -> acc + bytes.size } + 100L
+            val advertisedContentLength = data.sumOf { it.size } + 100L
             testInvalidContentLength(advertisedContentLength, "expected 13126 bytes collected from flow, got 13026")
         }
 
@@ -110,10 +110,10 @@ abstract class ByteStreamFlowTest(
             // cancelling the scope should close/cancel the channel
             val waiter = Channel<Unit>(1)
             val flow = flow {
-                emit(randomByteArray(128))
-                emit(randomByteArray(277))
+                emit(testByteArray(128))
+                emit(testByteArray(277))
                 waiter.receive()
-                emit(randomByteArray(97))
+                emit(testByteArray(97))
             }
 
             val job = Job()
@@ -139,10 +139,10 @@ abstract class ByteStreamFlowTest(
             // cancelling the channel should cancel the scope (via write failing)
             val waiter = Channel<Unit>(1)
             val flow = flow {
-                emit(randomByteArray(128))
-                emit(randomByteArray(277))
+                emit(testByteArray(128))
+                emit(testByteArray(277))
                 waiter.receive()
-                emit(randomByteArray(97))
+                emit(testByteArray(97))
             }
 
             val uncaughtExceptions = mutableListOf<Throwable>()

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/content/ByteStreamInputStreamTest.kt
@@ -4,34 +4,12 @@
  */
 package aws.smithy.kotlin.runtime.content
 
-import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import aws.smithy.kotlin.runtime.io.SdkSource
-import aws.smithy.kotlin.runtime.io.source
 import java.io.InputStream
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
-fun interface ByteStreamFactory {
-    fun inputStream(input: ByteArray): InputStream
-    companion object {
-        val BYTE_ARRAY: ByteStreamFactory = ByteStreamFactory { input -> ByteStream.fromBytes(input).toInputStream() }
-
-        val SDK_SOURCE: ByteStreamFactory = ByteStreamFactory { input ->
-            object : ByteStream.SourceStream() {
-                override fun readFrom(): SdkSource = input.source()
-                override val contentLength: Long = input.size.toLong()
-            }.toInputStream()
-        }
-
-        val SDK_CHANNEL: ByteStreamFactory = ByteStreamFactory { input ->
-            object : ByteStream.ChannelStream() {
-                override fun readFrom(): SdkByteReadChannel = SdkByteReadChannel(input)
-                override val contentLength: Long = input.size.toLong()
-            }.toInputStream()
-        }
-    }
-}
+fun ByteStreamFactory.inputStream(input: ByteArray): InputStream = byteStream(input).toInputStream()
 
 class ByteStreamBufferInputStreamTest : ByteStreamInputStreamTest(ByteStreamFactory.BYTE_ARRAY)
 class ByteStreamSourceStreamInputStreamTest : ByteStreamInputStreamTest(ByteStreamFactory.SDK_SOURCE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes https://github.com/awslabs/aws-sdk-kotlin/issues/612

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Adds a conversion from `ByteStream` to `Flow<ByteArray>`
* Adds a converstion from `Flow<ByteArray>` to `ByteStream`

### Questions:
1. Should `ByteStream.Buffer` try to respect the `bufferSizeHint` parameter? The easiest thing to do was to ignore it which is also the most performant (otherwise we'll be chunking it and making additional copies). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
