### PR TITLE
feat: add type function to JMESPath visitor

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -165,6 +165,7 @@ object RuntimeTypes {
             val truthiness = symbol("truthiness")
             val urlEncodeComponent = symbol("urlEncodeComponent", "text")
             val toNumber = symbol("toNumber")
+            val type = symbol("type")
         }
 
         object Net : RuntimeTypePackage(KotlinDependency.CORE, "net") {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/waiters/KotlinJmespathExpressionVisitor.kt
@@ -224,9 +224,9 @@ class KotlinJmespathExpressionVisitor(
         expr: String,
         elvisExpr: String? = null,
         isObject: Boolean = false,
-        enforceNullGuard: Boolean = true,
+        ensureNullGuard: Boolean = true,
     ): VisitedExpression {
-        val dotFunctionExpr = if (enforceNullGuard) ensureNullGuard(shape, expr, elvisExpr) else ".$expr"
+        val dotFunctionExpr = if (ensureNullGuard) ensureNullGuard(shape, expr, elvisExpr) else ".$expr"
         val ident = addTempVar(expression.name.toCamelCase(), "$identifier$dotFunctionExpr")
 
         shape?.let { shapeCursor.addLast(shape) }
@@ -331,7 +331,7 @@ class KotlinJmespathExpressionVisitor(
         "type" -> {
             writer.addImport(RuntimeTypes.Core.Utils.type)
             val arg = expression.singleArg()
-            arg.dotFunction(expression, "type()", enforceNullGuard = false)
+            arg.dotFunction(expression, "type()", ensureNullGuard = false)
         }
 
         else -> throw CodegenException("Unknown function type in $expression")

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
@@ -68,7 +68,7 @@ public fun Any?.type(): String = when (this) {
     is Boolean -> "boolean"
     is List<*>, is Array<*> -> "array"
     is Short, is Int, is Long, is Float, is Double -> "number"
-    is HashMap<*, *>, is Any -> "object"
+    is Any -> "object"
     null -> "null"
     else -> throw Exception("Undetected type for: $this")
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
@@ -56,3 +56,19 @@ public inline fun <reified T> Collection<Collection<T>>.flattenIfPossible(): Col
 @InternalApi
 public val <T> Collection<T>.length: Int
     get() = size
+
+/**
+ * Returns a JS type as a string
+ *
+ * See: [JMESPath spec](https://jmespath.org/specification.html#type)
+ */
+@InternalApi
+public fun Any?.type(): String = when (this) {
+    is String -> "string"
+    is Boolean -> "boolean"
+    is List<*>, is Array<*> -> "array"
+    is Short, is Int, is Long, is Float, is Double -> "number"
+    is HashMap<*, *>, is Any -> "object"
+    null -> "null"
+    else -> throw Exception("Undetected type for: $this")
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/JMESPath.kt
@@ -67,7 +67,7 @@ public fun Any?.type(): String = when (this) {
     is String -> "string"
     is Boolean -> "boolean"
     is List<*>, is Array<*> -> "array"
-    is Short, is Int, is Long, is Float, is Double -> "number"
+    is Number -> "number"
     is Any -> "object"
     null -> "null"
     else -> throw Exception("Undetected type for: $this")

--- a/tests/codegen/waiter-tests/model/function-type.smithy
+++ b/tests/codegen/waiter-tests/model/function-type.smithy
@@ -1,0 +1,169 @@
+$version: "2"
+namespace com.test
+
+use smithy.waiters#waitable
+
+@suppress(["WaitableTraitJmespathProblem"])
+@waitable(
+    TypeFunctionStringEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.string) == types.string",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionBooleanEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.boolean) == types.boolean",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionArrayEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(lists.booleans) == types.array",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionShortEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.short) == types.number",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionIntegerEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.integer) == types.number",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionLongEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.long) == types.number",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionFloatEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.float) == types.number",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionDoubleEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.double) == types.number",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionObjectEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives) == types.objectType",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionMergedObjectEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(merge(primitives, primitives)) == types.objectType",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+    TypeFunctionNullEquals: {
+        acceptors: [
+            {
+                state: "success",
+                matcher: {
+                    output: {
+                        path: "type(primitives.boolean) == types.nullType",
+                        expected: "true",
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    },
+)
+@readonly
+@http(method: "GET", uri: "/type/{name}", code: 200)
+operation GetFunctionTypeEquals {
+    input: GetEntityRequest,
+    output: GetEntityResponse,
+    errors: [NotFound],
+}

--- a/tests/codegen/waiter-tests/model/function-type.smithy
+++ b/tests/codegen/waiter-tests/model/function-type.smithy
@@ -11,9 +11,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.string) == types.string",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.string)",
+                        expected: "string",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -25,9 +25,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.boolean) == types.boolean",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.boolean)",
+                        expected: "boolean",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -39,9 +39,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(lists.booleans) == types.array",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(lists.booleans)",
+                        expected: "array",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -53,9 +53,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.short) == types.number",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.short)",
+                        expected: "number",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -67,9 +67,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.integer) == types.number",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.integer)",
+                        expected: "number",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -81,9 +81,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.long) == types.number",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.long)",
+                        expected: "number",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -95,9 +95,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.float) == types.number",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.float)",
+                        expected: "number",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -109,9 +109,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.double) == types.number",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.double)",
+                        expected: "number",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -123,9 +123,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives) == types.objectType",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives)",
+                        expected: "object",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -137,9 +137,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(merge(primitives, primitives)) == types.objectType",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(merge(primitives, primitives))",
+                        expected: "object",
+                        comparator: "stringEquals"
                     }
                 }
             }
