### PR TITLE
refactor!: rename metrics and remove redundant metrics

### DIFF
--- a/.changes/b31b8667-e931-49cf-8897-4e2ded2b7f14.json
+++ b/.changes/b31b8667-e931-49cf-8897-4e2ded2b7f14.json
@@ -1,0 +1,5 @@
+{
+    "id": "b31b8667-e931-49cf-8897-4e2ded2b7f14",
+    "type": "misc",
+    "description": "Expose immutable `SpanContext` on `TraceSpan`"
+}

--- a/.changes/c063605b-4702-4d8a-a841-2e0b7aa78e78.json
+++ b/.changes/c063605b-4702-4d8a-a841-2e0b7aa78e78.json
@@ -1,0 +1,5 @@
+{
+    "id": "c063605b-4702-4d8a-a841-2e0b7aa78e78",
+    "type": "misc",
+    "description": "**BREAKING**: Remove `smithy.client.request.size`, `smithy.client.response.size`, `smithy.client.retires` metrics. Rename all `smithy.client.*` metrics to `smithy.client.call.*`."
+}

--- a/.changes/c063605b-4702-4d8a-a841-2e0b7aa78e78.json
+++ b/.changes/c063605b-4702-4d8a-a841-2e0b7aa78e78.json
@@ -1,5 +1,5 @@
 {
     "id": "c063605b-4702-4d8a-a841-2e0b7aa78e78",
     "type": "misc",
-    "description": "**BREAKING**: Remove `smithy.client.request.size`, `smithy.client.response.size`, `smithy.client.retires` metrics. Rename all `smithy.client.*` metrics to `smithy.client.call.*`."
+    "description": "**BREAKING**: Remove `smithy.client.request.size`, `smithy.client.response.size`, `smithy.client.retries` metrics. Rename all `smithy.client.*` metrics to `smithy.client.call.*`."
 }

--- a/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4j1xLoggerAdapter.kt
+++ b/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4j1xLoggerAdapter.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.telemetry.logging.slf4j
 
-import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.logging.LogLevel
 import aws.smithy.kotlin.runtime.telemetry.logging.LogRecordBuilder
 import aws.smithy.kotlin.runtime.telemetry.logging.LoggerProvider
