### PR TITLE
refactor: cleanup public symbols and rename transform package

### DIFF
--- a/.changes/2652a0e3-6588-4542-a35d-eafd5adf8c77.json
+++ b/.changes/2652a0e3-6588-4542-a35d-eafd5adf8c77.json
@@ -1,5 +1,0 @@
-{
-    "id": "2652a0e3-6588-4542-a35d-eafd5adf8c77",
-    "type": "misc",
-    "description": "Refactor codegen to place serialization and serialization into the `serde` package rather than the `transform` package. Relocate `TlsVersion` to the `net` package. Make `ByteArrayContent` and friends `internal` and force consumers to go through companion object convenience functions."
-}

--- a/.changes/2652a0e3-6588-4542-a35d-eafd5adf8c77.json
+++ b/.changes/2652a0e3-6588-4542-a35d-eafd5adf8c77.json
@@ -1,0 +1,5 @@
+{
+    "id": "2652a0e3-6588-4542-a35d-eafd5adf8c77",
+    "type": "misc",
+    "description": "Refactor codegen to place serialization and serialization into the `serde` package rather than the `transform` package. Relocate `TlsVersion` to the `net` package. Make `ByteArrayContent` and friends `internal` and force consumers to go through companion object convenience functions."
+}

--- a/.changes/40f4af9b-316c-4d95-a4d4-9b7787feba1d.json
+++ b/.changes/40f4af9b-316c-4d95-a4d4-9b7787feba1d.json
@@ -1,0 +1,5 @@
+{
+    "id": "40f4af9b-316c-4d95-a4d4-9b7787feba1d",
+    "type": "misc",
+    "description": "Refactor codegen to place serialization and deserialization code into the `serde` package rather than the `transform` package."
+}

--- a/.changes/4a39b540-3048-4f2c-b13e-9ff6a8975896.json
+++ b/.changes/4a39b540-3048-4f2c-b13e-9ff6a8975896.json
@@ -1,0 +1,5 @@
+{
+    "id": "4a39b540-3048-4f2c-b13e-9ff6a8975896",
+    "type": "misc",
+    "description": "Relocate `TlsVersion` to the `net` package."
+}

--- a/.changes/bd8a575c-ecec-4744-bde6-44f8900d573d.json
+++ b/.changes/bd8a575c-ecec-4744-bde6-44f8900d573d.json
@@ -1,5 +1,0 @@
-{
-    "id": "bd8a575c-ecec-4744-bde6-44f8900d573d",
-    "type": "misc",
-    "description": "Refactor codegen to place serialization and serialization into the `serde` package rather than the `transform` package. Relocate `TlsVersion` to the  package. Make `ByteArrayContent` and friends `internal` and force consumers to go through companion object convenience functions."
-}

--- a/.changes/bd8a575c-ecec-4744-bde6-44f8900d573d.json
+++ b/.changes/bd8a575c-ecec-4744-bde6-44f8900d573d.json
@@ -1,0 +1,5 @@
+{
+    "id": "bd8a575c-ecec-4744-bde6-44f8900d573d",
+    "type": "misc",
+    "description": "Refactor codegen to place serialization and serialization into the `serde` package rather than the `transform` package. Relocate `TlsVersion` to the  package. Make `ByteArrayContent` and friends `internal` and force consumers to go through companion object convenience functions."
+}

