### PR TITLE
fix: treat IO exceptions as retryable in HTTP engines

### DIFF
--- a/.changes/0645c929-bdfe-4d07-a131-b0b447422fff.json
+++ b/.changes/0645c929-bdfe-4d07-a131-b0b447422fff.json
@@ -1,0 +1,5 @@
+{
+    "id": "0645c929-bdfe-4d07-a131-b0b447422fff",
+    "type": "bugfix",
+    "description": "Treat all `IOException` errors in OkHttp engine as retryable (e.g., socket errors, DNS lookup failures, etc.)"
+}

--- a/.changes/0645c929-bdfe-4d07-a131-b0b447422fff.json
+++ b/.changes/0645c929-bdfe-4d07-a131-b0b447422fff.json
@@ -1,5 +1,5 @@
 {
     "id": "0645c929-bdfe-4d07-a131-b0b447422fff",
     "type": "bugfix",
-    "description": "Treat all `IOException` errors in OkHttp engine as retryable (e.g., socket errors, DNS lookup failures, etc.)"
+    "description": "Treat all IO errors in OkHttp & CRT engines as retryable (e.g., socket errors, DNS lookup failures, etc.)"
 }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtilTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtilTest.kt
@@ -1,8 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package aws.smithy.kotlin.runtime.http.engine.crt
 
+import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 class RequestUtilTest {
     @Test

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtilTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/common/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtilTest.kt
@@ -1,0 +1,42 @@
+package aws.smithy.kotlin.runtime.http.engine.crt
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.Test
+
+class RequestUtilTest {
+    @Test
+    fun testExceptionRetryability() {
+        setOf(
+            // All IO errors are retryable
+            "AWS_IO_SOCKET_NETWORK_DOWN",
+            "AWS_ERROR_IO_OPERATION_CANCELLED",
+            "AWS_IO_DNS_NO_ADDRESS_FOR_HOST",
+
+            // Any connection closure is retryable
+            "AWS_ERROR_HTTP_CONNECTION_CLOSED",
+            "AWS_ERROR_HTTP_SERVER_CLOSED",
+            "AWS_IO_BROKEN_PIPE",
+
+            // All proxy errors are retryable
+            "AWS_ERROR_HTTP_PROXY_CONNECT_FAILED",
+            "AWS_ERROR_HTTP_PROXY_STRATEGY_NTLM_CHALLENGE_TOKEN_MISSING",
+            "AWS_ERROR_HTTP_PROXY_STRATEGY_TOKEN_RETRIEVAL_FAILURE",
+
+            // Any connection manager issues are retryable
+            "AWS_ERROR_HTTP_CONNECTION_MANAGER_INVALID_STATE_FOR_ACQUIRE",
+            "AWS_ERROR_HTTP_CONNECTION_MANAGER_VENDED_CONNECTION_UNDERFLOW",
+            "AWS_ERROR_HTTP_CONNECTION_MANAGER_SHUTTING_DOWN",
+        ).forEach { name -> assertTrue(isRetryable(name), "Expected $name to be retryable!") }
+
+        setOf(
+            // Any other errors are not retryable
+            "AWS_ERROR_HTTP_INVALID_METHOD",
+            "AWS_ERROR_PKCS11_CKR_CANCEL",
+            "AWS_ERROR_PEM_MALFORMED",
+
+            // Unknown error codes are not retryable
+            null,
+        ).forEach { name -> assertFalse(isRetryable(name), "Expected $name to not be retryable!") }
+    }
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpUtils.kt
@@ -208,10 +208,9 @@ internal inline fun<T> mapOkHttpExceptions(block: () -> T): T =
     try {
         block()
     } catch (ex: IOException) {
-        throw HttpException(ex, ex.errCode(), ex.isRetryable())
+        throw HttpException(ex, ex.errCode(), retryable = true) // All IOExceptions are retryable
     }
 
-private fun Exception.isRetryable(): Boolean = isCauseOrSuppressed<ConnectException>() || isConnectionClosedException()
 private fun Exception.errCode(): HttpErrorCode = when {
     isConnectTimeoutException() -> HttpErrorCode.CONNECT_TIMEOUT
     isConnectionClosedException() -> HttpErrorCode.CONNECTION_CLOSED

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.EOFException
 import java.io.IOException
 import java.net.ConnectException
@@ -20,22 +21,21 @@ class OkHttpExceptionTest {
     data class ExceptionTest(
         val ex: Exception,
         val expectedError: HttpErrorCode,
-        val expectedRetryable: Boolean = false,
     )
 
     @Test
     fun testMapExceptions() {
         val tests = listOf(
             ExceptionTest(IOException("unknown"), expectedError = HttpErrorCode.SDK_UNKNOWN),
-            ExceptionTest(IOException(SocketTimeoutException("connect timeout")), expectedError = HttpErrorCode.CONNECT_TIMEOUT, true),
-            ExceptionTest(IOException().apply { addSuppressed(SocketTimeoutException("connect timeout")) }, expectedError = HttpErrorCode.CONNECT_TIMEOUT, true),
+            ExceptionTest(IOException(SocketTimeoutException("connect timeout")), expectedError = HttpErrorCode.CONNECT_TIMEOUT),
+            ExceptionTest(IOException().apply { addSuppressed(SocketTimeoutException("connect timeout")) }, expectedError = HttpErrorCode.CONNECT_TIMEOUT),
             ExceptionTest(IOException(SocketTimeoutException("read timeout")), expectedError = HttpErrorCode.SOCKET_TIMEOUT),
             ExceptionTest(IOException().apply { addSuppressed(SocketTimeoutException("read timeout")) }, expectedError = HttpErrorCode.SOCKET_TIMEOUT),
             ExceptionTest(SocketTimeoutException("read timeout"), expectedError = HttpErrorCode.SOCKET_TIMEOUT),
             ExceptionTest(IOException(SSLHandshakeException("negotiate error")), expectedError = HttpErrorCode.TLS_NEGOTIATION_ERROR),
-            ExceptionTest(ConnectException("test connect error"), expectedError = HttpErrorCode.SDK_UNKNOWN, true),
+            ExceptionTest(ConnectException("test connect error"), expectedError = HttpErrorCode.SDK_UNKNOWN),
             // see https://github.com/awslabs/aws-sdk-kotlin/issues/905
-            ExceptionTest(IOException("unexpected end of stream on https://test.aws.com", EOFException("\\n not found: limit=0 content=...")), expectedError = HttpErrorCode.CONNECTION_CLOSED, expectedRetryable = true),
+            ExceptionTest(IOException("unexpected end of stream on https://test.aws.com", EOFException("\\n not found: limit=0 content=...")), expectedError = HttpErrorCode.CONNECTION_CLOSED),
         )
 
         for (test in tests) {
@@ -46,7 +46,7 @@ class OkHttpExceptionTest {
             }
 
             assertEquals(test.expectedError, ex.errorCode, "ex=$ex; ${ex.suppressedExceptions}; cause=${ex.cause}; causeSuppressed=${ex.cause?.suppressedExceptions}")
-            assertEquals(test.expectedRetryable, ex.sdkErrorMetadata.isRetryable)
+            assertTrue(ex.sdkErrorMetadata.isRetryable)
         }
     }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change enables retrying on:
* all `IOException` errors in the default OkHttp engine
* many IO and IO-like errors in the CRT engine

This will enable transient problems like socket errors, DNS lookup failues, etc. to be retried the same as other retryable errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