@@ -151,9 +151,9 @@ use smithy.waiters#waitable
                 state: "success",
                 matcher: {
                     output: {
-                        path: "type(primitives.boolean) == types.nullType",
-                        expected: "true",
-                        comparator: "booleanEquals"
+                        path: "type(primitives.boolean)",
+                        expected: "null",
+                        comparator: "stringEquals"
                     }
                 }
             }

--- a/tests/codegen/waiter-tests/model/utils/structures.smithy
+++ b/tests/codegen/waiter-tests/model/utils/structures.smithy
@@ -21,6 +21,7 @@ structure GetEntityResponse {
     sampleValues: Values,
     objectOne: Values,
     objectTwo: Values,
+    types: Types,
 }
 
 structure EntityPrimitives {
@@ -171,4 +172,13 @@ structure Values {
     valueOne: String
     valueTwo: String
     valueThree: String
+}
+
+structure Types {
+    string: String
+    boolean: String
+    array: String
+    number: String
+    objectType: String
+    nullType: String
 }

--- a/tests/codegen/waiter-tests/model/utils/structures.smithy
+++ b/tests/codegen/waiter-tests/model/utils/structures.smithy
@@ -21,7 +21,6 @@ structure GetEntityResponse {
     sampleValues: Values,
     objectOne: Values,
     objectTwo: Values,
-    types: Types,
 }
 
 structure EntityPrimitives {
@@ -172,13 +171,4 @@ structure Values {
     valueOne: String
     valueTwo: String
     valueThree: String
-}
-
-structure Types {
-    string: String
-    boolean: String
-    array: String
-    number: String
-    objectType: String
-    nullType: String
 }

--- a/tests/codegen/waiter-tests/model/utils/waiter-operations.smithy
+++ b/tests/codegen/waiter-tests/model/utils/waiter-operations.smithy
@@ -30,5 +30,6 @@ service WaitersTestService {
         GetFunctionToArrayEquals,
         GetFunctionToStringEquals,
         GetFunctionToNumberEquals,
+        GetFunctionTypeEquals,
     ]
 }

--- a/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
+++ b/tests/codegen/waiter-tests/src/main/kotlin/com/test/DefaultWaitersTestClient.kt
@@ -72,6 +72,8 @@ class DefaultWaitersTestClient<T>(resultList: List<Result<T>>) : WaitersTestClie
 
     override suspend fun getFunctionToNumberEquals(input: GetFunctionToNumberEqualsRequest): GetFunctionToNumberEqualsResponse = findSuccess()
 
+    override suspend fun getFunctionTypeEquals(input: GetFunctionTypeEqualsRequest): GetFunctionTypeEqualsResponse = findSuccess()
+
     private fun <Response> findSuccess(): Response {
         val nextResult = results.next()
         @Suppress("UNCHECKED_CAST")

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.test
+
+import com.test.model.*
+import com.test.utils.successTest
+import com.test.waiters.*
+import org.junit.jupiter.api.Test
+
+class FunctionTypeTest {
+    @Test fun testTypeFunctionStringEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionStringEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { string = "foo" }
+            types = Types { string = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { string = "foo" }
+            types = Types { string = "string" }
+        },
+    )
+
+    @Test fun testTypeFunctionBooleanEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionBooleanEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { boolean = true }
+            types = Types { boolean = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { boolean = true }
+            types = Types { boolean = "boolean" }
+        },
+    )
+
+    @Test fun testTypeFunctionArrayEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionArrayEquals,
+        GetFunctionTypeEqualsResponse {
+            lists = EntityLists { booleans = listOf(true) }
+            types = Types { array = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            lists = EntityLists { booleans = listOf(true) }
+            types = Types { array = "array" }
+        },
+    )
+
+    @Test fun testTypeFunctionShortEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionShortEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { short = 1 }
+            types = Types { number = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { short = 1 }
+            types = Types { number = "number" }
+        },
+    )
+
+    @Test fun testTypeFunctionIntegerEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionIntegerEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { integer = 1 }
+            types = Types { number = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { integer = 1 }
+            types = Types { number = "number" }
+        },
+    )
+
+    @Test fun testTypeFunctionLongEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionLongEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { long = 1L }
+            types = Types { number = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { long = 1L }
+            types = Types { number = "number" }
+        },
+    )
+
+    @Test fun testTypeFunctionFloatEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionFloatEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { float = 1f }
+            types = Types { number = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { float = 1f }
+            types = Types { number = "number" }
+        },
+    )
+
+    @Test fun testTypeFunctionDoubleEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionDoubleEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { double = 1.0 }
+            types = Types { number = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { double = 1.0 }
+            types = Types { number = "number" }
+        },
+    )
+
+    @Test fun testTypeFunctionObjectEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionObjectEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { }
+            types = Types { objectType = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { }
+            types = Types { objectType = "object" }
+        },
+    )
+
+    @Test fun testTypeFunctionMergedObjectEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionMergedObjectEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { }
+            types = Types { objectType = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { }
+            types = Types { objectType = "object" }
+        },
+    )
+
+    @Test fun testTypeFunctionNullEquals() = successTest(
+        GetFunctionTypeEqualsRequest { name = "test" },
+        WaitersTestClient::waitUntilTypeFunctionNullEquals,
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { boolean = null }
+            types = Types { nullType = "foo" }
+        },
+        GetFunctionTypeEqualsResponse {
+            primitives = EntityPrimitives { boolean = null }
+            types = Types { nullType = "null" }
+        },
+    )
+}

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
@@ -8,7 +8,7 @@ package com.test
 import com.test.model.*
 import com.test.utils.successTest
 import com.test.waiters.*
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 class FunctionTypeTest {
     @Test fun testTypeFunctionStringEquals() = successTest(

--- a/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
+++ b/tests/codegen/waiter-tests/src/test/kotlin/com/test/FunctionTypeTest.kt
@@ -5,7 +5,10 @@
 
 package com.test
 
-import com.test.model.*
+import com.test.model.EntityLists
+import com.test.model.EntityPrimitives
+import com.test.model.GetFunctionTypeEqualsRequest
+import com.test.model.GetFunctionTypeEqualsResponse
 import com.test.utils.successTest
 import com.test.waiters.*
 import kotlin.test.Test
@@ -16,11 +19,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionStringEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { string = "foo" }
-            types = Types { string = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { string = "foo" }
-            types = Types { string = "string" }
         },
     )
 
@@ -29,11 +27,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionBooleanEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { boolean = true }
-            types = Types { boolean = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { boolean = true }
-            types = Types { boolean = "boolean" }
         },
     )
 
