### PR TITLE
fix: run `test` and `jvmTest` in downstream CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -109,4 +109,5 @@ jobs:
         # the generated protocol test projects will use whatever the SDK thinks the version of smithy-kotlin should be
         sed -i "s/smithy-kotlin-version = .*$/smithy-kotlin-version = \"$SMITHY_KOTLIN_VERSION\"/" gradle/libs.versions.toml
         ./gradlew --parallel publishToMavenLocal
+        ./gradlew test jvmTest
         ./gradlew testAllProtocols

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         // Add our custom gradle plugin(s) to buildscript classpath (comes from github source)
         classpath("aws.sdk.kotlin:build-plugins") {
             version {
-                require("0.2.5")
+                require("0.2.7")
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Run `test` and `jvmTest` tasks in the downstream CI. `publishToMavenLocal` does not run a full build, so currently the unit tests are not run as part of this CI

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