@@ -45,10 +44,6 @@ private class Slf4j1xLogRecordBuilderAdapter(
 
     override fun setKeyValuePair(key: String, value: Any) {
         kvp[key] = value
-    }
-
-    override fun setContext(context: Context) {
-        // TODO - add a way to get the current trace context and set the key/value pair on it?
     }
 
     override fun emit() {

--- a/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4j2xLoggerAdapter.kt
+++ b/runtime/observability/logging-slf4j2/jvm/src/aws/smithy/kotlin/runtime/telemetry/logging/slf4j/Slf4j2xLoggerAdapter.kt
@@ -4,7 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.telemetry.logging.slf4j
 
-import aws.smithy.kotlin.runtime.telemetry.context.Context
 import aws.smithy.kotlin.runtime.telemetry.logging.LogLevel
 import aws.smithy.kotlin.runtime.telemetry.logging.LogRecordBuilder
 import org.slf4j.event.Level
@@ -35,10 +34,6 @@ private class Slf4j2xLogRecordBuilderAdapter(
 
     override fun setKeyValuePair(key: String, value: Any) {
         delegate.addKeyValue(key, value)
-    }
-
-    override fun setContext(context: Context) {
-        // TODO - add a way to get the current trace context and set the key/value pair on it?
     }
 
     override fun emit() = delegate.log()

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -68,7 +68,6 @@ public final class aws/smithy/kotlin/runtime/telemetry/logging/LogLevel : java/l
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder {
 	public abstract fun emit ()V
 	public abstract fun setCause (Ljava/lang/Throwable;)V
-	public abstract fun setContext (Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
 	public abstract fun setKeyValuePair (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun setMessage (Ljava/lang/String;)V
 	public abstract fun setMessage (Lkotlin/jvm/functions/Function0;)V
@@ -190,6 +189,18 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Def
 public final class aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExtKt {
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/SpanContext {
+	public static final field Companion Laws/smithy/kotlin/runtime/telemetry/trace/SpanContext$Companion;
+	public abstract fun getSpanId ()Ljava/lang/String;
+	public abstract fun getTraceId ()Ljava/lang/String;
+	public abstract fun isRemote ()Z
+	public abstract fun isValid ()Z
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/trace/SpanContext$Companion {
+	public final fun getInvalid ()Laws/smithy/kotlin/runtime/telemetry/trace/SpanContext;
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/trace/SpanKind : java/lang/Enum {
 	public static final field CLIENT Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;
 	public static final field INTERNAL Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;
@@ -209,7 +220,7 @@ public final class aws/smithy/kotlin/runtime/telemetry/trace/SpanStatus : java/l
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan : aws/smithy/kotlin/runtime/telemetry/context/Scope {
 	public abstract fun close ()V
 	public abstract fun emitEvent (Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)V
-	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getSpanContext ()Laws/smithy/kotlin/runtime/telemetry/trace/SpanContext;
 	public abstract fun mergeAttributes (Laws/smithy/kotlin/runtime/util/Attributes;)V
 	public abstract fun set (Laws/smithy/kotlin/runtime/util/AttributeKey;Ljava/lang/Object;)V
 	public abstract fun setStatus (Laws/smithy/kotlin/runtime/telemetry/trace/SpanStatus;)V

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/LogRecordBuilder.kt
@@ -5,8 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
-import aws.smithy.kotlin.runtime.telemetry.context.Context
-
 /**
  * Construct a logging record that can be emitted to an underlying logger.
  */
@@ -37,12 +35,6 @@ public interface LogRecordBuilder {
      * @param value the value to associate with [key]
      */
     public fun setKeyValuePair(key: String, value: Any)
-
-    /**
-     * Set the telemetry context to associate with this log record
-     * @param context the context to associate
-     */
-    public fun setContext(context: Context)
 
     /**
      * Emit this event to the underlying logger

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/logging/NoOpLogger.kt
@@ -5,8 +5,6 @@
 
 package aws.smithy.kotlin.runtime.telemetry.logging
 
-import aws.smithy.kotlin.runtime.telemetry.context.Context
-
 internal object NoOpLoggerProvider : LoggerProvider {
     override fun getOrCreateLogger(name: String): Logger = NoOpLogger
 }
@@ -26,6 +24,5 @@ private object NoOpLogRecordBuilder : LogRecordBuilder {
     override fun setMessage(message: String) {}
     override fun setMessage(message: MessageSupplier) {}
     override fun setKeyValuePair(key: String, value: Any) {}
-    override fun setContext(context: Context) {}
     override fun emit() {}
 }

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/NoOpTracerProvider.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/NoOpTracerProvider.kt
@@ -23,7 +23,7 @@ private object NoOpTracer : Tracer {
 }
 
 private object NoOpTraceSpan : TraceSpan {
-    override val name: String = "NoOpSpan"
+    override val spanContext: SpanContext = SpanContext.Invalid
     override fun emitEvent(name: String, attributes: Attributes) {}
     override fun setStatus(status: SpanStatus) {}
     override operator fun <T : Any> set(key: AttributeKey<T>, value: T) {}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/SpanContext.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/SpanContext.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.telemetry.trace
+
+/**
+ * The immutable state that must be serialized and propagated as part of a distributed trace context.
+ */
+public interface SpanContext {
+    public companion object {
+        public val Invalid: SpanContext = InvalidSpanContext
+    }
+
+    /**
+     * The unique trace identifier this span belongs to
+     */
+    public val traceId: String
+
+    /**
+     * The unique span identifier
+     */
+    public val spanId: String
+
+    /**
+     * True if the [SpanContext] was propagated from a remote parent
+     */
+    public val isRemote: Boolean
+
+    /**
+     * True if the [SpanContext] has a non-zero [traceId] and [spanId]
+     */
+    public val isValid: Boolean
+}
+
+private object InvalidSpanContext : SpanContext {
+    override val traceId: String = "00000000000000000000000000000000"
+    override val spanId: String = "0000000000000000"
+    override val isRemote: Boolean = false
+    override val isValid: Boolean = false
+}

--- a/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
+++ b/runtime/observability/telemetry-api/common/src/aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan.kt
@@ -16,9 +16,9 @@ import aws.smithy.kotlin.runtime.util.emptyAttributes
  */
 public interface TraceSpan : Scope {
     /**
-     * The name of the span
+     * The immutable tracing context this span belongs to
      */
-    public val name: String
+    public val spanContext: SpanContext
 
     /**
      * Set an attribute on the span
@@ -34,7 +34,6 @@ public interface TraceSpan : Scope {
      */
     public fun mergeAttributes(attributes: Attributes)
 
-    // FIXME - when would we use OTeL trace events vs logs?
     /**
      * Add an event to this span
      * @param name the name of the event

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/OperationTelemetryInterceptor.kt
@@ -57,14 +57,6 @@ internal class OperationTelemetryInterceptor(
             metrics.rpcCallDuration.recordSeconds(callDuration, perRpcAttributes, currentCtx)
         }
 
-        context.protocolRequest?.body?.contentLength?.let {
-            metrics.rpcRequestSize.record(it, perRpcAttributes, currentCtx)
-        }
-
-        context.protocolResponse?.body?.contentLength?.let {
-            metrics.rpcResponseSize.record(it, perRpcAttributes, currentCtx)
-        }
-
         context.response.exceptionOrNull()?.let { ex ->
             val exType = ex::class.simpleName
             val errorAttributes = if (exType != null) {
@@ -90,9 +82,6 @@ internal class OperationTelemetryInterceptor(
     override fun readAfterAttempt(context: ResponseInterceptorContext<Any, Any, HttpRequest, HttpResponse?>) {
         metrics.rpcAttempts.add(1L, perRpcAttributes, metrics.provider.contextManager.current())
         attempts++
-        if (attempts > 1) {
-            metrics.rpcRetryCount.add(1L, perRpcAttributes, metrics.provider.contextManager.current())
-        }
 
         val attemptDuration = attemptStart?.elapsedNow() ?: return
         metrics.rpcAttemptDuration.recordSeconds(attemptDuration, perRpcAttributes, metrics.provider.contextManager.current())

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationMetrics.kt
@@ -8,7 +8,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.metrics.DoubleHistogram
-import aws.smithy.kotlin.runtime.telemetry.metrics.LongHistogram
 import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
 
 /**
@@ -28,17 +27,14 @@ public class OperationMetrics(
         val None: OperationMetrics = OperationMetrics("NoOp", TelemetryProvider.None)
     }
 
-    public val rpcCallDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.duration", "s", "Overall call duration including retries")
-    public val rpcAttempts: MonotonicCounter = meter.createMonotonicCounter("smithy.client.attempts", "{attempt}", "The number of attempts for an operation")
-    public val rpcErrors: MonotonicCounter = meter.createMonotonicCounter("smithy.client.errors", "{error}", "The number of errors for an operation")
-    public val rpcRetryCount: MonotonicCounter = meter.createMonotonicCounter("smithy.client.retries", "{count}", "The number of retries for an operation")
-    public val rpcRequestSize: LongHistogram = meter.createLongHistogram("smithy.client.request.size", "By", "Size of the serialized request message")
-    public val rpcResponseSize: LongHistogram = meter.createLongHistogram("smithy.client.response.size", "By", "Size of the serialized response message")
-    public val rpcAttemptDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.attempt_duration", "s", "The time it takes to connect to complete an entire call attempt, including identity resolution, endpoint resolution, signing, sending the request, and receiving the HTTP status code and headers from the response for an operation")
-    public val rpcAttemptOverheadDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.attempt_overhead_duration", "s", "The time it takes to execute an attempt minus the time spent waiting for a response from the remote server")
-    public val serializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.serialization_duration", "s", "The time it takes to serialize a request message body")
-    public val deserializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.deserialization_duration", "s", "The time it takes to deserialize a response message body")
-    public val resolveEndpointDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.resolve_endpoint_duration", "s", "The time it takes to resolve an endpoint for a request")
-    public val resolveIdentityDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.auth.resolve_identity_duration", "s", "The time it takes to resolve an identity for signing a request")
-    public val signingDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.auth.signing_duration", "s", "The time it takes to sign a request")
+    public val rpcCallDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.duration", "s", "Overall call duration including retries")
+    public val rpcAttempts: MonotonicCounter = meter.createMonotonicCounter("smithy.client.call.attempts", "{attempt}", "The number of attempts for an operation")
+    public val rpcErrors: MonotonicCounter = meter.createMonotonicCounter("smithy.client.call.errors", "{error}", "The number of errors for an operation")
+    public val rpcAttemptDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.attempt_duration", "s", "The time it takes to connect to complete an entire call attempt, including identity resolution, endpoint resolution, signing, sending the request, and receiving the HTTP status code and headers from the response for an operation")
+    public val rpcAttemptOverheadDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.attempt_overhead_duration", "s", "The time it takes to execute an attempt minus the time spent waiting for a response from the remote server")
+    public val serializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.serialization_duration", "s", "The time it takes to serialize a request message body")
+    public val deserializationDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.deserialization_duration", "s", "The time it takes to deserialize a response message body")
+    public val resolveEndpointDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.resolve_endpoint_duration", "s", "The time it takes to resolve an endpoint for a request")
+    public val resolveIdentityDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.auth.resolve_identity_duration", "s", "The time it takes to resolve an identity for signing a request")
+    public val signingDuration: DoubleHistogram = meter.createDoubleHistogram("smithy.client.call.auth.signing_duration", "s", "The time it takes to sign a request")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a


## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* **refactor!**: remove `smithy.client.request.size`, `smithy.client.response.size`, and `smithy.client.retries` metrics
* **refactor!**: rename `smithy.client.*` metrics to `smithy.client.call.*` 
* **refactor**: Add `SpanContext` to `TraceSpan`
* **refactor!**: Remove `setContext` from fluent log builder in-favor of explicitly setting span context K/V pairs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
