### PR TITLE
chore: refactor ci workflows

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,6 +63,12 @@ jobs:
           echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
           ./gradlew apiCheck
           ./gradlew test allTests
+      - name: Save Test Reports
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: '**/build/reports'
 
   downstream:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         path: 'aws-kotlin-repo-tools'
         repository: 'awslabs/aws-kotlin-repo-tools'
-        ref: 'gh-action'
+        ref: '0.2.3'
         sparse-checkout: |
           .github
     - name: Checkout aws-sdk-kotlin

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,87 +4,98 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches:
-      - main
-      - 'feat-*'
   workflow_dispatch:
 
+# Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
+concurrency:
+  group: ci-pr-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
-  BUILDER_VERSION: v0.8.22
-  BUILDER_SOURCE: releases
-  # host owned by CRT team to host aws-crt-builder releases. Contact their on-call with any issues
-  BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  PACKAGE_NAME: smithy-kotlin
-  LINUX_BASE_IMAGE: ubuntu-16-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
 jobs:
-  linux-compat:
+  jvm:
     runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Build and Test ${{ env.PACKAGE_NAME }}
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        chmod a+x builder.pyz
-        echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-        ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
-
-  macos-compat:
-    runs-on: macos-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Build and Test ${{ env.PACKAGE_NAME }}
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        chmod a+x builder.pyz
-        echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-        ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
-
-  windows-compat:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # we build with a specific JDK version but source/target compatibility should ensure the jar is usable by
+        # the target versions we want to support
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Build and Test ${{ env.PACKAGE_NAME }}
+        uses: actions/checkout@v4
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+          cache: 'gradle'
+      - name: Test
+        shell: bash
         run: |
-          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python3 builder.pyz build -p ${{ env.PACKAGE_NAME }}
+          ./gradlew -Ptest.java.version=${{ matrix.java-version }} jvmTest --stacktrace
+
+  all-platforms:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+          cache: 'gradle'
+      - name: Test
+        shell: bash
+        run: |
+          echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
+          ./gradlew apiCheck
+          ./gradlew test allTests
 
   downstream:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
+      uses: actions/checkout@v4
       with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Build and Test ${{ env.PACKAGE_NAME }} Downstream Consumers
+        path: 'smithy-kotlin'
+    - name: Checkout tools
+      uses: actions/checkout@v4
+      with:
+        path: 'aws-kotlin-repo-tools'
+        repository: 'awslabs/aws-kotlin-repo-tools'
+        ref: 'gh-action'
+        sparse-checkout: |
+          .github
+    - name: Checkout aws-sdk-kotlin
+      uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
+      with:
+        # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
+        path: 'aws-sdk-kotlin'
+        repository: 'awslabs/aws-sdk-kotlin'
+    - name: Configure JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'
+        java-version: 17
+        cache: 'gradle'
+    - name: Build and Test aws-sdk-kotlin downstream
       run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec downstream
+        # TODO - JVM only
+        cd $GITHUB_WORKSPACE/smithy-kotlin
+        ./gradlew --parallel publishToMavenLocal
+        cd $GITHUB_WORKSPACE/aws-sdk-kotlin
+        ./gradlew --parallel publishToMavenLocal
+        ./gradlew testAllProtocols

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ allprojects {
 
     if (testJavaVersion != null) {
         tasks.withType<Test> {
+            // JDK8 tests fail with out of memory sometimes, not sure why...
+            maxHeapSize = "2g"
             val toolchains = project.extensions.getByType<JavaToolchainService>()
             javaLauncher.set(
                 toolchains.launcherFor {

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -37,11 +37,11 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.stream.Collectors
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.name
 import kotlin.io.path.readText
-import kotlin.streams.toList
 import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
@@ -94,7 +94,9 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
     private val testDirPaths: List<Path> by lazy {
         Files
             .walk(testSuitePath)
-            .toList()
+            // Due to https://youtrack.jetbrains.com/issue/KT-47039 setting jvmTarget compatibility isn't enough
+            // ignore the toList() extension in-favor of something that should work JDK8+ even if we compile with JDK17+
+            .collect(Collectors.toList())
             .filter { !it.isDirectory() && it.name == "request.txt" }
             .filterNot { it.parent.name in disabledTests }
             .map { it.parent }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -63,4 +63,10 @@ subprojects {
     dependencies {
         dokkaPlugin(project(":dokka-smithy"))
     }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -52,9 +52,6 @@ subprojects {
                 }
             }
         }
-
-        // Due to https://youtrack.jetbrains.com/issue/KT-47039 setting jvmTarget compatibility isn't enough
-        jvmToolchain(8)
     }
 
     kotlin.sourceSets.all {
@@ -65,5 +62,11 @@ subprojects {
 
     dependencies {
         dokkaPlugin(project(":dokka-smithy"))
+    }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
     }
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -52,6 +52,9 @@ subprojects {
                 }
             }
         }
+
+        // Due to https://youtrack.jetbrains.com/issue/KT-47039 setting jvmTarget compatibility isn't enough
+        jvmToolchain(8)
     }
 
     kotlin.sourceSets.all {
@@ -62,11 +65,5 @@ subprojects {
 
     dependencies {
         dokkaPlugin(project(":dokka-smithy"))
-    }
-
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,14 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+}
+
 sourceControl {
     gitRepository(java.net.URI("https://github.com/awslabs/aws-kotlin-repo-tools.git")) {
         producesModule("aws.sdk.kotlin:build-plugins")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Refactor CI to no longer need CRT builder (still used by codebuild jobs for now though). Restructures main PR workflow to test against a matrix of JVM versions and match upstream `aws-sdk-kotlin` https://github.com/awslabs/aws-sdk-kotlin/pull/1069

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
