### PR TITLE
feat: implement clock skew interceptor

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -336,13 +336,6 @@ object RuntimeTypes {
         }
     }
 
-    object Kotlin {
-        object Time {
-            val Duration = "kotlin.time.Duration".toSymbol()
-            val nanoseconds = "kotlin.time.Duration.Companion.nanoseconds".toSymbol()
-        }
-    }
-
     object KotlinCoroutines {
         val coroutineContext = "kotlin.coroutines.coroutineContext".toSymbol()
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -88,6 +88,7 @@ object RuntimeTypes {
             val FlexibleChecksumsRequestInterceptor = symbol("FlexibleChecksumsRequestInterceptor")
             val FlexibleChecksumsResponseInterceptor = symbol("FlexibleChecksumsResponseInterceptor")
             val ResponseLengthValidationInterceptor = symbol("ResponseLengthValidationInterceptor")
+            val ClockSkewInterceptor = symbol("ClockSkewInterceptor")
         }
     }
 
@@ -332,6 +333,13 @@ object RuntimeTypes {
         }
         object TelemetryDefaults : RuntimeTypePackage(KotlinDependency.TELEMETRY_DEFAULTS) {
             val Global = symbol("Global")
+        }
+    }
+
+    object Kotlin {
+        object Time {
+            val Duration = "kotlin.time.Duration".toSymbol()
+            val nanoseconds = "kotlin.time.Duration.Companion.nanoseconds".toSymbol()
         }
     }
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -12,6 +12,7 @@ import aws.smithy.kotlin.runtime.auth.awssigning.internal.setAwsChunkedBody
 import aws.smithy.kotlin.runtime.auth.awssigning.internal.setAwsChunkedHeaders
 import aws.smithy.kotlin.runtime.auth.awssigning.internal.useAwsChunkedEncoding
 import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.util.get
@@ -118,7 +119,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
         val contextSignedBodyHeader = attributes.getOrNull(AwsSigningAttributes.SignedBodyHeader)
 
         // operation signing config is baseConfig + operation specific config/overrides