@@ -42,11 +35,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionArrayEquals,
         GetFunctionTypeEqualsResponse {
             lists = EntityLists { booleans = listOf(true) }
-            types = Types { array = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            lists = EntityLists { booleans = listOf(true) }
-            types = Types { array = "array" }
         },
     )
 
@@ -55,11 +43,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionShortEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { short = 1 }
-            types = Types { number = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { short = 1 }
-            types = Types { number = "number" }
         },
     )
 
@@ -68,11 +51,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionIntegerEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { integer = 1 }
-            types = Types { number = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { integer = 1 }
-            types = Types { number = "number" }
         },
     )
 
@@ -81,11 +59,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionLongEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { long = 1L }
-            types = Types { number = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { long = 1L }
-            types = Types { number = "number" }
         },
     )
 
@@ -94,11 +67,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionFloatEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { float = 1f }
-            types = Types { number = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { float = 1f }
-            types = Types { number = "number" }
         },
     )
 
@@ -107,11 +75,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionDoubleEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { double = 1.0 }
-            types = Types { number = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { double = 1.0 }
-            types = Types { number = "number" }
         },
     )
 
@@ -120,11 +83,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionObjectEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { }
-            types = Types { objectType = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { }
-            types = Types { objectType = "object" }
         },
     )
 
@@ -133,11 +91,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionMergedObjectEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { }
-            types = Types { objectType = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { }
-            types = Types { objectType = "object" }
         },
     )
 
@@ -146,11 +99,6 @@ class FunctionTypeTest {
         WaitersTestClient::waitUntilTypeFunctionNullEquals,
         GetFunctionTypeEqualsResponse {
             primitives = EntityPrimitives { boolean = null }
-            types = Types { nullType = "foo" }
-        },
-        GetFunctionTypeEqualsResponse {
-            primitives = EntityPrimitives { boolean = null }
-            types = Types { nullType = "null" }
         },
     )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
-Added `type` function to JMESPath visitor

NOTES: 
-Added flag to ignore null guards to `dotFunction` 
-Smithy's JMESPath parser won't allow string comparison so I had to get around that using the `Types` structure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
