### PR TITLE
fix: ignore __type field when deserializing unions in json protocols

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/AbstractSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/AbstractSerdeDescriptorGenerator.kt
@@ -86,7 +86,7 @@ abstract class AbstractSerdeDescriptorGenerator(
 
         /**
          * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
-         * This is here to then ignore it when deserializing unions for AWS restJson1, awsJson1_0, and awsJson1_1
+         * This property should be ignored unless there is an explicit '__type' member in the model for AWS restJson1, awsJson1_0, and awsJson1_1
          *
          * Source: https://github.com/smithy-lang/smithy/pull/1945
          * Also see: [JsonDeserializerTest]
@@ -106,7 +106,7 @@ abstract class AbstractSerdeDescriptorGenerator(
 
             /**
              * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
-             * This is here to then ignore it when deserializing unions for AWS restJson1, awsJson1_0, and awsJson1_1
+             * This property should be ignored unless there is an explicit '__type' member in the model for AWS restJson1, awsJson1_0, and awsJson1_1
              *
              * Source: https://github.com/smithy-lang/smithy/pull/1945
              * Also see: [JsonDeserializerTest]

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/AbstractSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/AbstractSerdeDescriptorGenerator.kt
@@ -86,12 +86,15 @@ abstract class AbstractSerdeDescriptorGenerator(
 
         /**
          * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
-         * This property should be ignored unless there is an explicit '__type' member in the model for AWS restJson1, awsJson1_0, and awsJson1_1
+         * This property should be ignored for unions unless there is an explicit '__type' member in the model for:
+         * AWS restJson1, awsJson1_0, and awsJson1_1
          *
          * Source: https://github.com/smithy-lang/smithy/pull/1945
          * Also see: [JsonDeserializerTest]
          */
-        if (objectShape.isUnionShape && isJsonProtocol && "__type" !in memberShapes.map { it.memberName }) writer.write("val __TYPE_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName(\"__type\"))")
+        if (objectShape.isUnionShape && isJsonProtocol && "__type" !in memberShapes.map { it.memberName }) {
+            writer.write("val __TYPE_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName(\"__type\"))")
+        }
 
         writer.withBlock("val OBJ_DESCRIPTOR = SdkObjectDescriptor.build {", "}") {
             val objTraits = getObjectDescriptorTraits()
@@ -106,12 +109,15 @@ abstract class AbstractSerdeDescriptorGenerator(
 
             /**
              * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
-             * This property should be ignored unless there is an explicit '__type' member in the model for AWS restJson1, awsJson1_0, and awsJson1_1
+             * This property should be ignored for unions unless there is an explicit '__type' member in the model for:
+             * AWS restJson1, awsJson1_0, and awsJson1_1
              *
              * Source: https://github.com/smithy-lang/smithy/pull/1945
              * Also see: [JsonDeserializerTest]
              */
-            if (objectShape.isUnionShape && isJsonProtocol && "__type" !in memberShapes.map { it.memberName }) write("field(__TYPE_DESCRIPTOR)")
+            if (objectShape.isUnionShape && isJsonProtocol && "__type" !in memberShapes.map { it.memberName }) {
+                write("field(__TYPE_DESCRIPTOR)")
+            }
         }
         writer.write("")
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeJsonUnionGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeJsonUnionGenerator.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.rendering.serde
+
+import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
+import software.amazon.smithy.kotlin.codegen.core.withBlock
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+
+class DeserializeJsonUnionGenerator(
+    ctx: ProtocolGenerator.GenerationContext,
+    private val unionName: String,
+    members: List<MemberShape>,
+    writer: KotlinWriter,
+    defaultTimestampFormat: TimestampFormatTrait.Format,
+) : DeserializeUnionGenerator(ctx, unionName, members, writer, defaultTimestampFormat) {
+
+    /**
+     * Iterate over all supplied [MemberShape]s to generate serializers.
+     */
+    override fun render() {
+        // inline an empty object descriptor when the struct has no members
+        // otherwise use the one generated as part of the companion object
+        val objDescriptor = if (members.isNotEmpty()) "OBJ_DESCRIPTOR" else "SdkObjectDescriptor.build {}"
+        writer.withBlock("deserializer.deserializeStruct($objDescriptor) {", "}") {
+            // field iterators MUST be driven to completion so that underlying tokens are consumed
+            // and the deserializer state is maintained
+            withBlock("loop@while(true) {", "}") {
+                withBlock("when(findNextFieldIndex()) {", "}") {
+                    members
+                        .sortedBy { it.memberName }
+                        .forEach { memberShape -> renderMemberShape(memberShape) }
+
+                    /**
+                     * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
+                     * This property should be ignored unless there is an explicit '__type' member in the model
+                     *
+                     * Source: https://github.com/smithy-lang/smithy/pull/1945
+                     */
+                    if ("__type" !in members.map { it.memberName }) write("__TYPE_DESCRIPTOR.index -> skipValue()")
+
+                    write("null -> break@loop")
+                    write("else -> value = $unionName.SdkUnknown.also { skipValue() }")
+                }
+            }
+        }
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
@@ -34,6 +34,15 @@ class DeserializeUnionGenerator(
                     members
                         .sortedBy { it.memberName }
                         .forEach { memberShape -> renderMemberShape(memberShape) }
+
+                    /**
+                     * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
+                     * This property should be ignored unless there is an explicit '__type' member in the model
+                     *
+                     * Source: https://github.com/smithy-lang/smithy/pull/1945
+                     */
+                    if ("__type" !in members.map { it.memberName }) write("__TYPE_DESCRIPTOR.index -> skipValue()")
+
                     write("null -> break@loop")
                     write("else -> value = $unionName.SdkUnknown.also { skipValue() }")
                 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGenerator.kt
@@ -11,7 +11,7 @@ import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerato
 import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 
-class DeserializeUnionGenerator(
+open class DeserializeUnionGenerator(
     ctx: ProtocolGenerator.GenerationContext,
     private val unionName: String,
     members: List<MemberShape>,
@@ -34,14 +34,6 @@ class DeserializeUnionGenerator(
                     members
                         .sortedBy { it.memberName }
                         .forEach { memberShape -> renderMemberShape(memberShape) }
-
-                    /**
-                     * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
-                     * This property should be ignored unless there is an explicit '__type' member in the model
-                     *
-                     * Source: https://github.com/smithy-lang/smithy/pull/1945
-                     */
-                    if ("__type" !in members.map { it.memberName }) write("__TYPE_DESCRIPTOR.index -> skipValue()")
 
                     write("null -> break@loop")
                     write("else -> value = $unionName.SdkUnknown.also { skipValue() }")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonParserGenerator.kt
@@ -129,7 +129,7 @@ open class JsonParserGenerator(
         JsonSerdeDescriptorGenerator(ctx.toRenderingContext(protocolGenerator, shape, writer), members, supportsJsonNameTrait).render()
         if (shape.isUnionShape) {
             val name = ctx.symbolProvider.toSymbol(shape).name
-            DeserializeUnionGenerator(ctx, name, members, writer, defaultTimestampFormat).render()
+            DeserializeJsonUnionGenerator(ctx, name, members, writer, defaultTimestampFormat).render()
         } else {
             DeserializeStructGenerator(ctx, members, writer, defaultTimestampFormat).render()
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.kotlin.codegen.rendering.serde
 import software.amazon.smithy.kotlin.codegen.core.RenderingContext
 import software.amazon.smithy.kotlin.codegen.core.RuntimeTypes
 import software.amazon.smithy.kotlin.codegen.core.addImport
+import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.getTrait
 import software.amazon.smithy.kotlin.codegen.utils.dq
 import software.amazon.smithy.model.shapes.MemberShape
@@ -22,7 +23,74 @@ open class JsonSerdeDescriptorGenerator(
     ctx: RenderingContext<Shape>,
     memberShapes: List<MemberShape>? = null,
     private val supportsJsonNameTrait: Boolean = true,
-) : AbstractSerdeDescriptorGenerator(ctx, memberShapes, isJsonProtocol = true) {
+) : AbstractSerdeDescriptorGenerator(ctx, memberShapes) {
+
+    override fun render() {
+        if (memberShapes.isEmpty()) return
+
+        // FIXME - decompose these symbols directly when they are emitted
+        val serdeDescriptorSymbols = setOf(
+            RuntimeTypes.Serde.SdkFieldDescriptor,
+            RuntimeTypes.Serde.SdkObjectDescriptor,
+            RuntimeTypes.Serde.SerialKind,
+            RuntimeTypes.Serde.deserializeStruct,
+            RuntimeTypes.Serde.deserializeList,
+            RuntimeTypes.Serde.deserializeMap,
+            RuntimeTypes.Serde.field,
+            RuntimeTypes.Serde.asSdkSerializable,
+            RuntimeTypes.Serde.serializeStruct,
+            RuntimeTypes.Serde.serializeList,
+            RuntimeTypes.Serde.serializeMap,
+        )
+        writer.addImport(serdeDescriptorSymbols)
+        val sortedMembers = memberShapes.sortedBy { it.memberName }
+        for (member in sortedMembers) {
+            val memberTarget = ctx.model.expectShape(member.target)
+            renderFieldDescriptor(member, memberTarget)
+
+            val nestedMember = memberTarget.childShape(ctx.model)
+            if (nestedMember?.isContainerShape() == true) {
+                renderContainerFieldDescriptors(member, nestedMember)
+            }
+        }
+
+        /**
+         * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
+         * This property should be ignored for unions unless there is an explicit '__type' member in the model for:
+         * AWS restJson1, awsJson1_0, and awsJson1_1
+         *
+         * Source: https://github.com/smithy-lang/smithy/pull/1945
+         * Also see: [JsonDeserializerTest]
+         */
+        if (objectShape.isUnionShape && "__type" !in memberShapes.map { it.memberName }) {
+            writer.write("val __TYPE_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName(\"__type\"))")
+        }
+
+        writer.withBlock("val OBJ_DESCRIPTOR = SdkObjectDescriptor.build {", "}") {
+            val objTraits = getObjectDescriptorTraits()
+            objTraits.forEach { trait ->
+                writer.addImport(trait.symbol)
+                writer.write("trait($trait)")
+            }
+
+            for (member in sortedMembers) {
+                write("field(#L)", member.descriptorName())
+            }
+
+            /**
+             * Older implementations of AWS JSON protocols will unnecessarily serialize a '__type' property.
+             * This property should be ignored for unions unless there is an explicit '__type' member in the model for:
+             * AWS restJson1, awsJson1_0, and awsJson1_1
+             *
+             * Source: https://github.com/smithy-lang/smithy/pull/1945
+             * Also see: [JsonDeserializerTest]
+             */
+            if (objectShape.isUnionShape && "__type" !in memberShapes.map { it.memberName }) {
+                write("field(__TYPE_DESCRIPTOR)")
+            }
+        }
+        writer.write("")
+    }
 
     override fun getFieldDescriptorTraits(
         member: MemberShape,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGenerator.kt
@@ -22,7 +22,7 @@ open class JsonSerdeDescriptorGenerator(
     ctx: RenderingContext<Shape>,
     memberShapes: List<MemberShape>? = null,
     private val supportsJsonNameTrait: Boolean = true,
-) : AbstractSerdeDescriptorGenerator(ctx, memberShapes) {
+) : AbstractSerdeDescriptorGenerator(ctx, memberShapes, isJsonProtocol = true) {
 
     override fun getFieldDescriptorTraits(
         member: MemberShape,

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeJsonUnionGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeJsonUnionGeneratorTest.kt
@@ -55,7 +55,7 @@ class DeserializeJsonUnionGeneratorTest {
     @Test
     fun `it deserializes a union '__type' value`() {
         val model = (
-                modelPrefix + """            
+            modelPrefix + """            
             structure FooResponse { 
                 fooUnion: PrimitiveUnion
             }
@@ -66,7 +66,7 @@ class DeserializeJsonUnionGeneratorTest {
                 __type: String
             }
         """
-                ).toSmithyModel()
+            ).toSmithyModel()
 
         val expected = """
             deserializer.deserializeStruct(OBJ_DESCRIPTOR) {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/DeserializeUnionGeneratorTest.kt
@@ -40,6 +40,7 @@ class DeserializeUnionGeneratorTest {
                     when(findNextFieldIndex()) {
                         I32_DESCRIPTOR.index -> value = PrimitiveUnion.I32(deserializeInt())
                         STRINGA_DESCRIPTOR.index -> value = PrimitiveUnion.Stringa(deserializeString())
+                        __TYPE_DESCRIPTOR.index -> skipValue()
                         null -> break@loop
                         else -> value = PrimitiveUnion.SdkUnknown.also { skipValue() }
                     }
@@ -99,6 +100,7 @@ class DeserializeUnionGeneratorTest {
                                 }
                                 MyAggregateUnion.UnionMap(map0)
                             }
+                        __TYPE_DESCRIPTOR.index -> skipValue()
                         null -> break@loop
                         else -> value = MyAggregateUnion.SdkUnknown.also { skipValue() }
                     }
@@ -199,6 +201,7 @@ class DeserializeUnionGeneratorTest {
                                 }
                                 FooUnion.StrMapVal(map0)
                             }
+                        __TYPE_DESCRIPTOR.index -> skipValue()
                         null -> break@loop
                         else -> value = FooUnion.SdkUnknown.also { skipValue() }
                     }
@@ -296,6 +299,7 @@ class DeserializeUnionGeneratorTest {
                                 }
                                 MyAggregateUnion.MapOfLists(map0)
                             }
+                        __TYPE_DESCRIPTOR.index -> skipValue()
                         null -> break@loop
                         else -> value = MyAggregateUnion.SdkUnknown.also { skipValue() }
                     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/JsonSerdeDescriptorGeneratorTest.kt
@@ -46,6 +46,89 @@ class JsonSerdeDescriptorGeneratorTest {
     }
 
     @Test
+    fun itHandlesSimpleUnionDescriptors() {
+        val model = """
+                @http(method: "POST", uri: "/foo")
+                operation Foo {
+                    input: FooRequest
+                }  
+                
+                structure FooRequest { 
+                    strVal: String,
+                    intVal: Integer
+                }
+                
+                union FooResponse {
+                    x: String,
+                    y: String
+                }
+        """.prependNamespaceAndService(operations = listOf("Foo")).toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        val shape = model.expectShape(ShapeId.from("com.test#FooResponse"))
+        val renderingCtx = testCtx.toRenderingContext(writer, shape)
+
+        JsonSerdeDescriptorGenerator(renderingCtx).render()
+
+        val expectedDescriptors = """
+            val X_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("x"))
+            val Y_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("y"))
+            val __TYPE_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("__type"))
+            val OBJ_DESCRIPTOR = SdkObjectDescriptor.build {
+                field(X_DESCRIPTOR)
+                field(Y_DESCRIPTOR)
+                field(__TYPE_DESCRIPTOR)
+            }
+            """.formatForTest("")
+
+        val contents = writer.toString()
+        contents.shouldContainOnlyOnceWithDiff(expectedDescriptors)
+    }
+
+    @Test
+    fun `it handles union descriptors with '__type'`() {
+        val model = """
+                @http(method: "POST", uri: "/foo")
+                operation Foo {
+                    input: FooRequest
+                }  
+                
+                structure FooRequest { 
+                    strVal: String,
+                    intVal: Integer
+                }
+                
+                union FooResponse {
+                    x: String,
+                    y: String,
+                    __type: String
+                }
+        """.prependNamespaceAndService(operations = listOf("Foo")).toSmithyModel()
+
+        val testCtx = model.newTestContext()
+        val writer = testCtx.newWriter()
+        val shape = model.expectShape(ShapeId.from("com.test#FooResponse"))
+        val renderingCtx = testCtx.toRenderingContext(writer, shape)
+
+        JsonSerdeDescriptorGenerator(renderingCtx).render()
+
+        val expectedDescriptors = """
+            val TYPE_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("__type"))
+            val X_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("x"))
+            val Y_DESCRIPTOR = SdkFieldDescriptor(SerialKind.String, JsonSerialName("y"))
+            val OBJ_DESCRIPTOR = SdkObjectDescriptor.build {
+                field(TYPE_DESCRIPTOR)
+                field(X_DESCRIPTOR)
+                field(Y_DESCRIPTOR)
+            }
+            """.formatForTest("")
+
+        val contents = writer.toString()
+        contents.shouldContainOnlyOnceWithDiff(expectedDescriptors)
+    }
+
+    @Test
     fun itGeneratesNestedDescriptors() {
         val model = """            
             @http(method: "POST", uri: "/foo")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
closes aws-sdk-kotlin#1044

## Description of changes
-Added a flag for JSON protocols
-Added a `__type` to union object descriptors
-Ignoring `__type` unless it's member explicitly in union shape

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