-        val signingConfig = AwsSigningConfig {
+        var signingConfig = AwsSigningConfig {
             region = attributes[AwsSigningAttributes.SigningRegion]
             service = attributes.getOrNull(AwsSigningAttributes.SigningService) ?: checkNotNull(config.service)
             credentials = signingRequest.identity as Credentials
@@ -151,6 +152,15 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
                 // use the payload to compute the hash
                 else -> HashSpecification.CalculateFromPayload
             }
+        }
+
+        // Apply clock skew if necessary
+        signingConfig = if (attributes.contains(HttpOperationContext.ClockSkew)) {
+            val builder = signingConfig.toBuilder()
+            builder.signingDate = builder.signingDate?.plus(attributes[HttpOperationContext.ClockSkew])
+            builder.build()
+        } else {
+            signingConfig
         }
 
         if (signingConfig.useAwsChunkedEncoding) {

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -169,6 +169,36 @@ public final class aws/smithy/kotlin/runtime/http/interceptors/ChecksumMismatchE
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public static final field Companion Laws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor$Companion;
+	public fun <init> ()V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor$Companion {
+	public final fun getCLOCK_SKEW_THRESHOLD-UwyO8pc ()J
+	public final fun getSkew-3nIYWDw (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;)J
+	public final fun isSkewed (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;)Z
+}
+
 public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseException : aws/smithy/kotlin/runtime/SdkBaseException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -47,7 +47,7 @@ public class ClockSkewInterceptor : HttpInterceptor {
         val logger = coroutineContext.logger<ClockSkewInterceptor>()
 
         if (currentSkew != Duration.ZERO) {
-            logger.info { "applying clock skew $currentSkew to client"}
+            logger.info { "applying clock skew $currentSkew to client" }
             context.executionContext[HttpOperationContext.ClockSkew] = currentSkew
         }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.http.interceptors
 
 import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
@@ -58,7 +62,7 @@ public class ClockSkewInterceptor : HttpInterceptor {
             logger.warn { "client clock is skewed $skew, applying correction" }
             context.executionContext[HttpOperationContext.ClockSkew] = skew
         } else {
-            logger.info { "client clock ($clientTime) is not skewed from the server ($serverTime)"}
+            logger.info { "client clock ($clientTime) is not skewed from the server ($serverTime)" }
         }
 
         return context.protocolResponse

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -4,6 +4,7 @@
  */
 package aws.smithy.kotlin.runtime.http.interceptors
 
+import aws.smithy.kotlin.runtime.client.ProtocolRequestInterceptorContext
 import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
@@ -36,6 +37,26 @@ public class ClockSkewInterceptor : HttpInterceptor {
         public fun Instant.isSkewed(serverTime: Instant): Boolean = getSkew(serverTime).absoluteValue >= CLOCK_SKEW_THRESHOLD
     }
 
+    // Clock skew to be applied to all requests
+    private var currentSkew: Duration = Duration.ZERO
+
+    /**
+     * Apply the previously-computed skew, if it's set, to the execution context before signing
+     */
+    public override suspend fun modifyBeforeSigning(context: ProtocolRequestInterceptorContext<Any, HttpRequest>): HttpRequest {
+        val logger = coroutineContext.logger<ClockSkewInterceptor>()
+
+        if (currentSkew != Duration.ZERO) {
+            logger.info { "applying clock skew $currentSkew to client"}
+            context.executionContext[HttpOperationContext.ClockSkew] = currentSkew
+        }
+
+        return context.protocolRequest
+    }
+
+    /**
+     * After receiving a response, check if the client clock is skewed and apply a correction if necessary.
+     */
     public override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
         val logger = coroutineContext.logger<ClockSkewInterceptor>()
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -1,0 +1,66 @@
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.client.ProtocolResponseInterceptorContext
+import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.http.response.header
+import aws.smithy.kotlin.runtime.telemetry.logging.logger
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+public class ClockSkewInterceptor : HttpInterceptor {
+    public companion object {
+        /**
+         * How much must the clock be skewed before attempting correction
+         */
+        public val CLOCK_SKEW_THRESHOLD: Duration = 4.minutes
+
+        /**
+         * Get the current skew between the client time and [serverTime] as a [Duration].
+         * It may be negative if the serverTime is in the future.
+         * @param serverTime the server's time
+         */
+        public fun Instant.getSkew(serverTime: Instant): Duration {
+            return this.until(serverTime)
+        }
+
+        /**
+         * Determine whether the client's clock is skewed relative to the server.
+         * @param serverTime the server's time
+         */
+        public fun Instant.isSkewed(serverTime: Instant): Boolean {
+            return getSkew(serverTime).absoluteValue >= CLOCK_SKEW_THRESHOLD
+        }
+    }
+
+    public override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {
+        val logger = coroutineContext.logger<ClockSkewInterceptor>()
+
+        val clientTime = context.protocolRequest.headers["x-amz-date"]?.let {
+            Instant.fromIso8601(it)
+        } ?: run {
+            logger.info { "client did not send \"x-amz-date\" header, skipping skew calculation" }
+            return context.protocolResponse
+        }
+
+        val serverTime = context.protocolResponse.header("Date")?.let {
+            Instant.fromRfc5322(it)
+        } ?: run {
+            logger.info { "service did not return \"Date\" header, skipping skew calculation" }
+            return context.protocolResponse
+        }
+
+        if (clientTime.isSkewed(serverTime)) {
+            val skew = clientTime.getSkew(serverTime)
+            logger.warn { "client clock is skewed $skew, applying correction" }
+            context.executionContext[HttpOperationContext.ClockSkew] = skew
+        } else {
+            logger.info { "client clock ($clientTime) is not skewed from the server ($serverTime)"}
+        }
+
+        return context.protocolResponse
+    }
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -24,7 +24,7 @@ public class ClockSkewInterceptor : HttpInterceptor {
 
         /**
          * Get the current skew between the client time and [serverTime] as a [Duration].
-         * It may be negative if the serverTime is in the future.
+         * It may be negative if the serverTime is in the past.
          * @param serverTime the server's time
          */
         public fun Instant.getSkew(serverTime: Instant): Duration = this.until(serverTime)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -78,9 +78,9 @@ public class ClockSkewInterceptor : HttpInterceptor {
         }
 
         if (clientTime.isSkewed(serverTime)) {
-            val skew = clientTime.getSkew(serverTime)
-            logger.warn { "client clock is skewed $skew, applying correction" }
-            context.executionContext[HttpOperationContext.ClockSkew] = skew
+            currentSkew = clientTime.getSkew(serverTime)
+            logger.warn { "client clock is skewed $currentSkew, applying correction" }
+            context.executionContext[HttpOperationContext.ClockSkew] = currentSkew
         } else {
             logger.info { "client clock ($clientTime) is not skewed from the server ($serverTime)" }
         }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -27,7 +27,7 @@ public class ClockSkewInterceptor : HttpInterceptor {
          * It may be negative if the serverTime is in the future.
          * @param serverTime the server's time
          */
-        public fun Instant.getSkew(serverTime: Instant): Duration =this.until(serverTime)
+        public fun Instant.getSkew(serverTime: Instant): Duration = this.until(serverTime)
 
         /**
          * Determine whether the client's clock is skewed relative to the server.

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -27,17 +27,13 @@ public class ClockSkewInterceptor : HttpInterceptor {
          * It may be negative if the serverTime is in the future.
          * @param serverTime the server's time
          */
-        public fun Instant.getSkew(serverTime: Instant): Duration {
-            return this.until(serverTime)
-        }
+        public fun Instant.getSkew(serverTime: Instant): Duration =this.until(serverTime)
 
         /**
          * Determine whether the client's clock is skewed relative to the server.
          * @param serverTime the server's time
          */
-        public fun Instant.isSkewed(serverTime: Instant): Boolean {
-            return getSkew(serverTime).absoluteValue >= CLOCK_SKEW_THRESHOLD
-        }
+        public fun Instant.isSkewed(serverTime: Instant): Boolean = getSkew(serverTime).absoluteValue >= CLOCK_SKEW_THRESHOLD
     }
 
     public override suspend fun modifyBeforeDeserialization(context: ProtocolResponseInterceptorContext<Any, HttpRequest, HttpResponse>): HttpResponse {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptor.kt
@@ -16,6 +16,9 @@ import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
+/**
+ * An interceptor used to detect clock skew (difference between client and server clocks) and apply a correction.
+ */
 public class ClockSkewInterceptor : HttpInterceptor {
     public companion object {
         /**

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -9,6 +9,7 @@ import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.http.HttpCall
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.util.*
+import kotlin.time.Duration
 
 /**
  * Common configuration for an SDK (HTTP) operation/call
@@ -50,6 +51,11 @@ public object HttpOperationContext {
      * Cached attribute level attributes (e.g. rpc.method, rpc.service, etc)
      */
     public val OperationAttributes: AttributeKey<Attributes> = AttributeKey("aws.smithy.kotlin#OperationAttributes")
+
+    /**
+     * The clock skew duration to apply to any time-based calculations in the operation (e.g. signing)
+     */
+    public val ClockSkew: AttributeKey<Duration> = AttributeKey("aws.smithy.kotlin#ClockSkew")
 }
 
 internal val ExecutionContext.operationMetrics: OperationMetrics

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.interceptors
+
+import aws.smithy.kotlin.runtime.http.*
+import aws.smithy.kotlin.runtime.http.content.ByteArrayContent
+import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companion.CLOCK_SKEW_THRESHOLD
+import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companion.getSkew
+import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companion.isSkewed
+import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.operation.newTestOperation
+import aws.smithy.kotlin.runtime.http.operation.roundTrip
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
+import aws.smithy.kotlin.runtime.httptest.TestEngine
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.io.source
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+
+class ClockSkewInterceptorTest {
+    @Test
+    fun testNotSkewed() {
+        val clientTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
+        val serverTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
+        assertFalse(clientTime.isSkewed(serverTime))
+    }
+
+    @Test
+    fun testSkewed() {
+        val clientTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
+        val serverTime = Instant.fromRfc5322("Wed, 7 Oct 2023 16:20:50 -0400")
+        assertTrue(clientTime.isSkewed(serverTime))
+        assertEquals(1.days, clientTime.getSkew(serverTime))
+    }
+
+    @Test
+    fun testNegativeSkewed() {
+        val clientTime = Instant.fromRfc5322("Wed, 7 Oct 2023 16:20:50 -0400")
+        val serverTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
+        assertTrue(clientTime.isSkewed(serverTime))
+        assertEquals(0.seconds - 1.days, clientTime.getSkew(serverTime))
+    }
+
+    @Test
+    fun testSkewThreshold() {
+        val minute = 20
+        var clientTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:${minute - CLOCK_SKEW_THRESHOLD.inWholeMinutes}:50 -0400")
+        val serverTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:$minute:50 -0400")
+        assertTrue(clientTime.isSkewed(serverTime))
+        assertEquals(CLOCK_SKEW_THRESHOLD, clientTime.getSkew(serverTime))
+
+        // narrow the skew by one second, crossing the threshold
+        clientTime += 1.seconds
+        assertFalse(clientTime.isSkewed(serverTime))
+    }
+
+    @Test
+    fun testClockSkewApplied() = runTest {
+        val serverTimeString = "Wed, 14 Sep 2023 16:20:50 -0400"
+        val serverTime = Instant.fromRfc5322(serverTimeString)
+
+        val clientTimeString = "20231006T131604Z"
+        val clientTime = Instant.fromIso8601(clientTimeString)
+
+        val client = getMockClient("bla".encodeToByteArray(), Headers {
+            append("Date", serverTimeString)
+        })
+
+        val req = HttpRequestBuilder().apply {
+            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+        }
+        req.headers.append("x-amz-date", clientTimeString)
+
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        op.interceptors.add(ClockSkewInterceptor())
+
+        op.roundTrip(client, Unit)
+
+        // Validate the skew got stored in execution context
+        val expectedSkew = clientTime.getSkew(serverTime)
+        assertEquals(op.context.getOrNull(HttpOperationContext.ClockSkew), expectedSkew)
+    }
+
+    @Test
+    fun testClockSkewNotApplied() = runTest {
+        val serverTimeString = "Wed, 06 Oct 2023 13:16:04 -0000"
+        val clientTimeString = "20231006T131604Z"
+
+        val client = getMockClient("bla".encodeToByteArray(), Headers {
+            append("Date", serverTimeString)
+        })
+
+        val req = HttpRequestBuilder().apply {
+            body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
+        }
+        req.headers.append("x-amz-date", clientTimeString)
+
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        op.interceptors.add(ClockSkewInterceptor())
+
+        op.roundTrip(client, Unit)
+
+        // Validate no skew was detected
+        assertNull(op.context.getOrNull(HttpOperationContext.ClockSkew))
+    }
+
+    private fun getMockClient(response: ByteArray, responseHeaders: Headers = Headers.Empty): SdkHttpClient {
+        val mockEngine = TestEngine { _, request ->
+            val body = object : HttpBody.SourceContent() {
+                override val contentLength: Long = response.size.toLong()
+                override fun readFrom(): SdkSource = response.source()
+                override val isOneShot: Boolean get() = false
+            }
+            val resp = HttpResponse(HttpStatusCode.OK, responseHeaders, body)
+            HttpCall(request, resp, Instant.now(), Instant.now())
+        }
+        return SdkHttpClient(mockEngine)
+    }
+}

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
@@ -29,6 +29,7 @@ class ClockSkewInterceptorTest {
     fun testNotSkewed() {
         val clientTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
         val serverTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
+        assertEquals(clientTime, serverTime)
         assertFalse(clientTime.isSkewed(serverTime))
     }
 
@@ -56,7 +57,7 @@ class ClockSkewInterceptorTest {
         assertTrue(clientTime.isSkewed(serverTime))
         assertEquals(CLOCK_SKEW_THRESHOLD, clientTime.getSkew(serverTime))
 
-        // narrow the skew by one second, crossing the threshold
+        // shrink the skew by one second, crossing the threshold
         clientTime += 1.seconds
         assertFalse(clientTime.isSkewed(serverTime))
     }
@@ -95,6 +96,7 @@ class ClockSkewInterceptorTest {
     fun testClockSkewNotApplied() = runTest {
         val serverTimeString = "Wed, 06 Oct 2023 13:16:04 -0000"
         val clientTimeString = "20231006T131604Z"
+        assertEquals(Instant.fromRfc5322(serverTimeString), Instant.fromIso8601(clientTimeString))
 
         val client = getMockClient(
             "bla".encodeToByteArray(),

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
@@ -10,9 +10,9 @@ import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companio
 import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companion.getSkew
 import aws.smithy.kotlin.runtime.http.interceptors.ClockSkewInterceptor.Companion.isSkewed
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
-import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
 import aws.smithy.kotlin.runtime.http.operation.roundTrip
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.io.SdkSource
@@ -69,9 +69,12 @@ class ClockSkewInterceptorTest {
         val clientTimeString = "20231006T131604Z"
         val clientTime = Instant.fromIso8601(clientTimeString)
 
-        val client = getMockClient("bla".encodeToByteArray(), Headers {
-            append("Date", serverTimeString)
-        })
+        val client = getMockClient(
+            "bla".encodeToByteArray(),
+            Headers {
+                append("Date", serverTimeString)
+            },
+        )
 
         val req = HttpRequestBuilder().apply {
             body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())
@@ -93,9 +96,12 @@ class ClockSkewInterceptorTest {
         val serverTimeString = "Wed, 06 Oct 2023 13:16:04 -0000"
         val clientTimeString = "20231006T131604Z"
 
-        val client = getMockClient("bla".encodeToByteArray(), Headers {
-            append("Date", serverTimeString)
-        })
+        val client = getMockClient(
+            "bla".encodeToByteArray(),
+            Headers {
+                append("Date", serverTimeString)
+            },
+        )
 
         val req = HttpRequestBuilder().apply {
             body = ByteArrayContent("<Foo>bar</Foo>".encodeToByteArray())

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/ClockSkewInterceptorTest.kt
@@ -20,6 +20,7 @@ import aws.smithy.kotlin.runtime.io.source
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
@@ -44,7 +45,7 @@ class ClockSkewInterceptorTest {
         val clientTime = Instant.fromRfc5322("Wed, 7 Oct 2023 16:20:50 -0400")
         val serverTime = Instant.fromRfc5322("Wed, 6 Oct 2023 16:20:50 -0400")
         assertTrue(clientTime.isSkewed(serverTime))
-        assertEquals(0.seconds - 1.days, clientTime.getSkew(serverTime))
+        assertEquals(Duration.ZERO - 1.days, clientTime.getSkew(serverTime))
     }
 
     @Test

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -8,11 +8,13 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 public class aws/smithy/kotlin/runtime/ErrorMetadata {
 	public static final field Companion Laws/smithy/kotlin/runtime/ErrorMetadata$Companion;
 	public fun <init> ()V
+	public final fun isClockSkewError ()Z
 	public final fun isRetryable ()Z
 	public final fun isThrottling ()Z
 }
 
 public final class aws/smithy/kotlin/runtime/ErrorMetadata$Companion {
+	public final fun getClockSkewError ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getRetryable ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getThrottlingError ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
@@ -1193,6 +1195,7 @@ public final class aws/smithy/kotlin/runtime/retries/policy/RetryDirective$Termi
 public final class aws/smithy/kotlin/runtime/retries/policy/RetryErrorType : java/lang/Enum {
 	public static final field ClientSide Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static final field ServerSide Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
+	public static final field Skew Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static final field Throttling Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static final field Transient Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
 	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/retries/policy/RetryErrorType;
@@ -1245,6 +1248,7 @@ public final class aws/smithy/kotlin/runtime/time/Instant : java/lang/Comparable
 	public final fun minus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public final fun plus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public fun toString ()Ljava/lang/String;
+	public final fun until-5sfh64U (Laws/smithy/kotlin/runtime/time/Instant;)J
 }
 
 public final class aws/smithy/kotlin/runtime/time/Instant$Companion {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -8,13 +8,11 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 public class aws/smithy/kotlin/runtime/ErrorMetadata {
 	public static final field Companion Laws/smithy/kotlin/runtime/ErrorMetadata$Companion;
 	public fun <init> ()V
-	public final fun isClockSkewError ()Z
 	public final fun isRetryable ()Z
 	public final fun isThrottling ()Z
 }
 
 public final class aws/smithy/kotlin/runtime/ErrorMetadata$Companion {
-	public final fun getClockSkewError ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getRetryable ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getThrottlingError ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/policy/RetryErrorType.kt
@@ -30,4 +30,9 @@ public enum class RetryErrorType {
      * effect on the server
      */
     Transient,
+
+    /**
+     * An error indicating that the client and server clock are skewed. A retry may be attempted after correction.
+     */
+    Skew,
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -43,6 +43,8 @@ public expect class Instant : Comparable<Instant> {
      */
     public operator fun minus(duration: Duration): Instant
 
+    public fun until(other: Instant): Duration
+
     public companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -22,6 +22,7 @@ import java.time.format.SignStyle
 import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 import java.time.Instant as jtInstant
 
 public actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
@@ -79,6 +80,8 @@ public actual class Instant(internal val value: jtInstant) : Comparable<Instant>
             }
         }
     }
+
+    public actual fun until(other: Instant): Duration = value.until(other.value, ChronoUnit.NANOS).nanoseconds
 
     public actual companion object {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implements a clock skew interceptor which detects clock skews and applies corrections. The clock skew is stored as part of the interceptor's state so it can be applied to all future requests.


## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/awslabs/aws-sdk-kotlin/issues/213

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
