### PR TITLE
fix: only import `transform` namespace if there are modeled operations

### DIFF
--- a/.changes/598b7088-0032-4336-8aab-3c242876301c.json
+++ b/.changes/598b7088-0032-4336-8aab-3c242876301c.json
@@ -1,0 +1,5 @@
+{
+    "id": "598b7088-0032-4336-8aab-3c242876301c",
+    "type": "bugfix",
+    "description": "Fix codegen of services with no operations"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -128,7 +128,9 @@ abstract class HttpProtocolClientGenerator(
 
     protected open fun importSymbols(writer: KotlinWriter) {
         writer.addImport("${ctx.settings.pkg.name}.model", "*")
-        writer.addImport("${ctx.settings.pkg.name}.transform", "*")
+        if (ctx.service.allOperations.isNotEmpty()) {
+            writer.addImport("${ctx.settings.pkg.name}.transform", "*")
+        }
 
         val defaultClientSymbols = setOf(
             RuntimeTypes.HttpClient.Operation.SdkHttpOperation,

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -128,7 +128,7 @@ abstract class HttpProtocolClientGenerator(
 
     protected open fun importSymbols(writer: KotlinWriter) {
         writer.addImport("${ctx.settings.pkg.name}.model", "*")
-        if (ctx.service.allOperations.isNotEmpty()) {
+        if (TopDownIndex(ctx.model).getContainedOperations(ctx.service).isNotEmpty()) {
             writer.addImport("${ctx.settings.pkg.name}.transform", "*")
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug discovered during testing of our internal preview builds. If a service does not model operations, we should not try to import from the `transform.*` namespace, because it doesn't exist.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A -- internal only

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
