### PR TITLE
chore: remove unused experimental annotations

### DIFF
--- a/docs/design/binary-streaming.md
+++ b/docs/design/binary-streaming.md
@@ -405,7 +405,6 @@ suspend fun ByteStream.toByteArray(): ByteArray {...}
 /**
  * Consume a [ByteStream] and decode the contests as a string
  */
-@OptIn(ExperimentalStdlibApi::class)
 suspend fun ByteStream.decodeToString(): String = toByteArray().decodeToString()
 
 
@@ -588,8 +587,6 @@ fun fromByteArray(array: ByteArray): Flow<ByteArray> = flowOf(array)
 fun fromString(string: String): Flow<ByteArray> = fromByteArray(string.toByteArray())
 fun fromFile(file: File): Flow<ByteArray> = TODO()
 
-
-@OptIn(ExperimentalStdlibApi::class)
 suspend fun Flow<ByteArray>.decodeToString(): String = toByteArray().decodeToString()
 
 // NOTE: this is just an example, there are potentially more efficient ways to do this

--- a/docs/design/waiters.md
+++ b/docs/design/waiters.md
@@ -218,7 +218,6 @@ class Waiter<I, O>(
     val acceptors: List<Acceptor<I, O>>,
     val delayProvider: DelayProvider,
 ) {
-    @OptIn(ExperimentalTime::class)
     suspend fun retry(input: I): WaiterOutcome<O> =
         withTimeout(options.maxDuration.inWholeMilliseconds) {
             doTryLoop(input, 1)

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProviderTest.kt
@@ -9,7 +9,6 @@ import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.ManualClock
 import aws.smithy.kotlin.runtime.util.Attributes
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,7 +16,6 @@ import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class CachedCredentialsProviderTest {
     private val epoch = Instant.fromIso8601("2020-10-16T03:56:00Z")
     private val testExpiration = epoch + 30.minutes

--- a/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
+++ b/runtime/auth/aws-credentials/common/test/aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProviderChainTest.kt
@@ -6,12 +6,10 @@
 package aws.smithy.kotlin.runtime.auth.awscredentials
 
 import aws.smithy.kotlin.runtime.util.Attributes
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class CredentialsProviderChainTest {
     private class TestCredentialsProvider(val accessKeyId: String? = null, val secretAccessKey: String? = null) : CredentialsProvider {
         override suspend fun resolve(attributes: Attributes): Credentials =

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
@@ -16,14 +16,12 @@ import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.Attributes
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 private const val NON_HTTPS_URL = "http://localhost:8080/path/to/resource?foo=bar"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class PresignerTest {
     // Verify that custom endpoint URL schemes aren't changed.
     // See https://github.com/awslabs/aws-sdk-kotlin/issues/938

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
@@ -12,12 +12,10 @@ import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.UrlBuilder
 import aws.smithy.kotlin.runtime.net.parameters
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultCanonicalizerTest {
     // Test adapted from https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     @Test

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSignatureCalculatorTest.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.hashing.sha256
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.decodeHexBytes
 import aws.smithy.kotlin.runtime.util.encodeToHex
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,7 +32,6 @@ class DefaultSignatureCalculatorTest {
     }
 
     // Test adapted from https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testSigningKey() = runTest {
         val config = AwsSigningConfig {

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedByteReadChannelTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedByteReadChannelTestBase.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.auth.awssigning.tests
 import aws.smithy.kotlin.runtime.auth.awssigning.*
 import aws.smithy.kotlin.runtime.auth.awssigning.internal.CHUNK_SIZE_BYTES
 import aws.smithy.kotlin.runtime.io.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
@@ -17,7 +16,6 @@ import kotlin.random.Random
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class AwsChunkedByteReadChannelTestBase : AwsChunkedTestBase(AwsChunkedReaderFactory.Channel) {
     @Test
     fun testSlowProducerMultipleChunksPartialLast(): TestResult = runTest {

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/AwsChunkedTestBase.kt
@@ -11,7 +11,6 @@ import aws.smithy.kotlin.runtime.http.DeferredHeaders
 import aws.smithy.kotlin.runtime.http.toHeaders
 import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -53,7 +52,6 @@ fun AwsChunkedReaderFactory.create(
     previousSignature: ByteArray,
 ): AwsChunkedTestReader = create(data, signer, signingConfig, previousSignature, DeferredHeaders.Empty)
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class AwsChunkedTestBase(
     val factory: AwsChunkedReaderFactory,
 ) : HasSigner {

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
@@ -16,7 +16,6 @@ import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -47,7 +46,6 @@ private const val EXPECTED_FINAL_CHUNK_SIGNATURE = "b6c6ea8a5354eaf15b3cb7646744
 private val EMPTY_BYTES = byteArrayOf()
 
 @Suppress("HttpUrlsUsage")
-@OptIn(ExperimentalCoroutinesApi::class)
 public abstract class BasicSigningTestBase : HasSigner {
     private val defaultSigningConfig = AwsSigningConfig {
         region = "us-east-1"

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -26,7 +26,6 @@ import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -40,7 +39,6 @@ class CrtAwsHttpSignerTest : AwsHttpSignerTestBase(CrtAwsSigner)
  * test suite in the `aws-signing-tests` module.
  */
 @Suppress("HttpUrlsUsage")
-@OptIn(ExperimentalCoroutinesApi::class)
 public abstract class AwsHttpSignerTestBase(
     private val signer: AwsSigner,
 ) {

--- a/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChainTest.kt
+++ b/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenProviderChainTest.kt
@@ -8,12 +8,10 @@ package aws.smithy.kotlin.runtime.http.auth
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class BearerTokenProviderChainTest {
     private class TestTokenProvider(val token: String? = null) : BearerTokenProvider {
         override suspend fun resolve(attributes: Attributes): BearerToken =

--- a/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenSignerTest.kt
+++ b/runtime/auth/http-auth/common/test/aws/smithy/kotlin/runtime/http/auth/BearerTokenSignerTest.kt
@@ -11,13 +11,11 @@ import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class BearerTokenSignerTest {
     @Test
     fun testAuthorizationHeader() = runTest {

--- a/runtime/auth/identity-api/common/test/aws/smithy/kotlin/runtime/identity/IdentityProviderChainTest.kt
+++ b/runtime/auth/identity-api/common/test/aws/smithy/kotlin/runtime/identity/IdentityProviderChainTest.kt
@@ -9,14 +9,12 @@ import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.emptyAttributes
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class IdentityProviderChainTest {
 
     private class TestChain(vararg providers: IdentityProvider) : IdentityProviderChain<IdentityProvider, Identity>(*providers)

--- a/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStreamTest.kt
+++ b/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/ReadChannelBodyStreamTest.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -21,7 +20,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ReadChannelBodyStreamTest {
     private fun mutableBuffer(capacity: Int): Pair<MutableBuffer, ByteArray> {
         val dest = ByteArray(capacity)

--- a/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStreamTest.kt
+++ b/runtime/crt-util/common/test/aws/smithy/kotlin/runtime/crt/SdkSourceBodyStreamTest.kt
@@ -9,14 +9,12 @@ import aws.sdk.kotlin.crt.io.MutableBuffer
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.source
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkSourceBodyStreamTest {
     private fun mutableBuffer(capacity: Int): Pair<MutableBuffer, ByteArray> {
         val dest = ByteArray(capacity)

--- a/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
+++ b/runtime/observability/telemetry-api/common/test/aws/smithy/kotlin/runtime/telemetry/logging/TestLoggingContext.kt
@@ -5,12 +5,10 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TestLoggingContext {
     @Test
     fun testWithLogCtx() = runTest {

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningTest.kt
@@ -16,14 +16,12 @@ import aws.smithy.kotlin.runtime.time.ManualClock
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.encodeToHex
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class EventStreamSigningTest {
     private val testCredentials = Credentials("fake access key", "fake secret key")
     private val testCredentialsProvider = object : CredentialsProvider {

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameDecoderTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameDecoderTest.kt
@@ -7,14 +7,12 @@ package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
 import aws.smithy.kotlin.runtime.io.*
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FrameDecoderTest {
 
     @Test

--- a/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameEncoderTest.kt
+++ b/runtime/protocol/aws-event-stream/common/test/aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameEncoderTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.awsprotocol.eventstream
 
 import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.io.SdkBuffer
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -16,7 +15,6 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FrameEncoderTest {
     @Test
     fun testEncode() = runTest {

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
@@ -13,12 +13,10 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AwsJsonProtocolTest {
 
     @Test

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.awsprotocol.json
 
 import aws.smithy.kotlin.runtime.http.Headers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,7 +12,6 @@ import kotlin.test.assertEquals
 @Suppress("HttpUrlsUsage")
 class RestJsonErrorDeserializerTest {
 
-    @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
     @Test
     fun `it deserializes aws restJson error codes`() = runTest {
         val tests = listOf(
@@ -64,7 +62,6 @@ class RestJsonErrorDeserializerTest {
         }
     }
 
-    @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
     @Test
     fun `it deserializes aws restJson error codes using right location check order`() = runTest {
         // Checking for header code return
@@ -112,7 +109,6 @@ class RestJsonErrorDeserializerTest {
         assertEquals("BodyCode", RestJsonErrorDeserializer.deserialize(headers, payload).code)
     }
 
-    @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
     @Test
     fun `it deserializes aws restJson error messages`() = runTest {
         val expected = "one ring to rule bring them all, and in the darkness bind them"

--- a/runtime/protocol/aws-xml-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/xml/Ec2QueryErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-xml-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/xml/Ec2QueryErrorDeserializerTest.kt
@@ -5,14 +5,12 @@
 package aws.smithy.kotlin.runtime.awsprotocol.xml
 
 import aws.smithy.kotlin.runtime.serde.DeserializationException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class Ec2QueryErrorDeserializerTest {
     @Test
     fun `it deserializes ec2Query errors`() = runTest {

--- a/runtime/protocol/aws-xml-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/xml/RestXmlErrorDeserializerTest.kt
+++ b/runtime/protocol/aws-xml-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/xml/RestXmlErrorDeserializerTest.kt
@@ -5,11 +5,9 @@
 package aws.smithy.kotlin.runtime.awsprotocol.xml
 
 import aws.smithy.kotlin.runtime.serde.DeserializationException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RestXmlErrorDeserializerTest {
 
     @Test

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandler.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.CoroutineContext
  * Implements the CRT stream response interface which proxies the response from the CRT to the SDK
  * @param conn The HTTP connection used to make the request. Will be closed when the response handler completes
  */
-@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 internal class SdkStreamResponseHandler(
     private val conn: HttpClientConnection,
     private val callContext: CoroutineContext,
@@ -80,7 +80,6 @@ internal class SdkStreamResponseHandler(
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun createHttpResponseBody(contentLength: Long?): HttpBody {
         val ch = SdkByteChannel(true)
         val writerContext = callContext + callContext.derivedName("response-body-writer")

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/SdkStreamResponseHandlerTest.kt
@@ -15,13 +15,11 @@ import aws.smithy.kotlin.runtime.io.SdkSink
 import aws.smithy.kotlin.runtime.io.readAll
 import aws.smithy.kotlin.runtime.io.readToBuffer
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkStreamResponseHandlerTest {
 
     private class MockHttpStream(override val responseStatusCode: Int) : HttpStream {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/AsyncStressTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/AsyncStressTest.kt
@@ -19,7 +19,6 @@ import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -27,7 +26,6 @@ import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AsyncStressTest : TestWithLocalServer() {
 
     override val server = embeddedServer(CIO, serverPort) {

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
@@ -10,11 +10,9 @@ import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.readToByteArray
 import aws.smithy.kotlin.runtime.io.source
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SendChunkedBodyTest {
     private class MockHttpStream(override val responseStatusCode: Int) : HttpStream {
         var closed: Boolean = false

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class OkHttpResponseTest {
 
     private val testMetrics = HttpClientMetrics("test", TelemetryProvider.None)

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class StreamingRequestBodyTest {
     @Test
     fun testWriteTo() = runTest {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -34,7 +34,6 @@ import aws.smithy.kotlin.runtime.telemetry.metrics.measureSeconds
 import aws.smithy.kotlin.runtime.util.attributesOf
 import aws.smithy.kotlin.runtime.util.merge
 import kotlin.coroutines.coroutineContext
-import kotlin.time.ExperimentalTime
 import aws.smithy.kotlin.runtime.io.middleware.decorate as decorateHandler
 
 @InternalApi
@@ -262,7 +261,6 @@ internal class AuthHandler<Input, Output>(
     private val endpointResolver: EndpointResolver? = null,
 ) : Handler<SdkHttpRequest, Output> {
 
-    @OptIn(ExperimentalTime::class)
     override suspend fun call(request: SdkHttpRequest): Output {
         // select an auth scheme by reconciling the (priority) list of candidates returned from the resolver
         // with the ones actually configured/available for the SDK

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptorTest.kt
@@ -13,14 +13,12 @@ import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.fail
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ContinueInterceptorTest {
     private fun context(request: HttpRequest) = object : ProtocolRequestInterceptorContext<Any, HttpRequest> {
         override val protocolRequest: HttpRequest = request

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/DiscoveredEndpointErrorInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/DiscoveredEndpointErrorInterceptorTest.kt
@@ -13,11 +13,9 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DiscoveredEndpointErrorInterceptorTest {
     @Test
     fun testCacheInvalidation() = runTest {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -19,11 +19,9 @@ import aws.smithy.kotlin.runtime.io.*
 import aws.smithy.kotlin.runtime.util.encodeBase64String
 import aws.smithy.kotlin.runtime.util.get
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FlexibleChecksumsRequestInterceptorTest {
     private val client = SdkHttpClient(TestEngine())
 
@@ -145,7 +143,7 @@ class FlexibleChecksumsRequestInterceptorTest {
         expectedHash.update(byteArray)
 
         assertTrue(completableDeferred.isCompleted)
-        assertEquals(expectedHash.digest().encodeBase64String(), completableDeferred.getCompleted())
+        assertEquals(expectedHash.digest().encodeBase64String(), completableDeferred.await())
     }
 
     @Test
@@ -167,7 +165,7 @@ class FlexibleChecksumsRequestInterceptorTest {
         expectedHash.update(byteArray)
 
         assertTrue(completableDeferred.isCompleted)
-        assertEquals(expectedHash.digest().encodeBase64String(), completableDeferred.getCompleted())
+        assertEquals(expectedHash.digest().encodeBase64String(), completableDeferred.await())
     }
 
     @Test

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptorTest.kt
@@ -17,7 +17,6 @@ import aws.smithy.kotlin.runtime.io.source
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
@@ -41,7 +40,6 @@ inline fun <reified I> newTestOperation(serialized: HttpRequestBuilder): SdkHttp
         }
     }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FlexibleChecksumsResponseInterceptorTest {
 
     private val response = "abc".repeat(1024).toByteArray()

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/Md5ChecksumInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/Md5ChecksumInterceptorTest.kt
@@ -15,13 +15,11 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class Md5ChecksumInterceptorTest {
     private val client = SdkHttpClient(TestEngine())
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponseTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponseTest.kt
@@ -15,13 +15,11 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultValidateResponseTest {
     @Test
     fun itThrowsExceptionOnNon200Response() = runTest {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/MutateHeadersTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/MutateHeadersTest.kt
@@ -13,12 +13,10 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.headers
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MutateHeadersTest {
     private val client = SdkHttpClient(TestEngine())
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
@@ -16,12 +16,10 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RetryMiddlewareTest {
     private val client = SdkHttpClient(TestEngine())
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/AuthHandlerTest.kt
@@ -23,13 +23,11 @@ import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.attributesOf
 import aws.smithy.kotlin.runtime.util.get
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpAuthHandlerTest {
     private val testAttrKey = AttributeKey<String>("HttpAuthHandlerTest")
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorOrderTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorOrderTest.kt
@@ -10,11 +10,9 @@ import aws.smithy.kotlin.runtime.http.interceptors.HttpInterceptor
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.collections.shouldNotContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@ExperimentalCoroutinesApi
 class HttpInterceptorOrderTest {
     private val allHooks = listOf(
         "readBeforeExecution",

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTest.kt
@@ -13,7 +13,6 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.toBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.http.response.copy
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.IllegalStateException
 import kotlin.test.*
@@ -26,7 +25,6 @@ import kotlin.test.*
  * 2. Write only hook that modifies at every chance possible
  * 3. Read only observer hook that asserts any modified value
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpInterceptorTest {
 
     class TestWriteHook : HttpInterceptor {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTypeValidationTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/HttpInterceptorTypeValidationTest.kt
@@ -11,12 +11,10 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.IllegalStateException
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpInterceptorTypeValidationTest {
     @Test
     fun testModifyBeforeSerializationTypeFailure() = runTest {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/OperationEndpointTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/OperationEndpointTest.kt
@@ -11,12 +11,10 @@ import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class OperationEndpointTest {
     @Test
     fun testHostIsSet() = runTest {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecutionTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecutionTest.kt
@@ -20,14 +20,12 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkOperationExecutionTest {
 
     @Test

--- a/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
+++ b/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
@@ -10,13 +10,11 @@ import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.net.Host
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TestConnectionTest {
     @Test
     fun testAssertRequestsSuccess() = runTest {

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpBodyTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpBodyTest.kt
@@ -10,7 +10,6 @@ import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.SdkByteChannel
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.writeAll
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,7 +17,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpBodyTest {
     @Test
     fun testFromByteStreamBytes() {

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/HttpRequestBuilderTest.kt
@@ -18,13 +18,11 @@ import aws.smithy.kotlin.runtime.net.Host
 import aws.smithy.kotlin.runtime.net.QueryParameters
 import aws.smithy.kotlin.runtime.net.Scheme
 import aws.smithy.kotlin.runtime.net.Url
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpRequestBuilderTest {
     @Test
     fun itBuilds() {

--- a/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
+++ b/runtime/protocol/http/common/test/aws/smithy/kotlin/runtime/http/response/HttpResponseTest.kt
@@ -11,7 +11,6 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,7 +18,6 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class HttpResponseTest {
     @Test
     fun testProtocolResponseExtensions() {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.content
  * Container for wrapping a String as a [ByteStream]
  */
 public class StringContent(str: String) : ByteStream.Buffer() {
-    @OptIn(ExperimentalStdlibApi::class)
     private val asBytes: ByteArray = str.encodeToByteArray()
 
     override val contentLength: Long = asBytes.size.toLong()

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Base64.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Base64.kt
@@ -46,13 +46,11 @@ private fun base64DecodedLen(encoded: ByteArray): Int {
 /**
  * Encode [String] in base64 format and UTF-8 character encoding.
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun String.encodeBase64(): String = encodeToByteArray().encodeBase64().decodeToString()
 
 /**
  * Encode [ByteArray] in base64 format and UTF-8 character encoding as a [String].
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun ByteArray.encodeBase64String(): String = encodeBase64().decodeToString()
 
 /**
@@ -90,13 +88,11 @@ public fun ByteArray.encodeBase64(): ByteArray {
 /**
  * Decode [String] from base64 format
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun String.decodeBase64(): String = decodeBase64Bytes().decodeToString()
 
 /**
  * Decode [String] from base64 format to a [ByteArray]
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun String.decodeBase64Bytes(): ByteArray = encodeToByteArray().decodeBase64()
 
 /**

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/HashingByteReadChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/HashingByteReadChannelTest.kt
@@ -11,7 +11,6 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class HashingByteReadChannelTest {
 
     private val hashFunctionNames = listOf("crc32", "crc32c", "md5", "sha1", "sha256")

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/HashingSourceTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/HashingSourceTest.kt
@@ -9,7 +9,6 @@ import aws.smithy.kotlin.runtime.hashing.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class HashingSourceTest {
 
     private val hashFunctionNames = listOf("crc32", "crc32c", "md5", "sha1", "sha256")

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/JobChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/JobChannelTest.kt
@@ -6,14 +6,12 @@
 package aws.smithy.kotlin.runtime.io
 
 import aws.smithy.kotlin.runtime.io.internal.JobChannel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class JobChannelTest {
     @Test
     fun testClose() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelSuspendTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelSuspendTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkByteChannelSuspendTest : ManualDispatchTestBase() {
     private val ch = SdkByteChannel()
 

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/SdkByteChannelTest.kt
@@ -5,13 +5,11 @@
 
 package aws.smithy.kotlin.runtime.io
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkByteChannelTest {
     @Test
     fun testCreateAndClose() {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/middleware/MiddlewareTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/middleware/MiddlewareTest.kt
@@ -6,12 +6,10 @@
 package aws.smithy.kotlin.runtime.io.middleware
 
 import aws.smithy.kotlin.runtime.io.Handler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class MiddlewareTest {
 
     @Test

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/middleware/PhaseTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/io/middleware/PhaseTest.kt
@@ -6,12 +6,10 @@
 package aws.smithy.kotlin.runtime.io.middleware
 
 import aws.smithy.kotlin.runtime.io.Handler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class PhaseTest {
     @Test
     fun `it orders interceptors`() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/StandardRetryStrategyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/StandardRetryStrategyTest.kt
@@ -11,11 +11,9 @@ import aws.smithy.kotlin.runtime.retries.delay.RetryTokenBucket
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class StandardRetryStrategyTest {
     @Test
     fun testInitialSuccess() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitterTest.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.retries.delay
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -14,7 +13,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ExponentialBackoffWithJitterTest {
     @Test
     fun testScaling() = runTest {
@@ -54,7 +52,6 @@ class ExponentialBackoffWithJitterTest {
     }
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 private suspend fun TestScope.backoffSeries(times: Int, delayer: ExponentialBackoffWithJitter): List<Int> =
     (1..times)
         .map { idx -> measure { delayer.backoff(idx) } }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -22,7 +22,7 @@ import kotlin.time.TimeSource
 private const val DEFAULT_RETRY_COST = 2
 private const val DEFAULT_TIMEOUT_RETRY_COST = 3
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+@OptIn(ExperimentalTime::class)
 class StandardRetryTokenBucketTest {
     @Test
     fun testWaitForCapacity() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/CachedValueTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/CachedValueTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class CachedValueTest {
     @Test
     fun testNull() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/LazyAsyncValueTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/LazyAsyncValueTest.kt
@@ -5,12 +5,10 @@
 
 package aws.smithy.kotlin.runtime.util
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class LazyAsyncValueTest {
     @Test
     fun testLoadOnce() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/ReadThroughCacheTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/ReadThroughCacheTest.kt
@@ -5,14 +5,12 @@
 package aws.smithy.kotlin.runtime.util
 
 import aws.smithy.kotlin.runtime.time.ManualClock
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ReadThroughCacheTest {
     @Test
     fun testReadThrough() = runTest {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/UuidTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/util/UuidTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@ExperimentalUnsignedTypes
 class UuidTest {
     @Test
     fun `it should generate random UUIDs`() {

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/io/FileSourceTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/io/FileSourceTest.kt
@@ -7,13 +7,11 @@ package aws.smithy.kotlin.runtime.io
 
 import aws.smithy.kotlin.runtime.testing.RandomTempFile
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FileSourceTest {
     @Test
     fun testStartPositionValidation() = runTest {

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/io/SdkSourceExtensionsTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/io/SdkSourceExtensionsTest.kt
@@ -7,16 +7,13 @@ package aws.smithy.kotlin.runtime.io
 
 import aws.smithy.kotlin.runtime.io.internal.JobChannel
 import aws.smithy.kotlin.runtime.testing.RandomTempFile
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import java.util.concurrent.CancellationException
 import kotlin.test.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class SdkSourceExtensionsTest {
     @Test
     fun testReadToByteArray() = runTest {

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.math.abs
 import kotlin.test.*
 
-@OptIn(ExperimentalStdlibApi::class)
 class JsonDeserializerTest {
     @Test
     fun itHandlesDoubles() {

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
@@ -12,7 +12,6 @@ import kotlin.test.assertEquals
 
 private val testAnonObjDescriptor = SdkObjectDescriptor.build { }
 
-@OptIn(ExperimentalStdlibApi::class)
 class JsonSerializerTest {
 
     @Test

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonStreamWriterTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonStreamWriterTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalStdlibApi::class)
 class JsonStreamWriterTest {
     @Test
     fun testArrayOfObjects() {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerAWSTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerAWSTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerAWSTest {
 
     class HostedZoneConfig private constructor(builder: Builder) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerListTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerListTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerListTest {
 
     class ListDeserializer private constructor(builder: BuilderImpl) {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerMapTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerMapTest.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.serde.*
 import io.kotest.matchers.maps.shouldContainExactly
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerMapTest {
 
     @Test

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerNamespaceTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerNamespaceTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 // See https://awslabs.github.io/smithy/spec/xml.html#xmlname-trait
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerNamespaceTest {
 
     @Test

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerPrimitiveTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerPrimitiveTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerPrimitiveTest {
     @Test
     fun itHandlesDoubles() {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerStructTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlDeserializerStructTest.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.serde.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlDeserializerStructTest {
     @Test
     fun `it handles basic structs with attribs`() {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlSerializerTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlSerializerTest.kt
@@ -27,7 +27,6 @@ private fun String.toXmlCompactString(): String =
         .replace("\n", "")
         .replace(Regex(">\\s+"), ">")
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlSerializerTest {
 
     @Test

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.serde.xml
 import aws.smithy.kotlin.runtime.serde.DeserializationException
 import kotlin.test.*
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlStreamReaderTest {
     @Test
     fun itDeserializesXml() {

--- a/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
+++ b/runtime/serde/serde-xml/common/test/aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.serde.xml
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalStdlibApi::class)
 class XmlStreamWriterTest {
 
     @Test

--- a/runtime/smithy-client/common/test/aws/smithy/kotlin/runtime/client/config/LogModeClientSettingTest.kt
+++ b/runtime/smithy-client/common/test/aws/smithy/kotlin/runtime/client/config/LogModeClientSettingTest.kt
@@ -9,13 +9,11 @@ import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.client.LogMode
 import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.util.TestPlatformProvider
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class LogModeClientSettingTest {
 
     @Test

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
@@ -2,8 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-@file:OptIn(ExperimentalCoroutinesApi::class)
-
 package aws.smithy.kotlin.runtime.smithy.test
 
 import aws.smithy.kotlin.runtime.http.HeadersBuilder
@@ -14,7 +12,6 @@ import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.util.text.urlEncodeComponent
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.assertEquals
@@ -87,7 +84,6 @@ public fun httpRequestTest(block: HttpRequestTestBuilder.() -> Unit): TestResult
     assertRequest(testBuilder.expected.build(), actual)
 }
 
-@OptIn(ExperimentalStdlibApi::class)
 private suspend fun assertRequest(expected: ExpectedHttpRequest, actual: HttpRequest) {
     // run the assertions
     assertEquals(expected.method, actual.method, "expected method: `${expected.method}`; got: `${actual.method}`")

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTest.kt
@@ -13,7 +13,6 @@ import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
@@ -75,7 +74,6 @@ public class HttpResponseTestBuilder<T> {
  * }
  * ```
  */
-@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
 public fun <T> httpResponseTest(block: HttpResponseTestBuilder<T>.() -> Unit): TestResult = runTest {
     val testBuilder = HttpResponseTestBuilder<T>().apply(block)
 

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/Utils.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/Utils.kt
@@ -14,13 +14,11 @@ import kotlin.test.fail
  * Convenience method for (test) code generation so that it doesn't have to deal
  * with opt-in requirements
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun String.encodeAsByteArray(): ByteArray = encodeToByteArray()
 
 /**
  * Assert that the [actual] body is empty
  */
-@OptIn(ExperimentalStdlibApi::class)
 public suspend fun assertEmptyBody(@Suppress("UNUSED_PARAMETER") expected: HttpBody?, actual: HttpBody?) {
     if (actual !is HttpBody.Empty) {
         val actualBody = actual?.readAll()?.decodeToString()
@@ -31,7 +29,6 @@ public suspend fun assertEmptyBody(@Suppress("UNUSED_PARAMETER") expected: HttpB
 /**
  * Assert that [actual] == [expected]
  */
-@OptIn(ExperimentalStdlibApi::class)
 public suspend fun assertBytesEqual(expected: HttpBody?, actual: HttpBody?) {
     val actualRead = actual?.readAll()
     val expectedRead = expected?.readAll()
@@ -41,7 +38,6 @@ public suspend fun assertBytesEqual(expected: HttpBody?, actual: HttpBody?) {
 /**
  * Assert that [actual] == [expected]
  */
-@OptIn(ExperimentalStdlibApi::class)
 public fun assertBytesEqual(expected: ByteArray?, actual: ByteArray?) {
     if (expected == null) {
         assertNull(actual, "expected no content; found ${actual?.decodeToString()}")

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTestBuilderTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpResponseTestBuilderTest.kt
@@ -15,7 +15,6 @@ class HttpResponseTestBuilderTest {
     private data class Foo(val bar: Int, val baz: String)
 
     @Test
-    @OptIn(ExperimentalStdlibApi::class)
     fun itBuildsResponses() {
         httpResponseTest<Foo> {
             expected {

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/UtilsTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/UtilsTest.kt
@@ -7,12 +7,10 @@ package aws.smithy.kotlin.runtime.smithy.test
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFails
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UtilsTest {
 
     private val testBodyContents = "bueller...bueller".encodeAsByteArray()

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/XmlAssertionsTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/XmlAssertionsTest.kt
@@ -7,13 +7,11 @@ package aws.smithy.kotlin.runtime.smithy.test
 
 import aws.smithy.kotlin.runtime.serde.xml.dom.XmlNode
 import aws.smithy.kotlin.runtime.serde.xml.dom.toXmlString
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class XmlAssertionsTest {
 
     @Test

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/ManualDispatchTestBase.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/ManualDispatchTestBase.kt
@@ -5,7 +5,6 @@
 
 package aws.smithy.kotlin.runtime.testing
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
@@ -39,7 +38,6 @@ import kotlin.test.assertNotEquals
  *
  * Explicitly yielding or hitting a natural suspension point will run the next continuation queued
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 public abstract class ManualDispatchTestBase {
     private var current = 0
 


### PR DESCRIPTION
## Issue \#

Related to https://github.com/awslabs/aws-sdk-kotlin/issues/860

## Description of changes

This change removes some now-unnecessary opt-ins for experimental annotations. No functional change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
