### PR TITLE
misc: add `visibility` build setting

### DIFF
--- a/.changes/b6288fbe-a409-473c-a6ac-12c3c310b963.json
+++ b/.changes/b6288fbe-a409-473c-a6ac-12c3c310b963.json
@@ -1,0 +1,5 @@
+{
+    "id": "b6288fbe-a409-473c-a6ac-12c3c310b963",
+    "type": "misc",
+    "description": "Generate internal-only clients with  visibility"
+}

--- a/.changes/b6288fbe-a409-473c-a6ac-12c3c310b963.json
+++ b/.changes/b6288fbe-a409-473c-a6ac-12c3c310b963.json
@@ -1,5 +1,5 @@
 {
     "id": "b6288fbe-a409-473c-a6ac-12c3c310b963",
     "type": "misc",
-    "description": "Generate internal-only clients with  visibility"
+    "description": "Generate internal-only clients with `internal` visibility"
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -197,6 +197,10 @@ class UnresolvableProtocolException(message: String) : CodegenException(message)
 
 private fun <T> Optional<T>.orNull(): T? = if (isPresent) get() else null
 
+/**
+ * The visibility of code-generated classes, objects, interfaces, etc.
+ * Valid values are `public` and `internal`. `private` not supported because codegen would not compile with private classes.
+ */
 enum class Visibility(val value: String) {
     PUBLIC("public"),
     INTERNAL("internal"),
@@ -212,7 +216,7 @@ enum class Visibility(val value: String) {
 
 /**
  * Contains API settings for a Kotlin project
- * @param visibility String representing the visibility of code-generated classes, objects, interfaces, etc.
+ * @param visibility Enum representing the visibility of code-generated classes, objects, interfaces, etc.
  */
 data class ApiSettings(
     val visibility: Visibility = Visibility.PUBLIC,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -99,7 +99,7 @@ data class KotlinSettings(
                 PackageSettings(packageName, version, desc),
                 sdkId,
                 BuildSettings.fromNode(build),
-                ApiSettings.fromNode(api)
+                ApiSettings.fromNode(api),
             )
         }
     }
@@ -197,10 +197,10 @@ class UnresolvableProtocolException(message: String) : CodegenException(message)
 
 private fun <T> Optional<T>.orNull(): T? = if (isPresent) get() else null
 
-
 enum class Visibility(val value: String) {
     PUBLIC("public"),
-    INTERNAL("internal");
+    INTERNAL("internal"),
+    ;
 
     companion object {
         public fun fromValue(value: String): Visibility = when (value.toLowerCase()) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import java.util.Optional
 import java.util.logging.Logger
+import kotlin.streams.toList
 
 // shapeId of service from which to generate an SDK
 private const val SERVICE = "service"

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.node.StringNode
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import java.lang.IllegalArgumentException
 import java.util.Optional
 import java.util.logging.Logger
 import kotlin.streams.toList
@@ -206,10 +207,15 @@ enum class Visibility(val value: String) {
     INTERNAL("internal"),
     ;
 
+    override fun toString(): String {
+        return value
+    }
+
     companion object {
         public fun fromValue(value: String): Visibility = when (value.lowercase()) {
+            "public" -> PUBLIC
             "internal" -> INTERNAL
-            else -> PUBLIC
+            else -> throw IllegalArgumentException("$value is not a valid Visibility, expected ${PUBLIC} or ${INTERNAL}")
         }
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -207,15 +207,13 @@ enum class Visibility(val value: String) {
     INTERNAL("internal"),
     ;
 
-    override fun toString(): String {
-        return value
-    }
+    override fun toString(): String = value
 
     companion object {
         public fun fromValue(value: String): Visibility = when (value.lowercase()) {
             "public" -> PUBLIC
             "internal" -> INTERNAL
-            else -> throw IllegalArgumentException("$value is not a valid Visibility, expected ${PUBLIC} or ${INTERNAL}")
+            else -> throw IllegalArgumentException("$value is not a valid Visibility value, expected $PUBLIC or $INTERNAL")
         }
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -160,7 +160,7 @@ data class BuildSettings(
     val generateDefaultBuildFiles: Boolean = true,
     val optInAnnotations: List<String>? = null,
     val generateMultiplatformProject: Boolean = false,
-    val visibility: VisibilitySettings = VisibilitySettings.Default
+    val visibility: VisibilitySettings = VisibilitySettings.Default,
 ) {
     companion object {
         const val ROOT_PROJECT = "rootProject"

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -197,18 +197,31 @@ class UnresolvableProtocolException(message: String) : CodegenException(message)
 
 private fun <T> Optional<T>.orNull(): T? = if (isPresent) get() else null
 
+
+enum class Visibility(val value: String) {
+    PUBLIC("public"),
+    INTERNAL("internal");
+
+    companion object {
+        public fun fromValue(value: String): Visibility = when (value.toLowerCase()) {
+            "internal" -> INTERNAL
+            else -> PUBLIC
+        }
+    }
+}
+
 /**
  * Contains API settings for a Kotlin project
  * @param visibility String representing the visibility of code-generated classes, objects, interfaces, etc.
  */
 data class ApiSettings(
-    val visibility: String = "public",
+    val visibility: Visibility = Visibility.PUBLIC,
 ) {
     companion object {
         const val VISIBILITY = "visibility"
 
         fun fromNode(node: Optional<ObjectNode>): ApiSettings = node.map {
-            val visibility = node.get().getStringMemberOrDefault(VISIBILITY, "public")
+            val visibility = Visibility.fromValue(node.get().getStringMemberOrDefault(VISIBILITY, "public"))
             ApiSettings(visibility)
         }.orElse(Default)
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -207,7 +207,7 @@ enum class Visibility(val value: String) {
     ;
 
     companion object {
-        public fun fromValue(value: String): Visibility = when (value.toLowerCase()) {
+        public fun fromValue(value: String): Visibility = when (value.lowercase()) {
             "internal" -> INTERNAL
             else -> PUBLIC
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -33,7 +33,9 @@ object ExceptionBaseClassGenerator {
 
         val name = clientName(ctx.settings.sdkId)
         writer.dokka("Base class for all service related exceptions thrown by the $name client")
-        writer.withBlock("#L open class #T : #T {", "}",
+        writer.withBlock(
+            "#L open class #T : #T {",
+            "}",
             ctx.settings.build.visibility.error,
             serviceException,
             baseException,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -36,7 +36,7 @@ object ExceptionBaseClassGenerator {
         writer.withBlock(
             "#L open class #T : #T {",
             "}",
-            ctx.settings.api.visibility,
+            ctx.settings.api.visibility.value,
             serviceException,
             baseException,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -33,9 +33,8 @@ object ExceptionBaseClassGenerator {
 
         val name = clientName(ctx.settings.sdkId)
         writer.dokka("Base class for all service related exceptions thrown by the $name client")
-        writer.withBlock(
-            "public open class #T : #T {",
-            "}",
+        writer.withBlock("#L open class #T : #T {", "}",
+            ctx.settings.build.visibility.error,
             serviceException,
             baseException,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -36,7 +36,7 @@ object ExceptionBaseClassGenerator {
         writer.withBlock(
             "#L open class #T : #T {",
             "}",
-            ctx.settings.build.visibility.error,
+            ctx.settings.api.visibility,
             serviceException,
             baseException,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ExceptionBaseClassGenerator.kt
@@ -36,7 +36,7 @@ object ExceptionBaseClassGenerator {
         writer.withBlock(
             "#L open class #T : #T {",
             "}",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             serviceException,
             baseException,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -70,8 +70,8 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
 
     fun render() {
         writer.write("\n\n")
-        writer.write("#L const val ServiceId: String = #S", ctx.settings.api.visibility.value, ctx.settings.sdkId)
-        writer.write("#L const val SdkVersion: String = #S", ctx.settings.api.visibility.value, ctx.settings.pkg.version)
+        writer.write("#L const val ServiceId: String = #S", ctx.settings.api.visibility, ctx.settings.sdkId)
+        writer.write("#L const val SdkVersion: String = #S", ctx.settings.api.visibility, ctx.settings.pkg.version)
         writer.write("\n\n")
 
         writer.putContext("service.name", ctx.settings.sdkId)
@@ -84,7 +84,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.renderAnnotations(service)
         writer.openBlock(
             "#L interface ${serviceSymbol.name} : #T {",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             RuntimeTypes.SmithyClient.SdkClient,
         )
             .call {
@@ -205,7 +205,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         writer.withBlock(
             "#1L fun #2T.withConfig(block: #2T.Config.Builder.() -> Unit): #2T {",
             "}",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             serviceSymbol,
         ) {
             write("val newConfig = config.toBuilder().apply(block).build()")
@@ -229,7 +229,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
                     writer.renderAnnotations(op)
                     writer.write(
                         "#L suspend inline fun #T.#L(crossinline block: #T.Builder.() -> Unit): #T = #L(#T.Builder().apply(block).build())",
-                        ctx.settings.api.visibility.value,
+                        ctx.settings.api.visibility,
                         serviceSymbol,
                         operationName,
                         inputSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -67,7 +67,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         requireNotNull(ctx.shape) { "ServiceShape is required to render a service client" }
     private val serviceSymbol = ctx.symbolProvider.toSymbol(service)
     private val writer = ctx.writer
-    private val visibility = ctx.settings.build.visibility.serviceClient
+    private val visibility = ctx.settings.api.visibility
 
     fun render() {
         writer.write("\n\n")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -82,9 +82,10 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
 
         writer.renderDocumentation(service)
         writer.renderAnnotations(service)
-        writer.openBlock("#L interface ${serviceSymbol.name} : #T {",
+        writer.openBlock(
+            "#L interface ${serviceSymbol.name} : #T {",
             ctx.settings.api.visibility.value,
-            RuntimeTypes.SmithyClient.SdkClient
+            RuntimeTypes.SmithyClient.SdkClient,
         )
             .call {
                 // allow access to client's Config
@@ -201,9 +202,11 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
             write("Any resources created on your behalf will be shared between clients, and will only be closed when ALL clients using them are closed.")
             write("If you provide a resource (e.g. [HttpClientEngine]) to the SDK, you are responsible for managing the lifetime of that resource.")
         }
-        writer.withBlock("#1L fun #2T.withConfig(block: #2T.Config.Builder.() -> Unit): #2T {", "}",
+        writer.withBlock(
+            "#1L fun #2T.withConfig(block: #2T.Config.Builder.() -> Unit): #2T {",
+            "}",
             ctx.settings.api.visibility.value,
-            serviceSymbol
+            serviceSymbol,
         ) {
             write("val newConfig = config.toBuilder().apply(block).build()")
             write("return Default#L(newConfig)", serviceSymbol.name)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -67,7 +67,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         requireNotNull(ctx.shape) { "ServiceShape is required to render a service client" }
     private val serviceSymbol = ctx.symbolProvider.toSymbol(service)
     private val writer = ctx.writer
-    private val visibility = ctx.settings.api.visibility
+    private val visibility = ctx.settings.api.visibility.value
 
     fun render() {
         writer.write("\n\n")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientGenerator.kt
@@ -67,11 +67,12 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
         requireNotNull(ctx.shape) { "ServiceShape is required to render a service client" }
     private val serviceSymbol = ctx.symbolProvider.toSymbol(service)
     private val writer = ctx.writer
+    private val visibility = ctx.settings.build.visibility.serviceClient
 
     fun render() {
         writer.write("\n\n")
-        writer.write("public const val ServiceId: String = #S", ctx.settings.sdkId)
-        writer.write("public const val SdkVersion: String = #S", ctx.settings.pkg.version)
+        writer.write("$visibility const val ServiceId: String = #S", ctx.settings.sdkId)
+        writer.write("$visibility const val SdkVersion: String = #S", ctx.settings.pkg.version)
         writer.write("\n\n")
 
         writer.putContext("service.name", ctx.settings.sdkId)
@@ -82,7 +83,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
 
         writer.renderDocumentation(service)
         writer.renderAnnotations(service)
-        writer.openBlock("public interface ${serviceSymbol.name} : #T {", RuntimeTypes.SmithyClient.SdkClient)
+        writer.openBlock("$visibility interface ${serviceSymbol.name} : #T {", RuntimeTypes.SmithyClient.SdkClient)
             .call {
                 // allow access to client's Config
                 writer.dokka("${serviceSymbol.name}'s configuration")
@@ -198,7 +199,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
             write("Any resources created on your behalf will be shared between clients, and will only be closed when ALL clients using them are closed.")
             write("If you provide a resource (e.g. [HttpClientEngine]) to the SDK, you are responsible for managing the lifetime of that resource.")
         }
-        writer.withBlock("public fun #1T.withConfig(block: #1T.Config.Builder.() -> Unit): #1T {", "}", serviceSymbol) {
+        writer.withBlock("$visibility fun #1T.withConfig(block: #1T.Config.Builder.() -> Unit): #1T {", "}", serviceSymbol) {
             write("val newConfig = config.toBuilder().apply(block).build()")
             write("return Default#L(newConfig)", serviceSymbol.name)
         }
@@ -219,7 +220,7 @@ class ServiceClientGenerator(private val ctx: RenderingContext<ServiceShape>) {
                     writer.renderDocumentation(op)
                     writer.renderAnnotations(op)
                     writer.write(
-                        "public suspend inline fun #T.#L(crossinline block: #T.Builder.() -> Unit): #T = #L(#T.Builder().apply(block).build())",
+                        "$visibility suspend inline fun #T.#L(crossinline block: #T.Builder.() -> Unit): #T = #L(#T.Builder().apply(block).build())",
                         serviceSymbol,
                         operationName,
                         inputSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -54,7 +54,7 @@ class StructureGenerator(
     private fun renderStructure() {
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) {",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             symbol,
         )
             .call { renderImmutableProperties() }
@@ -305,7 +305,7 @@ class StructureGenerator(
 
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             symbol,
         )
             .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -54,7 +54,7 @@ class StructureGenerator(
     private fun renderStructure() {
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) {",
-            ctx.settings.build.visibility.structure,
+            ctx.settings.api.visibility,
             symbol,
         )
             .call { renderImmutableProperties() }
@@ -305,7 +305,7 @@ class StructureGenerator(
 
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
-            ctx.settings.build.visibility.error,
+            ctx.settings.api.visibility,
             symbol,
         )
             .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -54,7 +54,7 @@ class StructureGenerator(
     private fun renderStructure() {
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) {",
-            ctx.settings.api.visibility,
+            ctx.settings.api.visibility.value,
             symbol,
         )
             .call { renderImmutableProperties() }
@@ -305,7 +305,7 @@ class StructureGenerator(
 
         writer.openBlock(
             "#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
-            ctx.settings.api.visibility,
+            ctx.settings.api.visibility.value,
             symbol,
         )
             .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -52,9 +52,10 @@ class StructureGenerator(
      * Renders a normal (non-error) Smithy structure to a Kotlin class
      */
     private fun renderStructure() {
-        writer.openBlock("#L class #T private constructor(builder: Builder) {",
+        writer.openBlock(
+            "#L class #T private constructor(builder: Builder) {",
             ctx.settings.build.visibility.structure,
-            symbol
+            symbol,
         )
             .call { renderImmutableProperties() }
             .write("")
@@ -302,9 +303,10 @@ class StructureGenerator(
         val exceptionBaseClass = ExceptionBaseClassGenerator.baseExceptionSymbol(ctx.settings)
         writer.addImport(exceptionBaseClass)
 
-        writer.openBlock("#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
+        writer.openBlock(
+            "#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
             ctx.settings.build.visibility.error,
-            symbol
+            symbol,
         )
             .write("")
             .call { renderImmutableProperties() }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/StructureGenerator.kt
@@ -52,7 +52,10 @@ class StructureGenerator(
      * Renders a normal (non-error) Smithy structure to a Kotlin class
      */
     private fun renderStructure() {
-        writer.openBlock("public class #T private constructor(builder: Builder) {", symbol)
+        writer.openBlock("#L class #T private constructor(builder: Builder) {",
+            ctx.settings.build.visibility.structure,
+            symbol
+        )
             .call { renderImmutableProperties() }
             .write("")
             .call { renderCompanionObject() }
@@ -299,7 +302,10 @@ class StructureGenerator(
         val exceptionBaseClass = ExceptionBaseClassGenerator.baseExceptionSymbol(ctx.settings)
         writer.addImport(exceptionBaseClass)
 
-        writer.openBlock("public class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {", symbol)
+        writer.openBlock("#L class #T private constructor(builder: Builder) : ${exceptionBaseClass.name}() {",
+            ctx.settings.build.visibility.error,
+            symbol
+        )
             .write("")
             .call { renderImmutableProperties() }
             .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -48,7 +48,10 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
         val implSymbol = getImplementationSymbol(ctx.settings)
 
         ctx.delegator.useSymbolWriter(symbol) { writer ->
-            writer.withBlock("public interface #T {", "}", symbol) {
+            writer.withBlock("#L interface #T {", "}",
+                ctx.settings.build.visibility.structure,
+                symbol
+            ) {
                 dokka("The name of the operation currently being invoked.")
                 write("public val operationName: String")
             }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -51,7 +51,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             writer.withBlock(
                 "#L interface #T {",
                 "}",
-                ctx.settings.build.visibility.structure,
+                ctx.settings.api.visibility,
                 symbol,
             ) {
                 dokka("The name of the operation currently being invoked.")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -48,9 +48,11 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
         val implSymbol = getImplementationSymbol(ctx.settings)
 
         ctx.delegator.useSymbolWriter(symbol) { writer ->
-            writer.withBlock("#L interface #T {", "}",
+            writer.withBlock(
+                "#L interface #T {",
+                "}",
                 ctx.settings.build.visibility.structure,
-                symbol
+                symbol,
             ) {
                 dokka("The name of the operation currently being invoked.")
                 write("public val operationName: String")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -51,7 +51,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             writer.withBlock(
                 "#L interface #T {",
                 "}",
-                ctx.settings.api.visibility.value,
+                ctx.settings.api.visibility,
                 symbol,
             ) {
                 dokka("The name of the operation currently being invoked.")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -51,7 +51,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             writer.withBlock(
                 "#L interface #T {",
                 "}",
-                ctx.settings.api.visibility,
+                ctx.settings.api.visibility.value,
                 symbol,
             ) {
                 dokka("The name of the operation currently being invoked.")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -55,7 +55,7 @@ open class AuthSchemeProviderGenerator {
         }
         writer.write(
             "#L interface #T : #T<#T>",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             symbol,
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
@@ -67,7 +67,7 @@ open class AuthSchemeProviderGenerator {
         writer.withBlock(
             "#L object #T : #T {",
             "}",
-            ctx.settings.api.visibility.value,
+            ctx.settings.api.visibility,
             getDefaultSymbol(ctx.settings),
             getSymbol(ctx.settings),
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -54,7 +54,8 @@ open class AuthSchemeProviderGenerator {
             write("See [#T] for the default SDK behavior of this interface.", getDefaultSymbol(ctx.settings))
         }
         writer.write(
-            "public interface #T : #T<#T>",
+            "#L interface #T : #T<#T>",
+            ctx.settings.build.visibility.structure,
             symbol,
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
@@ -64,8 +65,9 @@ open class AuthSchemeProviderGenerator {
     private fun renderDefaultImpl(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {
         // FIXME - probably can't remain an object
         writer.withBlock(
-            "public object #T : #T {",
+            "#L object #T : #T {",
             "}",
+            ctx.settings.build.visibility.structure,
             getDefaultSymbol(ctx.settings),
             getSymbol(ctx.settings),
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -55,7 +55,7 @@ open class AuthSchemeProviderGenerator {
         }
         writer.write(
             "#L interface #T : #T<#T>",
-            ctx.settings.build.visibility.structure,
+            ctx.settings.api.visibility,
             symbol,
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
@@ -67,7 +67,7 @@ open class AuthSchemeProviderGenerator {
         writer.withBlock(
             "#L object #T : #T {",
             "}",
-            ctx.settings.build.visibility.structure,
+            ctx.settings.api.visibility,
             getDefaultSymbol(ctx.settings),
             getSymbol(ctx.settings),
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -55,7 +55,7 @@ open class AuthSchemeProviderGenerator {
         }
         writer.write(
             "#L interface #T : #T<#T>",
-            ctx.settings.api.visibility,
+            ctx.settings.api.visibility.value,
             symbol,
             RuntimeTypes.Auth.Identity.AuthSchemeProvider,
             paramsSymbol,
@@ -67,7 +67,7 @@ open class AuthSchemeProviderGenerator {
         writer.withBlock(
             "#L object #T : #T {",
             "}",
-            ctx.settings.api.visibility,
+            ctx.settings.api.visibility.value,
             getDefaultSymbol(ctx.settings),
             getSymbol(ctx.settings),
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -82,7 +82,7 @@ class DefaultEndpointProviderGenerator(
         writer.withBlock(
             "#L class #T: #T {",
             "}",
-            settings.api.visibility,
+            settings.api.visibility.value,
             defaultProviderSymbol,
             interfaceSymbol,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -62,6 +62,7 @@ class DefaultEndpointProviderGenerator(
     private val defaultProviderSymbol: Symbol,
     private val interfaceSymbol: Symbol,
     private val paramsSymbol: Symbol,
+    private val settings: KotlinSettings,
     private val externalFunctions: Map<String, Symbol> = emptyMap(),
     private val propertyRenderers: Map<String, EndpointPropertyRenderer> = emptyMap(),
 ) : ExpressionRenderer {
@@ -78,7 +79,11 @@ class DefaultEndpointProviderGenerator(
 
     fun render() {
         renderDocumentation()
-        writer.withBlock("public class #T: #T {", "}", defaultProviderSymbol, interfaceSymbol) {
+        writer.withBlock("#L class #T: #T {", "}",
+            settings.build.visibility.structure,
+            defaultProviderSymbol,
+            interfaceSymbol
+        ) {
             renderResolve()
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -79,10 +79,12 @@ class DefaultEndpointProviderGenerator(
 
     fun render() {
         renderDocumentation()
-        writer.withBlock("#L class #T: #T {", "}",
+        writer.withBlock(
+            "#L class #T: #T {",
+            "}",
             settings.build.visibility.structure,
             defaultProviderSymbol,
-            interfaceSymbol
+            interfaceSymbol,
         ) {
             renderResolve()
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -82,7 +82,7 @@ class DefaultEndpointProviderGenerator(
         writer.withBlock(
             "#L class #T: #T {",
             "}",
-            settings.api.visibility.value,
+            settings.api.visibility,
             defaultProviderSymbol,
             interfaceSymbol,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -82,7 +82,7 @@ class DefaultEndpointProviderGenerator(
         writer.withBlock(
             "#L class #T: #T {",
             "}",
-            settings.build.visibility.structure,
+            settings.api.visibility,
             defaultProviderSymbol,
             interfaceSymbol,
         ) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
@@ -38,7 +38,7 @@ interface EndpointDelegator {
 
         if (rules != null) {
             ctx.delegator.useFileWriter(defaultProviderSymbol) {
-                DefaultEndpointProviderGenerator(it, rules, defaultProviderSymbol, providerSymbol, paramsSymbol).render()
+                DefaultEndpointProviderGenerator(it, rules, defaultProviderSymbol, providerSymbol, paramsSymbol, ctx.settings).render()
             }
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointDelegator.kt
@@ -33,7 +33,7 @@ interface EndpointDelegator {
         val defaultProviderSymbol = DefaultEndpointProviderGenerator.getSymbol(ctx.settings)
 
         ctx.delegator.useFileWriter(providerSymbol) {
-            EndpointProviderGenerator(it, providerSymbol, paramsSymbol).render()
+            EndpointProviderGenerator(it, ctx.settings, providerSymbol, paramsSymbol).render()
         }
 
         if (rules != null) {
@@ -49,7 +49,7 @@ interface EndpointDelegator {
     fun generateEndpointParameters(ctx: ProtocolGenerator.GenerationContext, rules: EndpointRuleSet?) {
         val paramsSymbol = EndpointParametersGenerator.getSymbol(ctx.settings)
         ctx.delegator.useFileWriter(paramsSymbol) {
-            EndpointParametersGenerator(it, rules, paramsSymbol).render()
+            EndpointParametersGenerator(it, ctx.settings, rules, paramsSymbol).render()
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -52,9 +52,11 @@ class EndpointParametersGenerator(
     fun render() {
         renderDocumentation()
         // FIXME - this should probably be an interface
-        writer.withBlock("#L class #T private constructor(builder: Builder) {", "}",
+        writer.withBlock(
+            "#L class #T private constructor(builder: Builder) {",
+            "}",
             settings.build.visibility.structure,
-            paramsSymbol
+            paramsSymbol,
         ) {
             renderFields()
             renderCompanionObject()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -55,7 +55,7 @@ class EndpointParametersGenerator(
         writer.withBlock(
             "#L class #T private constructor(builder: Builder) {",
             "}",
-            settings.api.visibility.value,
+            settings.api.visibility,
             paramsSymbol,
         ) {
             renderFields()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -55,7 +55,7 @@ class EndpointParametersGenerator(
         writer.withBlock(
             "#L class #T private constructor(builder: Builder) {",
             "}",
-            settings.api.visibility,
+            settings.api.visibility.value,
             paramsSymbol,
         ) {
             renderFields()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -55,7 +55,7 @@ class EndpointParametersGenerator(
         writer.withBlock(
             "#L class #T private constructor(builder: Builder) {",
             "}",
-            settings.build.visibility.structure,
+            settings.api.visibility,
             paramsSymbol,
         ) {
             renderFields()

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGenerator.kt
@@ -22,6 +22,7 @@ private const val DEFAULT_DEPRECATED_MESSAGE =
  */
 class EndpointParametersGenerator(
     private val writer: KotlinWriter,
+    private val settings: KotlinSettings,
     rules: EndpointRuleSet?,
     private val paramsSymbol: Symbol,
 ) {
@@ -51,7 +52,10 @@ class EndpointParametersGenerator(
     fun render() {
         renderDocumentation()
         // FIXME - this should probably be an interface
-        writer.withBlock("public class #T private constructor(builder: Builder) {", "}", paramsSymbol) {
+        writer.withBlock("#L class #T private constructor(builder: Builder) {", "}",
+            settings.build.visibility.structure,
+            paramsSymbol
+        ) {
             renderFields()
             renderCompanionObject()
             write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -35,7 +35,7 @@ class EndpointProviderGenerator(
         renderDocumentation()
         writer.write(
             "#L fun interface #T: #T<#T>",
-            settings.api.visibility.value,
+            settings.api.visibility,
             providerSymbol,
             RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
             paramsSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -35,7 +35,7 @@ class EndpointProviderGenerator(
         renderDocumentation()
         writer.write(
             "#L fun interface #T: #T<#T>",
-            settings.api.visibility,
+            settings.api.visibility.value,
             providerSymbol,
             RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
             paramsSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -35,7 +35,7 @@ class EndpointProviderGenerator(
         renderDocumentation()
         writer.write(
             "#L fun interface #T: #T<#T>",
-            settings.build.visibility.structure,
+            settings.api.visibility,
             providerSymbol,
             RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
             paramsSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointProviderGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.kotlin.codegen.model.buildSymbol
  */
 class EndpointProviderGenerator(
     private val writer: KotlinWriter,
+    private val settings: KotlinSettings,
     private val providerSymbol: Symbol,
     private val paramsSymbol: Symbol,
 ) {
@@ -33,7 +34,8 @@ class EndpointProviderGenerator(
     fun render() {
         renderDocumentation()
         writer.write(
-            "public fun interface #T: #T<#T>",
+            "#L fun interface #T: #T<#T>",
+            settings.build.visibility.structure,
             providerSymbol,
             RuntimeTypes.SmithyClient.Endpoints.EndpointProvider,
             paramsSymbol,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
@@ -46,7 +46,7 @@ class EndpointDiscovererGenerator(private val ctx: CodegenContext, private val d
             withBlock(
                 "#L class #T {",
                 "}",
-                ctx.settings.build.visibility.structure,
+                ctx.settings.api.visibility,
                 symbol,
             ) {
                 write(

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
@@ -43,9 +43,11 @@ class EndpointDiscovererGenerator(private val ctx: CodegenContext, private val d
                     calls.
                 """.trimIndent(),
             )
-            withBlock("#L class #T {", "}",
+            withBlock(
+                "#L class #T {",
+                "}",
                 ctx.settings.build.visibility.structure,
-                symbol
+                symbol,
             ) {
                 write(
                     "private val cache = #T<DiscoveryParams, #T>(10.#T, #T.System)",

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
@@ -46,7 +46,7 @@ class EndpointDiscovererGenerator(private val ctx: CodegenContext, private val d
             withBlock(
                 "#L class #T {",
                 "}",
-                ctx.settings.api.visibility,
+                ctx.settings.api.visibility.value,
                 symbol,
             ) {
                 write(

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
@@ -43,7 +43,10 @@ class EndpointDiscovererGenerator(private val ctx: CodegenContext, private val d
                     calls.
                 """.trimIndent(),
             )
-            withBlock("public class #T {", "}", symbol) {
+            withBlock("#L class #T {", "}",
+                ctx.settings.build.visibility.structure,
+                symbol
+            ) {
                 write(
                     "private val cache = #T<DiscoveryParams, #T>(10.#T, #T.System)",
                     RuntimeTypes.Core.Utils.ReadThroughCache,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererGenerator.kt
@@ -46,7 +46,7 @@ class EndpointDiscovererGenerator(private val ctx: CodegenContext, private val d
             withBlock(
                 "#L class #T {",
                 "}",
-                ctx.settings.api.visibility.value,
+                ctx.settings.api.visibility,
                 symbol,
             ) {
                 write(

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -184,4 +184,82 @@ class KotlinSettingsTest {
             Node.parse(contents).expectObjectNode(),
         )
     }
+
+    @Test
+    fun `supports internal visibility`() {
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
+
+        val contents = """
+            {
+                "package": {
+                    "name": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
+                    "version": "1.0.0"
+                },
+                "build": {
+                    "optInAnnotations": ["foo", "bar"]
+                },
+                "api": {
+                    "visibility": "internal"
+                }
+            }
+        """.trimIndent()
+
+        val settings = KotlinSettings.from(
+            model,
+            Node.parse(contents).expectObjectNode(),
+        )
+
+        assertEquals(Visibility.INTERNAL, settings.api.visibility)
+    }
+
+    @Test
+    fun `defaults to public visibility`() {
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
+
+        val contents = """
+            {
+                "package": {
+                    "name": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
+                    "version": "1.0.0"
+                },
+                "build": {
+                    "optInAnnotations": ["foo", "bar"]
+                }
+            }
+        """.trimIndent()
+
+        val settings = KotlinSettings.from(
+            model,
+            Node.parse(contents).expectObjectNode(),
+        )
+
+        assertEquals(Visibility.PUBLIC, settings.api.visibility)
+    }
+
+    @Test
+    fun `works with unsupported visibility values`() {
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
+
+        val contents = """
+            {
+                "package": {
+                    "name": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
+                    "version": "1.0.0"
+                },
+                "build": {
+                    "optInAnnotations": ["foo", "bar"]
+                },
+                "api": {
+                    "visibility": "I don't know, just make it visible"
+                }
+            }
+        """.trimIndent()
+
+        val settings = KotlinSettings.from(
+            model,
+            Node.parse(contents).expectObjectNode(),
+        )
+
+        assertEquals(Visibility.PUBLIC, settings.api.visibility)
+    }
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -239,6 +239,33 @@ class KotlinSettingsTest {
     }
 
     @Test
+    fun `supports public visibility`() {
+        val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
+
+        val contents = """
+            {
+                "package": {
+                    "name": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
+                    "version": "1.0.0"
+                },
+                "build": {
+                    "optInAnnotations": ["foo", "bar"]
+                },
+                "api": {
+                    "visibility": "public"
+                }
+            }
+        """.trimIndent()
+
+        val settings = KotlinSettings.from(
+            model,
+            Node.parse(contents).expectObjectNode(),
+        )
+
+        assertEquals(Visibility.PUBLIC, settings.api.visibility)
+    }
+
+    @Test
     fun `throws on unsupported visibility values`() {
         val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -5,11 +5,13 @@
 
 package software.amazon.smithy.kotlin.codegen
 
+import org.junit.jupiter.api.assertThrows
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
 import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ShapeId
+import java.lang.IllegalArgumentException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -237,7 +239,7 @@ class KotlinSettingsTest {
     }
 
     @Test
-    fun `works with unsupported visibility values`() {
+    fun `throws on unsupported visibility values`() {
         val model = javaClass.getResource("simple-service.smithy")!!.toSmithyModel()
 
         val contents = """
@@ -255,11 +257,11 @@ class KotlinSettingsTest {
             }
         """.trimIndent()
 
-        val settings = KotlinSettings.from(
-            model,
-            Node.parse(contents).expectObjectNode(),
-        )
-
-        assertEquals(Visibility.PUBLIC, settings.api.visibility)
+        assertThrows<IllegalArgumentException> {
+            KotlinSettings.from(
+                model,
+                Node.parse(contents).expectObjectNode(),
+            )
+        }
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -145,7 +145,7 @@ class DefaultEndpointProviderGeneratorTest {
             namespace = TestModelDefault.NAMESPACE
         }
         val settings = KotlinSettings(
-            service = ShapeId.from("EndpointProviderGeneratorTest"),
+            service = ShapeId.from("com.test#Test"),
             pkg = KotlinSettings.PackageSettings("name", "version"),
             sdkId = "testSdkId",
         )

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.endpoints
 
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
@@ -11,6 +12,7 @@ import software.amazon.smithy.kotlin.codegen.test.assertBalancedBracesAndParens
 import software.amazon.smithy.kotlin.codegen.test.formatForTest
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import kotlin.test.*
 
@@ -142,7 +144,13 @@ class DefaultEndpointProviderGeneratorTest {
             name = "DefaultEndpointProvider"
             namespace = TestModelDefault.NAMESPACE
         }
-        DefaultEndpointProviderGenerator(writer, rules, defaultSymbol, interfaceSymbol, paramsSymbol).render()
+        val settings = KotlinSettings(
+            service = ShapeId.from("EndpointProviderGeneratorTest"),
+            pkg = KotlinSettings.PackageSettings("name", "version"),
+            sdkId = "testSdkId"
+        )
+
+        DefaultEndpointProviderGenerator(writer, rules, defaultSymbol, interfaceSymbol, paramsSymbol, settings).render()
         generatedClass = writer.toString()
     }
 

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -147,7 +147,7 @@ class DefaultEndpointProviderGeneratorTest {
         val settings = KotlinSettings(
             service = ShapeId.from("EndpointProviderGeneratorTest"),
             pkg = KotlinSettings.PackageSettings("name", "version"),
-            sdkId = "testSdkId"
+            sdkId = "testSdkId",
         )
 
         DefaultEndpointProviderGenerator(writer, rules, defaultSymbol, interfaceSymbol, paramsSymbol, settings).render()

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/EndpointParametersGeneratorTest.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering.endpoints
 
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.test.TestModelDefault
@@ -11,6 +12,7 @@ import software.amazon.smithy.kotlin.codegen.test.assertBalancedBracesAndParens
 import software.amazon.smithy.kotlin.codegen.test.formatForTest
 import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import kotlin.test.*
 
@@ -83,7 +85,12 @@ class EndpointParametersGeneratorTest {
             name = "EndpointParameters"
             namespace = TestModelDefault.NAMESPACE
         }
-        EndpointParametersGenerator(writer, rules, paramsSymbol).render()
+        val settings = KotlinSettings(
+            service = ShapeId.from("com.test#Test"),
+            pkg = KotlinSettings.PackageSettings("name", "version"),
+            sdkId = "testSdkId",
+        )
+        EndpointParametersGenerator(writer, settings, rules, paramsSymbol).render()
 
         generatedClass = writer.toString()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates build settings to allow configuring visibility for `serviceClient`, `structure`, and `error`. This corresponds to visibility on the generated service client, Smithy Structure shapes, and Smithy Error shapes, respectively. 

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change is required so we can generate internal-only SDK clients with the proper `internal` visibility, so they don't show up in the public API footprint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
