### PR TITLE
fix: remove namespace from xml map entry serialization

### DIFF
--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
@@ -219,11 +219,10 @@ private class XmlMapSerializer(
             checkNotNull(mapTrait.entry)
         }
 
-        val entryNamespace = descriptor.findTrait<XmlNamespace>()
         val keyNamespace = descriptor.findTrait<XmlMapKeyNamespace>()
         val valueNamespace = descriptor.findTrait<XmlCollectionValueNamespace>()
 
-        xmlWriter.writeTag(tagName, entryNamespace) {
+        xmlWriter.writeTag(tagName) {
             writeTag(mapTrait.key, keyNamespace) { text(key) }
             writeTag(mapTrait.value, valueNamespace) { valueFn() }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
closes #957 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
-Removed xmlns from entry tag when serializing maps 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
