### PR TITLE
refactor: xml content type header renderer to be overridable

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -193,6 +193,15 @@ val Shape.isStreaming: Boolean
     get() = hasTrait<StreamingTrait>()
 
 /**
+ * Returns boolean indicating if operation input is union shaped
+ */
+fun OperationShape.payloadIsUnionShape(model: Model): Boolean {
+    val requestShape = model.expectShape<StructureShape>(input.get())
+    val payload = requestShape.findMemberWithTrait<HttpPayloadTrait>(model)?.targetOrSelf(model)
+    return payload is UnionShape
+}
+
+/**
  * Test if a member targets an event stream
  */
 fun StructureShape.hasEventStreamMember(model: Model): Boolean {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -21,7 +21,6 @@ import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rulesengine.traits.EndpointTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
-import kotlin.streams.toList
 
 /**
  * Get all shapes of a particular type from the model.
@@ -216,6 +215,14 @@ fun OperationShape.isInputEventStream(model: Model): Boolean {
 fun OperationShape.isOutputEventStream(model: Model): Boolean {
     val respShape = model.expectShape<StructureShape>(output.get())
     return respShape.hasEventStreamMember(model)
+}
+
+/**
+ * Returns boolean indicating if operation input is union shaped
+ */
+fun OperationShape.inputIsUnionShape(model: Model): Boolean {
+    val reqShape = model.expectShape<StructureShape>(input.get())
+    return reqShape.isUnionShape
 }
 
 /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/model/ShapeExt.kt
@@ -193,7 +193,7 @@ val Shape.isStreaming: Boolean
     get() = hasTrait<StreamingTrait>()
 
 /**
- * Returns boolean indicating if operation input is union shaped
+ * Returns boolean indicating if operations explicitly set HTTP payload is a union
  */
 fun OperationShape.payloadIsUnionShape(model: Model): Boolean {
     val requestShape = model.expectShape<StructureShape>(input.get())
@@ -224,14 +224,6 @@ fun OperationShape.isInputEventStream(model: Model): Boolean {
 fun OperationShape.isOutputEventStream(model: Model): Boolean {
     val respShape = model.expectShape<StructureShape>(output.get())
     return respShape.hasEventStreamMember(model)
-}
-
-/**
- * Returns boolean indicating if operation input is union shaped
- */
-fun OperationShape.inputIsUnionShape(model: Model): Boolean {
-    val reqShape = model.expectShape<StructureShape>(input.get())
-    return reqShape.isUnionShape
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
-The part of the code that renders the xml content type header is made overridable


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