--- a/.changes/ef3ee209-71da-4e92-9cf8-85b446d32bb0.json
+++ b/.changes/ef3ee209-71da-4e92-9cf8-85b446d32bb0.json
@@ -1,0 +1,5 @@
+{
+    "id": "ef3ee209-71da-4e92-9cf8-85b446d32bb0",
+    "type": "misc",
+    "description": "Make `ByteArrayContent` and friends `internal` and force consumers to go through companion object convenience functions."
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -50,6 +50,12 @@ data class KotlinSettings(
          * Derive a subpackage namespace from the root package name
          */
         fun subpackage(subpackageName: String): String = "$name.$subpackageName"
+
+        /**
+         * The package namespace for generated serialization/deserialization support
+         */
+        val serde: String
+            get() = subpackage("serde")
     }
 
     /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -19,7 +19,6 @@ object RuntimeTypes {
         val HttpBody = symbol("HttpBody")
         val HttpCall = symbol("HttpCall")
         val HttpMethod = symbol("HttpMethod")
-        val ByteArrayContent = symbol("ByteArrayContent", subpackage = "content")
         val readAll = symbol("readAll")
         val toByteStream = symbol("toByteStream")
         val toHttpBody = symbol("toHttpBody")
@@ -109,7 +108,6 @@ object RuntimeTypes {
             val buildDocument = symbol("buildDocument")
             val decodeToString = symbol("decodeToString")
             val Document = symbol("Document")
-            val StringContent = symbol("StringContent")
             val toByteArray = symbol("toByteArray")
         }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -97,12 +97,6 @@ class ShapeValueGenerator(
     }
 
     private fun primitiveDeclaration(writer: KotlinWriter, shape: Shape, block: () -> Unit) {
-        val blobHandlingSymbols = listOf(
-            RuntimeTypes.Core.Content.ByteArrayContent,
-            RuntimeTypes.Core.Content.ByteStream,
-            RuntimeTypes.Core.Content.StringContent,
-            RuntimeTypes.Core.Content.toByteArray,
-        )
         val suffix = when {
             shape.isEnum -> {
                 val symbol = symbolProvider.toSymbol(shape)
@@ -112,8 +106,7 @@ class ShapeValueGenerator(
 
             shape.type == ShapeType.BLOB -> {
                 if (shape.hasTrait<StreamingTrait>()) {
-                    writer.addImport(blobHandlingSymbols)
-                    writer.writeInline("StringContent(")
+                    writer.writeInline("#T.fromString(", RuntimeTypes.Core.Content.ByteStream)
                     ")"
                 } else {
                     // blob params are spit out as strings

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -163,7 +163,6 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             RuntimeTypes.Http.HttpBody,
             RuntimeTypes.Http.HttpMethod,
             RuntimeTypes.HttpClient.Operation.HttpSerialize,
-            RuntimeTypes.Http.ByteArrayContent,
             RuntimeTypes.Http.Request.HttpRequestBuilder,
             RuntimeTypes.Http.Request.url,
         )
@@ -265,7 +264,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             val sdg = structuredDataSerializer(ctx)
             val opBodySerializerFn = sdg.operationSerializer(ctx, op, documentMembers)
             writer.write("val payload = #T(context, input)", opBodySerializerFn)
-            writer.write("builder.body = #T(payload)", RuntimeTypes.Http.ByteArrayContent)
+            writer.write("builder.body = #T.fromBytes(payload)", RuntimeTypes.Http.HttpBody)
         }
 
         resolver.determineRequestContentType(op)?.let { contentType ->
@@ -428,7 +427,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 if (isBinaryStream) {
                     writer.write("builder.body = input.#L.#T() ?: #T.Empty", memberName, RuntimeTypes.Http.toHttpBody, RuntimeTypes.Http.HttpBody)
                 } else {
-                    writer.write("builder.body = #T(input.#L)", RuntimeTypes.Http.ByteArrayContent, memberName)
+                    writer.write("builder.body = #T.fromBytes(input.#L)", RuntimeTypes.Http.HttpBody, memberName)
                 }
             }
 
@@ -438,20 +437,20 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 } else {
                     memberName
                 }
-                writer.write("builder.body = #T(input.#L.#T())", RuntimeTypes.Http.ByteArrayContent, contents, KotlinTypes.Text.encodeToByteArray)
+                writer.write("builder.body = #T.fromBytes(input.#L.#T())", RuntimeTypes.Http.HttpBody, contents, KotlinTypes.Text.encodeToByteArray)
             }
 
             ShapeType.ENUM ->
                 writer.write(
-                    "builder.body = #T(input.#L.value.#T())",
-                    RuntimeTypes.Http.ByteArrayContent,
+                    "builder.body = #T.fromBytes(input.#L.value.#T())",
+                    RuntimeTypes.Http.HttpBody,
                     memberName,
                     KotlinTypes.Text.encodeToByteArray,
                 )
             ShapeType.INT_ENUM ->
                 writer.write(
-                    "builder.body = #T(input.#L.value.toString().#T())",
-                    RuntimeTypes.Http.ByteArrayContent,
+                    "builder.body = #T.fromBytes(input.#L.value.toString().#T())",
+                    RuntimeTypes.Http.HttpBody,
                     memberName,
                     KotlinTypes.Text.encodeToByteArray,
                 )
@@ -460,7 +459,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                 val sdg = structuredDataSerializer(ctx)
                 val payloadSerializerFn = sdg.payloadSerializer(ctx, binding.member)
                 writer.write("val payload = #T(input.#L)", payloadSerializerFn, memberName)
-                writer.write("builder.body = #T(payload)", RuntimeTypes.Http.ByteArrayContent)
+                writer.write("builder.body = #T.fromBytes(payload)", RuntimeTypes.Http.HttpBody)
             }
 
             else ->

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGenerator.kt
@@ -155,7 +155,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         val serializerSymbol = buildSymbol {
             definitionFile = "${op.serializerName()}.kt"
             name = op.serializerName()
-            namespace = "${ctx.settings.pkg.name}.transform"
+            namespace = ctx.settings.pkg.serde
 
             reference(inputSymbol, SymbolReference.ContextOption.DECLARE)
         }
@@ -487,7 +487,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             val definitionFileName = op.deserializerName().replaceFirstChar(Char::uppercaseChar)
             definitionFile = "$definitionFileName.kt"
             name = op.deserializerName()
-            namespace = ctx.settings.pkg.subpackage("transform")
+            namespace = ctx.settings.pkg.serde
 
             reference(outputSymbol, SymbolReference.ContextOption.DECLARE)
         }
@@ -542,7 +542,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             val deserializerName = "${outputSymbol.name}Deserializer"
             definitionFile = "$deserializerName.kt"
             name = deserializerName
-            namespace = ctx.settings.pkg.subpackage("transform")
+            namespace = ctx.settings.pkg.serde
             reference(outputSymbol, SymbolReference.ContextOption.DECLARE)
         }
 
@@ -996,7 +996,7 @@ fun OperationShape.errorHandlerName(): String = "throw${capitalizedDefaultName()
  */
 fun OperationShape.errorHandler(settings: KotlinSettings, block: SymbolRenderer): Symbol = buildSymbol {
     name = errorHandlerName()
-    namespace = "${settings.pkg.name}.transform"
+    namespace = settings.pkg.serde
     // place error handler in same file as operation deserializer
     definitionFile = "${deserializerName()}.kt"
     renderBy = block

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -127,6 +127,7 @@ abstract class HttpProtocolClientGenerator(
     }
 
     protected open fun importSymbols(writer: KotlinWriter) {
+        writer.addImport(ctx.settings.pkg.subpackage("model"), "*")
         if (TopDownIndex(ctx.model).getContainedOperations(ctx.service).isNotEmpty()) {
             writer.addImport(ctx.settings.pkg.serde, "*")
         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -127,9 +127,8 @@ abstract class HttpProtocolClientGenerator(
     }
 
     protected open fun importSymbols(writer: KotlinWriter) {
-        writer.addImport("${ctx.settings.pkg.name}.model", "*")
         if (TopDownIndex(ctx.model).getContainedOperations(ctx.service).isNotEmpty()) {
-            writer.addImport("${ctx.settings.pkg.name}.transform", "*")
+            writer.addImport(ctx.settings.pkg.serde, "*")
         }
 
         val defaultClientSymbols = setOf(

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
@@ -159,7 +159,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
             when (target) {
                 is BlobShape -> {
                     val suffix = if (target.hasTrait<StreamingTrait>()) {
-                        "?.toByteArray()"
+                        writer.format("?.#T()", RuntimeTypes.Core.Content.toByteArray)
                     } else {
                         ""
                     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerdeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/serde/SerdeExt.kt
@@ -42,8 +42,8 @@ fun OperationShape.bodySerializer(
     block: SymbolRenderer,
 ): Symbol = buildSymbol {
     name = bodySerializerName()
-    namespace = "${settings.pkg.name}.transform"
-    // place body serializer in same file as operation serializer implementaiton
+    namespace = settings.pkg.serde
+    // place body serializer in same file as operation serializer implementation
     definitionFile = "${serializerName()}.kt"
     renderBy = block
 }
@@ -68,7 +68,7 @@ fun OperationShape.bodyDeserializer(
     block: SymbolRenderer,
 ): Symbol = buildSymbol {
     name = bodyDeserializerName()
-    namespace = "${settings.pkg.name}.transform"
+    namespace = settings.pkg.serde
     // place body serializer in same file as operation serializer implementation
     definitionFile = "${deserializerName()}.kt"
     renderBy = block
@@ -95,7 +95,7 @@ fun Shape.documentSerializer(
 
     return buildSymbol {
         name = "$base$suffix"
-        namespace = settings.pkg.subpackage("transform")
+        namespace = settings.pkg.serde
         definitionFile = "${symbol.name}DocumentSerializer.kt"
         reference(symbol, SymbolReference.ContextOption.DECLARE)
         renderBy = block
@@ -123,7 +123,7 @@ fun Shape.documentDeserializer(
 
     return buildSymbol {
         name = "$base$suffix"
-        namespace = settings.pkg.subpackage("transform")
+        namespace = settings.pkg.serde
         definitionFile = "${symbol.name}DocumentDeserializer.kt"
         reference(symbol, SymbolReference.ContextOption.DECLARE)
         renderBy = block
@@ -141,7 +141,7 @@ fun Symbol.errorDeserializerName(): String = "deserialize" + StringUtils.capital
  */
 fun Symbol.errorDeserializer(settings: KotlinSettings, block: SymbolRenderer): Symbol = buildSymbol {
     name = errorDeserializerName()
-    namespace = "${settings.pkg.name}.transform"
+    namespace = settings.pkg.serde
     val symbol = this@errorDeserializer
     // place it in the same file as the exception deserializer, e.g. for HTTP protocols this will be in
     // same file as HttpDeserialize
@@ -163,7 +163,7 @@ fun Shape.payloadDeserializer(
     val suffix = mangledSuffix(members)
     return buildSymbol {
         name = "$base$suffix"
-        namespace = settings.pkg.subpackage("transform")
+        namespace = settings.pkg.serde
         definitionFile = "${symbol.name}PayloadDeserializer.kt"
         reference(symbol, SymbolReference.ContextOption.DECLARE)
         renderBy = block
@@ -183,7 +183,7 @@ fun Shape.payloadSerializer(
     val suffix = mangledSuffix(members)
     return buildSymbol {
         name = "$base$suffix"
-        namespace = "${settings.pkg.name}.transform"
+        namespace = settings.pkg.serde
         definitionFile = "${symbol.name}PayloadSerializer.kt"
         reference(symbol, SymbolReference.ContextOption.DECLARE)
         renderBy = block

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -41,7 +41,7 @@ class IdempotentTokenGeneratorTest {
                     }
             
                     val payload = serializeAllocateWidgetOperationBody(context, input)
-                    builder.body = ByteArrayContent(payload)
+                    builder.body = HttpBody.fromBytes(payload)
                     if (builder.body !is HttpBody.Empty) {
                         builder.headers.setMissing("Content-Type", "application/json")
                     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/IdempotentTokenGeneratorTest.kt
@@ -13,22 +13,22 @@ import kotlin.test.Test
 class IdempotentTokenGeneratorTest {
     private val defaultModel: Model = javaClass.getResource("idempotent-token-test-model.smithy").toSmithyModel()
 
-    private fun getTransformFileContents(filename: String): String {
+    private fun getSerdeFileContents(filename: String): String {
         val (ctx, manifest, generator) = defaultModel.newTestContext()
         generator.generateProtocolClient(ctx)
         ctx.delegator.flushWriters()
-        return manifest.getTransformFileContents(filename)
+        return manifest.getSerdeFileContents(filename)
     }
 
     // Assume a specific file path to retrieve a file from the manifest
-    private fun MockManifest.getTransformFileContents(filename: String, packageNamespace: String = TestModelDefault.NAMESPACE): String {
+    private fun MockManifest.getSerdeFileContents(filename: String, packageNamespace: String = TestModelDefault.NAMESPACE): String {
         val packageNamespaceExpr = packageNamespace.replace('.', '/')
-        return expectFileString("src/main/kotlin/$packageNamespaceExpr/transform/$filename")
+        return expectFileString("src/main/kotlin/$packageNamespaceExpr/serde/$filename")
     }
 
     @Test
     fun `it serializes operation payload inputs with idempotency token trait`() {
-        val contents = getTransformFileContents("AllocateWidgetOperationSerializer.kt")
+        val contents = getSerdeFileContents("AllocateWidgetOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
             internal class AllocateWidgetOperationSerializer: HttpSerialize<AllocateWidgetRequest> {
@@ -54,7 +54,7 @@ class IdempotentTokenGeneratorTest {
 
     @Test
     fun `it serializes operation query inputs with idempotency token trait`() {
-        val contents = getTransformFileContents("AllocateWidgetQueryOperationSerializer.kt")
+        val contents = getSerdeFileContents("AllocateWidgetQueryOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class AllocateWidgetQueryOperationSerializer: HttpSerialize<AllocateWidgetQueryRequest> {
@@ -78,7 +78,7 @@ internal class AllocateWidgetQueryOperationSerializer: HttpSerialize<AllocateWid
 
     @Test
     fun `it serializes operation header inputs with idempotency token trait`() {
-        val contents = getTransformFileContents("AllocateWidgetHeaderOperationSerializer.kt")
+        val contents = getSerdeFileContents("AllocateWidgetHeaderOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class AllocateWidgetHeaderOperationSerializer: HttpSerialize<AllocateWidgetHeaderRequest> {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -64,7 +64,7 @@ internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
         }
 
         val payload = serializeSmokeTestOperationBody(context, input)
-        builder.body = ByteArrayContent(payload)
+        builder.body = HttpBody.fromBytes(payload)
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
         }
@@ -92,7 +92,7 @@ internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRe
         }
 
         if (input.payload1 != null) {
-            builder.body = ByteArrayContent(input.payload1.encodeToByteArray())
+            builder.body = HttpBody.fromBytes(input.payload1.encodeToByteArray())
         }
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "text/plain")
@@ -119,7 +119,7 @@ internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobReques
         }
 
         if (input.payload1 != null) {
-            builder.body = ByteArrayContent(input.payload1)
+            builder.body = HttpBody.fromBytes(input.payload1)
         }
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/octet-stream")
@@ -174,7 +174,7 @@ internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRe
 
         if (input.payload1 != null) {
             val payload = serializeNested2Payload(input.payload1)
-            builder.body = ByteArrayContent(payload)
+            builder.body = HttpBody.fromBytes(payload)
         }
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
@@ -202,7 +202,7 @@ internal class ExplicitDocumentOperationSerializer: HttpSerialize<ExplicitDocume
 
         if (input.payload1 != null) {
             val payload = serializeDocumentPayload(input.payload1)
-            builder.body = ByteArrayContent(payload)
+            builder.body = HttpBody.fromBytes(payload)
         }
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
@@ -233,7 +233,7 @@ internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
         }
 
         val payload = serializeEnumInputOperationBody(context, input)
-        builder.body = ByteArrayContent(payload)
+        builder.body = HttpBody.fromBytes(payload)
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
         }
@@ -275,7 +275,7 @@ internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRe
         }
 
         val payload = serializeTimestampInputOperationBody(context, input)
-        builder.body = ByteArrayContent(payload)
+        builder.body = HttpBody.fromBytes(payload)
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
         }
@@ -308,7 +308,7 @@ internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
         }
 
         val payload = serializeBlobInputOperationBody(context, input)
-        builder.body = ByteArrayContent(payload)
+        builder.body = HttpBody.fromBytes(payload)
         if (builder.body !is HttpBody.Empty) {
             builder.headers.setMissing("Content-Type", "application/json")
         }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpBindingProtocolGeneratorTest.kt
@@ -17,27 +17,27 @@ import kotlin.test.assertTrue
 // NOTE: protocol conformance is mostly handled by the protocol tests suite
 class HttpBindingProtocolGeneratorTest {
     private val defaultModel = loadModelFromResource("http-binding-protocol-generator-test.smithy")
-    private fun getTransformFileContents(filename: String, testModel: Model = defaultModel): String {
+    private fun getSerdeFileContents(filename: String, testModel: Model = defaultModel): String {
         val (ctx, manifest, generator) = testModel.newTestContext()
         generator.generateProtocolClient(ctx)
         ctx.delegator.flushWriters()
-        return getTransformFileContents(manifest, filename)
+        return getSerdeFileContents(manifest, filename)
     }
 
-    private fun getTransformFileContents(manifest: MockManifest, filename: String): String = manifest
-        .expectFileString("src/main/kotlin/com/test/transform/$filename")
+    private fun getSerdeFileContents(manifest: MockManifest, filename: String): String = manifest
+        .expectFileString("src/main/kotlin/com/test/serde/$filename")
 
     @Test
     fun itCreatesSerializeTransformsInCorrectPackage() {
         val (ctx, manifest, generator) = defaultModel.newTestContext()
         generator.generateProtocolClient(ctx)
         ctx.delegator.flushWriters()
-        assertTrue(manifest.hasFile("src/main/kotlin/com/test/transform/SmokeTestOperationSerializer.kt"))
+        assertTrue(manifest.hasFile("src/main/kotlin/com/test/serde/SmokeTestOperationSerializer.kt"))
     }
 
     @Test
     fun itCreatesSmokeTestRequestSerializer() {
-        val contents = getTransformFileContents("SmokeTestOperationSerializer.kt")
+        val contents = getSerdeFileContents("SmokeTestOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val label1 = "\${input.label1}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
@@ -79,7 +79,7 @@ internal class SmokeTestOperationSerializer: HttpSerialize<SmokeTestRequest> {
 
     @Test
     fun itSerializesExplicitStringPayloads() {
-        val contents = getTransformFileContents("ExplicitStringOperationSerializer.kt")
+        val contents = getSerdeFileContents("ExplicitStringOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRequest> {
@@ -106,7 +106,7 @@ internal class ExplicitStringOperationSerializer: HttpSerialize<ExplicitStringRe
 
     @Test
     fun itSerializesExplicitBlobPayloads() {
-        val contents = getTransformFileContents("ExplicitBlobOperationSerializer.kt")
+        val contents = getSerdeFileContents("ExplicitBlobOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobRequest> {
@@ -133,7 +133,7 @@ internal class ExplicitBlobOperationSerializer: HttpSerialize<ExplicitBlobReques
 
     @Test
     fun itSerializesExplicitStreamingBlobPayloads() {
-        val contents = getTransformFileContents("ExplicitBlobStreamOperationSerializer.kt")
+        val contents = getSerdeFileContents("ExplicitBlobStreamOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlobStreamRequest> {
@@ -160,7 +160,7 @@ internal class ExplicitBlobStreamOperationSerializer: HttpSerialize<ExplicitBlob
 
     @Test
     fun itSerializesExplicitStructPayloads() {
-        val contents = getTransformFileContents("ExplicitStructOperationSerializer.kt")
+        val contents = getSerdeFileContents("ExplicitStructOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRequest> {
@@ -188,7 +188,7 @@ internal class ExplicitStructOperationSerializer: HttpSerialize<ExplicitStructRe
 
     @Test
     fun itSerializesExplicitDocumentPayloads() {
-        val contents = getTransformFileContents("ExplicitDocumentOperationSerializer.kt")
+        val contents = getSerdeFileContents("ExplicitDocumentOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class ExplicitDocumentOperationSerializer: HttpSerialize<ExplicitDocumentRequest> {
@@ -216,7 +216,7 @@ internal class ExplicitDocumentOperationSerializer: HttpSerialize<ExplicitDocume
 
     @Test
     fun itSerializesOperationInputsWithEnums() {
-        val contents = getTransformFileContents("EnumInputOperationSerializer.kt")
+        val contents = getSerdeFileContents("EnumInputOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
@@ -246,7 +246,7 @@ internal class EnumInputOperationSerializer: HttpSerialize<EnumInputRequest> {
 
     @Test
     fun itSerializesOperationInputsWithTimestamps() {
-        val contents = getTransformFileContents("TimestampInputOperationSerializer.kt")
+        val contents = getSerdeFileContents("TimestampInputOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val tsLabel = "\${input.tsLabel?.format(TimestampFormat.ISO_8601)}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
@@ -291,7 +291,7 @@ internal class TimestampInputOperationSerializer: HttpSerialize<TimestampInputRe
     fun itCreatesBlobInputRequestSerializer() {
         // base64 encoding is protocol dependent. The mock protocol generator is based on
         // json protocol though which does encode to base64
-        val contents = getTransformFileContents("BlobInputOperationSerializer.kt")
+        val contents = getSerdeFileContents("BlobInputOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
@@ -323,7 +323,7 @@ internal class BlobInputOperationSerializer: HttpSerialize<BlobInputRequest> {
 
     @Test
     fun itHandlesQueryStringLiterals() {
-        val contents = getTransformFileContents("ConstantQueryStringOperationSerializer.kt")
+        val contents = getSerdeFileContents("ConstantQueryStringOperationSerializer.kt")
         contents.assertBalancedBracesAndParens()
         val label1 = "\${input.hello}" // workaround for raw strings not being able to contain escapes
         val expectedContents = """
@@ -353,7 +353,7 @@ internal class ConstantQueryStringOperationSerializer: HttpSerialize<ConstantQue
 
     @Test
     fun itCreatesSmokeTestResponseDeserializer() {
-        val contents = getTransformFileContents("SmokeTestOperationDeserializer.kt")
+        val contents = getSerdeFileContents("SmokeTestOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
 internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse> {
@@ -383,7 +383,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesPrefixHeaders() {
-        val contents = getTransformFileContents("PrefixHeadersOperationDeserializer.kt")
+        val contents = getSerdeFileContents("PrefixHeadersOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         val keysForMember1 = response.headers.names().filter { it.startsWith("X-Foo-") }
@@ -404,7 +404,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesPrimitiveHeaders() {
-        val contents = getTransformFileContents("PrimitiveShapesOperationOperationDeserializer.kt")
+        val contents = getSerdeFileContents("PrimitiveShapesOperationOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         builder.hBool = response.headers["X-d"]?.toBoolean() ?: false
@@ -418,7 +418,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitStringPayloads() {
-        val contents = getTransformFileContents("ExplicitStringOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitStringOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         val contents = response.body.readAll()?.decodeToString()
@@ -429,7 +429,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitEnumPayloads() {
-        val contents = getTransformFileContents("ExplicitEnumOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitEnumOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         val contents = response.body.readAll()?.decodeToString()
@@ -440,7 +440,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitBlobPayloads() {
-        val contents = getTransformFileContents("ExplicitBlobOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitBlobOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         builder.payload1 = response.body.readAll()
@@ -450,7 +450,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitStreamingBlobPayloads() {
-        val contents = getTransformFileContents("ExplicitBlobStreamOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitBlobStreamOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         builder.payload1 = response.body.toByteStream()
@@ -460,7 +460,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitStructPayloads() {
-        val contents = getTransformFileContents("ExplicitStructOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitStructOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         val payload = response.body.readAll()
@@ -473,7 +473,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
 
     @Test
     fun itDeserializesExplicitDocumentPayloads() {
-        val contents = getTransformFileContents("ExplicitDocumentOperationDeserializer.kt")
+        val contents = getSerdeFileContents("ExplicitDocumentOperationDeserializer.kt")
         contents.assertBalancedBracesAndParens()
         val expectedContents = """
         val payload = response.body.readAll()
@@ -487,7 +487,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
     @Test
     fun itLeavesOffContentType() {
         // GET/HEAD/TRACE/OPTIONS/CONNECT shouldn't specify content-type
-        val contents = getTransformFileContents("ConstantQueryStringOperationSerializer.kt")
+        val contents = getSerdeFileContents("ConstantQueryStringOperationSerializer.kt")
         contents.shouldNotContain("Content-Type")
     }
 
@@ -502,7 +502,7 @@ internal class SmokeTestOperationDeserializer: HttpDeserialize<SmokeTestResponse
         """.prependNamespaceAndService(operations = listOf("Foo"))
             .toSmithyModel()
 
-        val contents = getTransformFileContents("FooOperationSerializer.kt", model)
+        val contents = getSerdeFileContents("FooOperationSerializer.kt", model)
 
         val latest = "\\\$LATEST"
         val expected = """

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGeneratorTest.kt
@@ -34,7 +34,7 @@ class HttpProtocolClientGeneratorTest {
     @Test
     fun `it imports external symbols`() {
         commonTestContents.shouldContainOnlyOnceWithDiff("import ${TestModelDefault.NAMESPACE}.model.*")
-        commonTestContents.shouldContainOnlyOnceWithDiff("import ${TestModelDefault.NAMESPACE}.transform.*")
+        commonTestContents.shouldContainOnlyOnceWithDiff("import ${TestModelDefault.NAMESPACE}.serde.*")
         commonTestContents.shouldContainOnlyOnceWithDiff("import ${KotlinDependency.HTTP.namespace}.SdkHttpClient")
         commonTestContents.shouldContainOnlyOnceWithDiff("import ${KotlinDependency.HTTP.namespace}.operation.SdkHttpOperation")
         commonTestContents.shouldContainOnlyOnceWithDiff("import ${KotlinDependency.HTTP.namespace}.operation.context")

--- a/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
+++ b/runtime/auth/aws-signing-tests/common/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/BasicSigningTestBase.kt
@@ -6,8 +6,8 @@ package aws.smithy.kotlin.runtime.auth.awssigning.tests
 
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awssigning.*
+import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.headers
@@ -66,7 +66,7 @@ public abstract class BasicSigningTestBase : HasSigner {
             headers.append("Host", "demo.us-east-1.amazonaws.com")
             headers.appendAll("x-amz-archive-description", listOf("test", "test"))
             val requestBody = "{\"TableName\": \"foo\"}"
-            body = ByteArrayContent(requestBody.encodeToByteArray())
+            body = HttpBody.fromBytes(requestBody.encodeToByteArray())
             headers.append("Content-Length", body.contentLength?.toString() ?: "0")
         }.build()
 
@@ -94,7 +94,7 @@ public abstract class BasicSigningTestBase : HasSigner {
             headers.append("Host", "demo.us-east-1.amazonaws.com")
             headers.appendAll("x-amz-archive-description", listOf("test", "test"))
             val requestBody = "{\"TableName\": \"foo\"}"
-            body = ByteArrayContent(requestBody.encodeToByteArray())
+            body = HttpBody.fromBytes(requestBody.encodeToByteArray())
             headers.append("Content-Length", body.contentLength?.toString() ?: "0")
         }.build()
 
@@ -198,7 +198,7 @@ public abstract class BasicSigningTestBase : HasSigner {
             url.path = "/"
             headers.append("Host", "test.amazonaws.com")
             headers.appendAll("x-amz-archive-description", listOf("test", "test"))
-            body = ByteArrayContent("body".encodeToByteArray())
+            body = HttpBody.fromBytes("body".encodeToByteArray())
             headers.append("Content-Length", body.contentLength?.toString() ?: "0")
         }
 

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -11,7 +11,6 @@ import aws.smithy.kotlin.runtime.auth.awssigning.*
 import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.auth.AwsHttpSigner
 import aws.smithy.kotlin.runtime.http.auth.SigV4AuthScheme
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
@@ -393,7 +392,7 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
 
         if (hasBody) {
             val bytes = runBlocking { chan.readRemaining().readBytes() }
-            builder.body = ByteArrayContent(bytes)
+            builder.body = HttpBody.fromBytes(bytes)
         }
 
         return builder

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -12,7 +12,6 @@ import aws.smithy.kotlin.runtime.auth.awssigning.DefaultAwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.crt.CrtAwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.internal.AWS_CHUNKED_THRESHOLD
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
@@ -68,7 +67,7 @@ public abstract class AwsHttpSignerTestBase(
                                     override val isOneShot: Boolean = !replayable
                                 }
                             }
-                            false -> ByteArrayContent(requestBody.encodeToByteArray())
+                            false -> HttpBody.fromBytes(requestBody.encodeToByteArray())
                         }
                         headers.append("Content-Length", body.contentLength?.toString() ?: "0")
                     }

--- a/runtime/protocol/aws-json-protocols/common/src/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocol.kt
+++ b/runtime/protocol/aws-json-protocols/common/src/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocol.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.awsprotocol.json
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.SdkClientOption
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.ModifyRequestMiddleware
 import aws.smithy.kotlin.runtime.http.operation.SdkHttpRequest
 import aws.smithy.kotlin.runtime.util.get
@@ -47,7 +46,7 @@ public class AwsJsonProtocol(
             // Empty body is required by AWS JSON 1.x protocols
             // https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#empty-body-serialization
             // https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#empty-body-serialization
-            req.subject.body = ByteArrayContent("{}".encodeToByteArray())
+            req.subject.body = HttpBody.fromBytes("{}".encodeToByteArray())
         }
         return req
     }

--- a/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
+++ b/runtime/protocol/aws-json-protocols/common/test/aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocolTest.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.awsprotocol.json
 
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
@@ -65,7 +64,7 @@ class AwsJsonProtocolTest {
                 override suspend fun serialize(context: ExecutionContext, input: Unit): HttpRequestBuilder =
                     HttpRequestBuilder().apply {
                         headers["Content-Type"] = "application/xml"
-                        body = ByteArrayContent("foo".encodeToByteArray())
+                        body = HttpBody.fromBytes("foo".encodeToByteArray())
                     }
             }
             deserializer = IdentityDeserializer

--- a/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ResponseUtils.kt
+++ b/runtime/protocol/aws-protocol-core/common/src/aws/smithy/kotlin/runtime/awsprotocol/ResponseUtils.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.category
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.isSuccess
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 
@@ -23,12 +22,7 @@ public const val X_AMZN_REQUEST_ID_HEADER: String = "x-amz-request-id"
  */
 @InternalApi
 public fun HttpResponse.withPayload(payload: ByteArray?): HttpResponse {
-    val newBody = if (payload != null) {
-        ByteArrayContent(payload)
-    } else {
-        HttpBody.Empty
-    }
-
+    val newBody = payload?.let { HttpBody.fromBytes(it) } ?: HttpBody.Empty
     return HttpResponse(status, headers, newBody)
 }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
@@ -9,13 +9,13 @@ import aws.sdk.kotlin.crt.io.SocketOptions
 import aws.sdk.kotlin.crt.io.TlsContext
 import aws.sdk.kotlin.crt.io.TlsContextOptionsBuilder
 import aws.sdk.kotlin.crt.io.Uri
-import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.crt.SdkDefaultIO
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
 import aws.smithy.kotlin.runtime.http.engine.ProxyConfig
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.io.Closeable
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/src/aws/smithy/kotlin/runtime/http/engine/crt/ConnectionManager.kt
@@ -9,7 +9,7 @@ import aws.sdk.kotlin.crt.io.SocketOptions
 import aws.sdk.kotlin.crt.io.TlsContext
 import aws.sdk.kotlin.crt.io.TlsContextOptionsBuilder
 import aws.sdk.kotlin.crt.io.Uri
-import aws.smithy.kotlin.runtime.config.TlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.crt.SdkDefaultIO
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
@@ -23,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import aws.sdk.kotlin.crt.io.TlsContext as CrtTlsContext
 import aws.sdk.kotlin.crt.io.TlsVersion as CrtTlsVersion
-import aws.smithy.kotlin.runtime.config.TlsVersion as SdkTlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion as SdkTlsVersion
 
 internal class ConnectionManager(
     private val config: CrtHttpEngineConfig,

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.http.engine.crt
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.crt.ReadChannelBodyStream
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.SdkSource
@@ -41,7 +40,7 @@ class RequestConversionTest {
 
     @Test
     fun testSdkToCrtRequestBytesBody() {
-        val body = ByteArrayContent("foobar".encodeToByteArray())
+        val body = HttpBody.fromBytes("foobar".encodeToByteArray())
         val request = HttpRequest(
             HttpMethod.POST,
             Url.parse("https://test.aws.com?foo=bar"),

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -5,12 +5,12 @@
 
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
-import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.http.HttpCall
 import aws.smithy.kotlin.runtime.http.config.EngineFactory
 import aws.smithy.kotlin.runtime.http.engine.*
 import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -5,7 +5,7 @@
 
 package aws.smithy.kotlin.runtime.http.engine.okhttp
 
-import aws.smithy.kotlin.runtime.config.TlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.http.HttpCall
 import aws.smithy.kotlin.runtime.http.config.EngineFactory
 import aws.smithy.kotlin.runtime.http.engine.*
@@ -18,7 +18,7 @@ import kotlinx.coroutines.job
 import okhttp3.*
 import java.util.concurrent.TimeUnit
 import kotlin.time.toJavaDuration
-import aws.smithy.kotlin.runtime.config.TlsVersion as SdkTlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion as SdkTlsVersion
 import okhttp3.TlsVersion as OkHttpTlsVersion
 
 /**

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -146,15 +146,15 @@ public final class aws/smithy/kotlin/runtime/http/engine/ProxySelector$Companion
 public final class aws/smithy/kotlin/runtime/http/engine/TlsContext {
 	public static final field Companion Laws/smithy/kotlin/runtime/http/engine/TlsContext$Companion;
 	public final fun getAlpn ()Ljava/util/List;
-	public final fun getMinVersion ()Laws/smithy/kotlin/runtime/config/TlsVersion;
+	public final fun getMinVersion ()Laws/smithy/kotlin/runtime/net/TlsVersion;
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/TlsContext$Builder {
 	public fun <init> ()V
 	public final fun getAlpn ()Ljava/util/List;
-	public final fun getMinVersion ()Laws/smithy/kotlin/runtime/config/TlsVersion;
+	public final fun getMinVersion ()Laws/smithy/kotlin/runtime/net/TlsVersion;
 	public final fun setAlpn (Ljava/util/List;)V
-	public final fun setMinVersion (Laws/smithy/kotlin/runtime/config/TlsVersion;)V
+	public final fun setMinVersion (Laws/smithy/kotlin/runtime/net/TlsVersion;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/TlsContext$Companion {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/TlsContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/TlsContext.kt
@@ -5,9 +5,9 @@
 package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.client.config.ClientSettings
-import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.http.config.HttpEngineConfigDsl
+import aws.smithy.kotlin.runtime.net.TlsVersion
 
 /**
  * Defines values related to TLS and secure connections.

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/TlsContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/TlsContext.kt
@@ -5,7 +5,7 @@
 package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.client.config.ClientSettings
-import aws.smithy.kotlin.runtime.config.TlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.http.config.HttpEngineConfigDsl
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -8,7 +8,6 @@ package aws.smithy.kotlin.runtime.http.interceptors
 import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.hashing.toHashFunction
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
 import aws.smithy.kotlin.runtime.http.operation.roundTrip
@@ -36,7 +35,7 @@ class FlexibleChecksumsRequestInterceptorTest {
     fun itSetsChecksumHeader() = runTest {
         checksums.forEach { (checksumAlgorithmName, expectedChecksumValue) ->
             val req = HttpRequestBuilder().apply {
-                body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+                body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
             }
 
             val op = newTestOperation<Unit, Unit>(req, Unit)
@@ -56,7 +55,7 @@ class FlexibleChecksumsRequestInterceptorTest {
     @Test
     fun itAllowsOnlyOneChecksumHeader() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+            body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
         }
         req.headers { append("x-amz-checksum-sha256", "sha256-checksum-value") }
         req.headers { append("x-amz-checksum-crc32", "crc32-checksum-value") }
@@ -81,7 +80,7 @@ class FlexibleChecksumsRequestInterceptorTest {
     @Test
     fun itThrowsOnUnsupportedChecksumAlgorithm() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+            body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
         }
 
         val unsupportedChecksumAlgorithmName = "fooblefabble1024"
@@ -171,7 +170,7 @@ class FlexibleChecksumsRequestInterceptorTest {
     @Test
     fun itUsesPrecalculatedChecksum() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+            body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
         }
         val checksumAlgorithmName = "sha256"
         val precalculatedChecksumValue = "sha256-checksum-value"

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/Md5ChecksumInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/Md5ChecksumInterceptorTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.http.interceptors
 
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.SdkHttpClient
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
 import aws.smithy.kotlin.runtime.http.operation.roundTrip
@@ -26,7 +25,7 @@ class Md5ChecksumInterceptorTest {
     @Test
     fun itSetsContentMd5Header() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+            body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
         }
         val op = newTestOperation<Unit, Unit>(req, Unit)
 
@@ -65,7 +64,7 @@ class Md5ChecksumInterceptorTest {
     @Test
     fun itDoesNotSetContentMd5Header() = runTest {
         val req = HttpRequestBuilder().apply {
-            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+            body = HttpBody.fromBytes("<Foo>bar</Foo>".encodeToByteArray())
         }
         val op = newTestOperation<Unit, Unit>(req, Unit)
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptorTest.kt
@@ -6,7 +6,6 @@ package aws.smithy.kotlin.runtime.http.interceptors
 
 import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.HttpCall
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.operation.*
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
@@ -60,7 +59,7 @@ class ResponseLengthValidationInterceptorTest {
             override fun readFrom() = SdkByteReadChannel(RESPONSE)
             override val isOneShot = false
         },
-        ByteArrayContent(RESPONSE),
+        HttpBody.fromBytes(RESPONSE),
     )
 
     private fun allBodies() = nonEmptyBodies() + HttpBody.Empty

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/HttpTrafficParser.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/HttpTrafficParser.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.httptest
 
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.url
@@ -102,7 +101,10 @@ private fun convertHeaders(headers: JsonObject): Headers {
     return builder.build()
 }
 
-private fun convertBody(body: String, bodyContentType: BodyContentType): HttpBody = when (bodyContentType) {
-    BodyContentType.UTF_8 -> ByteArrayContent(body.encodeToByteArray())
-    BodyContentType.BINARY -> ByteArrayContent(body.decodeBase64Bytes())
+private fun convertBody(body: String, bodyContentType: BodyContentType): HttpBody {
+    val payload = when (bodyContentType) {
+        BodyContentType.UTF_8 -> body.encodeToByteArray()
+        BodyContentType.BINARY -> body.decodeBase64Bytes()
+    }
+    return HttpBody.fromBytes(payload)
 }

--- a/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
+++ b/runtime/protocol/http-test/common/src/aws/smithy/kotlin/runtime/httptest/RecordingConnection.kt
@@ -9,7 +9,6 @@ import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.http.Headers
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpCall
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.readAll
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
@@ -39,7 +38,7 @@ public class RecordingEngine(private val wrapped: HttpClientEngine) : HttpClient
         is HttpBody.Empty -> HttpBody.Empty
         else -> {
             val bytes = body.readAll() ?: error("failed to copy $name body")
-            ByteArrayContent(bytes)
+            HttpBody.fromBytes(bytes)
         }
     }
 

--- a/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
+++ b/runtime/protocol/http-test/common/test/aws/smithy/kotlin/runtime/httptest/TestConnectionTest.kt
@@ -6,7 +6,6 @@
 package aws.smithy.kotlin.runtime.httptest
 
 import aws.smithy.kotlin.runtime.http.*
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.net.Host
 import io.kotest.matchers.string.shouldContain
@@ -24,7 +23,7 @@ class TestConnectionTest {
                     url.host = Host.Domain("test.com")
                     url.path = "/turtles-all-the-way-down"
                     headers.append("x-foo", "bar")
-                    body = ByteArrayContent("tests for your tests".encodeToByteArray())
+                    body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
                 }
             }
         }
@@ -36,7 +35,7 @@ class TestConnectionTest {
             url.path = "/turtles-all-the-way-down"
             headers.append("x-foo", "bar")
             headers.append("x-qux", "quux")
-            body = ByteArrayContent("tests for your tests".encodeToByteArray())
+            body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
         }
         client.call(req).complete()
 
@@ -51,7 +50,7 @@ class TestConnectionTest {
                     url.host = Host.Domain("test.com")
                     url.path = "/turtles-all-the-way-down"
                     headers.append("x-foo", "bar")
-                    body = ByteArrayContent("tests for your tests".encodeToByteArray())
+                    body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
                 }
             }
         }
@@ -105,7 +104,7 @@ class TestConnectionTest {
                     url.host = Host.Domain("test.com")
                     url.path = "/turtles-all-the-way-down"
                     headers.append("x-foo", "bar")
-                    body = ByteArrayContent("tests for your tests".encodeToByteArray())
+                    body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
                 }
             }
         }
@@ -116,7 +115,7 @@ class TestConnectionTest {
             url.host = Host.Domain("test.com")
             url.path = "/turtles-all-the-way-down"
             headers.append("x-foo", "bar")
-            body = ByteArrayContent("tests are good".encodeToByteArray())
+            body = HttpBody.fromBytes("tests are good".encodeToByteArray())
         }
         client.call(req).complete()
 
@@ -133,7 +132,7 @@ class TestConnectionTest {
                     url.host = Host.Domain("test.com")
                     url.path = "/turtles-all-the-way-down"
                     headers.append("x-foo", "bar")
-                    body = ByteArrayContent("tests for your tests".encodeToByteArray())
+                    body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
                 }
             }
             // ANY request
@@ -147,7 +146,7 @@ class TestConnectionTest {
             url.path = "/turtles-all-the-way-down"
             headers.append("x-foo", "bar")
             headers.append("x-qux", "quux")
-            body = ByteArrayContent("tests for your tests".encodeToByteArray())
+            body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
         }
         client.call(req).complete()
         client.call(
@@ -205,7 +204,7 @@ class TestConnectionTest {
             url.parameters.append("q1", "v1")
             headers.append("foo", "bar")
             headers.appendAll("baz", listOf("one", "two"))
-            body = ByteArrayContent("tests for your tests".encodeToByteArray())
+            body = HttpBody.fromBytes("tests for your tests".encodeToByteArray())
         }
 
         val call1 = client.call(req)

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -246,12 +246,6 @@ public final class aws/smithy/kotlin/runtime/http/HttpStatusCodeKt {
 	public static final fun isSuccess (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)Z
 }
 
-public final class aws/smithy/kotlin/runtime/http/content/ByteArrayContent : aws/smithy/kotlin/runtime/http/HttpBody$Bytes {
-	public fun <init> ([B)V
-	public fun bytes ()[B
-	public fun getContentLength ()Ljava/lang/Long;
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/http/request/HttpRequest {
 	public static final field Companion Laws/smithy/kotlin/runtime/http/request/HttpRequest$Companion;
 	public abstract fun getBody ()Laws/smithy/kotlin/runtime/http/HttpBody;

--- a/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/content/ByteArrayContent.kt
+++ b/runtime/protocol/http/common/src/aws/smithy/kotlin/runtime/http/content/ByteArrayContent.kt
@@ -9,7 +9,7 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 /**
  * Implementation of [HttpBody.Bytes] backed by a byte array
  */
-public class ByteArrayContent(private val bytes: ByteArray) : HttpBody.Bytes() {
+internal class ByteArrayContent(private val bytes: ByteArray) : HttpBody.Bytes() {
     override val contentLength: Long = bytes.size.toLong()
     override fun bytes(): ByteArray = bytes
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -72,15 +72,6 @@ public final class aws/smithy/kotlin/runtime/ServiceException$ErrorType : java/l
 public final class aws/smithy/kotlin/runtime/config/EnvironmentSettingKt {
 }
 
-public final class aws/smithy/kotlin/runtime/config/TlsVersion : java/lang/Enum {
-	public static final field TLS_1_0 Laws/smithy/kotlin/runtime/config/TlsVersion;
-	public static final field TLS_1_1 Laws/smithy/kotlin/runtime/config/TlsVersion;
-	public static final field TLS_1_2 Laws/smithy/kotlin/runtime/config/TlsVersion;
-	public static final field TLS_1_3 Laws/smithy/kotlin/runtime/config/TlsVersion;
-	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/config/TlsVersion;
-	public static fun values ()[Laws/smithy/kotlin/runtime/config/TlsVersion;
-}
-
 public abstract class aws/smithy/kotlin/runtime/content/ByteStream {
 	public static final field Companion Laws/smithy/kotlin/runtime/content/ByteStream$Companion;
 	public fun getContentLength ()Ljava/lang/Long;

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -676,6 +676,15 @@ public final class aws/smithy/kotlin/runtime/net/SchemeKt {
 public final class aws/smithy/kotlin/runtime/net/TextKt {
 }
 
+public final class aws/smithy/kotlin/runtime/net/TlsVersion : java/lang/Enum {
+	public static final field TLS_1_0 Laws/smithy/kotlin/runtime/net/TlsVersion;
+	public static final field TLS_1_1 Laws/smithy/kotlin/runtime/net/TlsVersion;
+	public static final field TLS_1_2 Laws/smithy/kotlin/runtime/net/TlsVersion;
+	public static final field TLS_1_3 Laws/smithy/kotlin/runtime/net/TlsVersion;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/TlsVersion;
+	public static fun values ()[Laws/smithy/kotlin/runtime/net/TlsVersion;
+}
+
 public final class aws/smithy/kotlin/runtime/net/Url {
 	public static final field Companion Laws/smithy/kotlin/runtime/net/Url$Companion;
 	public fun <init> (Laws/smithy/kotlin/runtime/net/Scheme;Laws/smithy/kotlin/runtime/net/Host;ILjava/lang/String;Laws/smithy/kotlin/runtime/net/QueryParameters;Ljava/lang/String;Laws/smithy/kotlin/runtime/net/UserInfo;ZZ)V

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -81,12 +81,6 @@ public final class aws/smithy/kotlin/runtime/config/TlsVersion : java/lang/Enum 
 	public static fun values ()[Laws/smithy/kotlin/runtime/config/TlsVersion;
 }
 
-public final class aws/smithy/kotlin/runtime/content/ByteArrayContent : aws/smithy/kotlin/runtime/content/ByteStream$Buffer {
-	public fun <init> ([B)V
-	public fun bytes ()[B
-	public fun getContentLength ()Ljava/lang/Long;
-}
-
 public abstract class aws/smithy/kotlin/runtime/content/ByteStream {
 	public static final field Companion Laws/smithy/kotlin/runtime/content/ByteStream$Companion;
 	public fun getContentLength ()Ljava/lang/Long;
@@ -331,12 +325,6 @@ public final class aws/smithy/kotlin/runtime/content/FileContent : aws/smithy/ko
 	public final fun getStart ()J
 	public fun isOneShot ()Z
 	public fun readFrom ()Laws/smithy/kotlin/runtime/io/SdkSource;
-}
-
-public final class aws/smithy/kotlin/runtime/content/StringContent : aws/smithy/kotlin/runtime/content/ByteStream$Buffer {
-	public fun <init> (Ljava/lang/String;)V
-	public fun bytes ()[B
-	public fun getContentLength ()Ljava/lang/Long;
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Crc32Kt {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteArrayContent.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/ByteArrayContent.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.content
 /**
  * Container for wrapping a ByteArray as a [ByteStream]
  */
-public class ByteArrayContent(private val bytes: ByteArray) : ByteStream.Buffer() {
+internal class ByteArrayContent(private val bytes: ByteArray) : ByteStream.Buffer() {
     override val contentLength: Long = bytes.size.toLong()
     override fun bytes(): ByteArray = bytes
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/content/StringContent.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.content
 /**
  * Container for wrapping a String as a [ByteStream]
  */
-public class StringContent(str: String) : ByteStream.Buffer() {
+internal class StringContent(str: String) : ByteStream.Buffer() {
     private val asBytes: ByteArray = str.encodeToByteArray()
 
     override val contentLength: Long = asBytes.size.toLong()

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/TlsVersion.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/TlsVersion.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.net
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/TlsVersion.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/TlsVersion.kt
@@ -1,8 +1,4 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-package aws.smithy.kotlin.runtime.config
+package aws.smithy.kotlin.runtime.net
 
 /**
  * Describes a version of TLS

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
@@ -7,9 +7,9 @@ package aws.smithy.kotlin.runtime.client.config
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.LogMode
 import aws.smithy.kotlin.runtime.config.EnvironmentSetting
-import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.config.enumEnvSetting
 import aws.smithy.kotlin.runtime.config.intEnvSetting
+import aws.smithy.kotlin.runtime.net.TlsVersion
 
 @InternalApi
 public object ClientSettings {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/ClientSettings.kt
@@ -7,7 +7,7 @@ package aws.smithy.kotlin.runtime.client.config
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.LogMode
 import aws.smithy.kotlin.runtime.config.EnvironmentSetting
-import aws.smithy.kotlin.runtime.config.TlsVersion
+import aws.smithy.kotlin.runtime.net.TlsVersion
 import aws.smithy.kotlin.runtime.config.enumEnvSetting
 import aws.smithy.kotlin.runtime.config.intEnvSetting
 

--- a/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
+++ b/runtime/smithy-test/common/src/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.smithy.test
 import aws.smithy.kotlin.runtime.http.HeadersBuilder
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.httptest.TestEngine
@@ -129,7 +128,7 @@ private suspend fun assertRequest(expected: ExpectedHttpRequest, actual: HttpReq
 
     val expectedBody = expected.body?.let {
         assertNotNull(expected.bodyAssert, "body assertion function is required if an expected body is defined")
-        ByteArrayContent(it.encodeToByteArray())
+        HttpBody.fromBytes(it.encodeToByteArray())
     }
 
     expected.bodyAssert?.invoke(expectedBody, actual.body)

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTestBuilderTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/HttpRequestTestBuilderTest.kt
@@ -4,8 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.smithy.test
 
+import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpMethod
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.headers
 import aws.smithy.kotlin.runtime.net.Host
@@ -300,7 +300,7 @@ class HttpRequestTestBuilderTest {
                 operation { mockEngine ->
                     // no actual body should not make it to our assertEquals but it should still fail (invalid test setup)
                     val request = HttpRequest {
-                        body = ByteArrayContent("do not pass go".encodeToByteArray())
+                        body = HttpBody.fromBytes("do not pass go".encodeToByteArray())
                     }
                     mockEngine.roundTrip(execContext, request)
                 }

--- a/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/UtilsTest.kt
+++ b/runtime/smithy-test/common/test/aws/smithy/kotlin/runtime/smithy/test/UtilsTest.kt
@@ -5,7 +5,6 @@
 package aws.smithy.kotlin.runtime.smithy.test
 
 import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -14,7 +13,7 @@ import kotlin.test.assertFails
 class UtilsTest {
 
     private val testBodyContents = "bueller...bueller".encodeAsByteArray()
-    private val testBody = ByteArrayContent(testBodyContents)
+    private val testBody = HttpBody.fromBytes(testBodyContents)
 
     @Test
     fun itComparesEmptyBodies() = runTest {
@@ -40,10 +39,10 @@ class UtilsTest {
         ex2.message!!.shouldContain("actual content was null")
 
         val ex3 = assertFails {
-            assertBytesEqual(ByteArrayContent("foo".encodeAsByteArray()), testBody)
+            assertBytesEqual(HttpBody.fromBytes("foo".encodeAsByteArray()), testBody)
         }
         ex3.message.shouldContain("actual bytes read does not match expected")
 
-        assertBytesEqual(ByteArrayContent(testBodyContents), testBody)
+        assertBytesEqual(HttpBody.fromBytes(testBodyContents), testBody)
     }
 }

--- a/tests/benchmarks/serde-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/serde-benchmarks/build.gradle.kts
@@ -111,9 +111,9 @@ val stageGeneratedSources = tasks.register("stageGeneratedSources") {
                 from("${it.projectionRootDir}")
                 into("${it.sourceSetRootDir}")
                 include("**/model/*.kt")
-                include("**/transform/*.kt")
-                exclude("**/transform/*OperationSerializer.kt")
-                exclude("**/transform/*OperationDeserializer.kt")
+                include("**/serde/*.kt")
+                exclude("**/serde/*OperationSerializer.kt")
+                exclude("**/serde/*OperationDeserializer.kt")
             }
         }
     }

--- a/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/json/TwitterBenchmark.kt
+++ b/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/json/TwitterBenchmark.kt
@@ -7,8 +7,8 @@ package aws.smithy.kotlin.benchmarks.serde.json
 
 import aws.smithy.kotlin.benchmarks.serde.BenchmarkBase
 import aws.smithy.kotlin.benchmarks.serde.json.twitter.model.TwitterFeed
-import aws.smithy.kotlin.benchmarks.serde.json.twitter.transform.deserializeTwitterFeedDocument
-import aws.smithy.kotlin.benchmarks.serde.json.twitter.transform.serializeTwitterFeedDocument
+import aws.smithy.kotlin.benchmarks.serde.json.twitter.serde.deserializeTwitterFeedDocument
+import aws.smithy.kotlin.benchmarks.serde.json.twitter.serde.serializeTwitterFeedDocument
 import aws.smithy.kotlin.runtime.serde.json.JsonDeserializer
 import aws.smithy.kotlin.runtime.serde.json.JsonSerializer
 import aws.smithy.kotlin.runtime.serde.json.JsonToken

--- a/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/xml/XmlDeserializerBenchmark.kt
+++ b/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/xml/XmlDeserializerBenchmark.kt
@@ -6,7 +6,7 @@ package aws.smithy.kotlin.benchmarks.serde.xml
 
 import aws.smithy.kotlin.benchmarks.serde.BenchmarkBase
 import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.model.CountriesAndStates
-import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.transform.deserializeCountriesAndStatesDocument
+import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.serde.deserializeCountriesAndStatesDocument
 import aws.smithy.kotlin.runtime.serde.xml.XmlDeserializer
 import kotlinx.benchmark.*
 import kotlinx.coroutines.runBlocking

--- a/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/xml/XmlSerializerBenchmark.kt
+++ b/tests/benchmarks/serde-benchmarks/jvm/src/aws/smithy/kotlin/benchmarks/serde/xml/XmlSerializerBenchmark.kt
@@ -6,8 +6,8 @@ package aws.smithy.kotlin.benchmarks.serde.xml
 
 import aws.smithy.kotlin.benchmarks.serde.BenchmarkBase
 import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.model.CountriesAndStates
-import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.transform.deserializeCountriesAndStatesDocument
-import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.transform.serializeCountriesAndStatesDocument
+import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.serde.deserializeCountriesAndStatesDocument
+import aws.smithy.kotlin.benchmarks.serde.xml.countriesstates.serde.serializeCountriesAndStatesDocument
 import aws.smithy.kotlin.runtime.serde.xml.XmlDeserializer
 import aws.smithy.kotlin.runtime.serde.xml.XmlSerializer
 import kotlinx.benchmark.*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Miscellaneous cleanup

* **refactor**: Render serialization/deserialization types into `serde` rather than `transform` package. This better matches our own terminology and was leftover from "do what Java does".
* **refactor**: Relocate `TlsVersion` into the `net` subpackage rather than `config`
* **refactor**: Make `StringContent` and `ByteArrayContent` `internal` and force consumers to go through the companion objects for the given types. e.g. `ByteStream.fromBytes(...)` rather than `ByteArrayContent(...)`. Same for `HttpBody.fromBytes(...)`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
