### PR TITLE
feat: enable auth resolution via endpoints

### DIFF
--- a/.changes/0be03245-2d3e-4bac-8bea-f893b29b6539.json
+++ b/.changes/0be03245-2d3e-4bac-8bea-f893b29b6539.json
@@ -1,0 +1,5 @@
+{
+    "id": "0be03245-2d3e-4bac-8bea-f893b29b6539",
+    "type": "feature",
+    "description": "Enable resolving auth schemes via endpoint resolution"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         // Add our custom gradle plugin(s) to buildscript classpath (comes from github source)
         classpath("aws.sdk.kotlin:build-plugins") {
             version {
-                require("0.2.8")
+                require("0.2.9")
             }
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/KotlinSettings.kt
@@ -263,16 +263,20 @@ enum class DefaultValueSerializationMode(val value: String) {
  * @param visibility Enum representing the visibility of code-generated classes, objects, interfaces, etc.
  * @param nullabilityCheckMode Enum representing the nullability check mode to use
  * @param defaultValueSerializationMode Enum representing when default values should be serialized
+ * @param enableEndpointAuthProvider flag indicating that endpoint resolution should be enabled as part of resolving
+ * an auth scheme. This is an advanced option that only a select few service clients like S3 and EventBridge require.
  */
 data class ApiSettings(
     val visibility: Visibility = Visibility.PUBLIC,
     val nullabilityCheckMode: CheckMode = CheckMode.CLIENT_CAREFUL,
     val defaultValueSerializationMode: DefaultValueSerializationMode = DefaultValueSerializationMode.WHEN_DIFFERENT,
+    val enableEndpointAuthProvider: Boolean = false,
 ) {
     companion object {
         const val VISIBILITY = "visibility"
         const val NULLABILITY_CHECK_MODE = "nullabilityCheckMode"
         const val DEFAULT_VALUE_SERIALIZATION_MODE = "defaultValueSerializationMode"
+        const val ENABLE_ENDPOINT_AUTH_PROVIDER = "enableEndpointAuthProvider"
 
         fun fromNode(node: Optional<ObjectNode>): ApiSettings = node.map {
             val visibility = node.get()
@@ -290,7 +294,8 @@ data class ApiSettings(
                         DefaultValueSerializationMode.WHEN_DIFFERENT.value,
                     ),
             )
-            ApiSettings(visibility, checkMode, defaultValueSerializationMode)
+            val enableEndpointAuthProvider = node.get().getBooleanMemberOrDefault(ENABLE_ENDPOINT_AUTH_PROVIDER, false)
+            ApiSettings(visibility, checkMode, defaultValueSerializationMode, enableEndpointAuthProvider)
         }.orElse(Default)
 
         /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/AbstractCodeWriterExt.kt
@@ -150,6 +150,14 @@ inline fun <W : AbstractCodeWriter<W>, reified V> AbstractCodeWriter<W>.getConte
  */
 inline fun <W : AbstractCodeWriter<W>, reified V> AbstractCodeWriter<W>.getContextValue(key: SectionKey<V>): V = getContextValue(key.name)
 
+/**
+ * Convenience function to set context only if there is no value already associated with the given [key]
+ */
+fun <W : AbstractCodeWriter<W>> AbstractCodeWriter<W>.putMissingContext(key: String, value: Any) {
+    if (getContext(key) != null) return
+    putContext(key, value)
+}
+
 typealias InlineCodeWriter = AbstractCodeWriter<*>.() -> Unit
 
 /**

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -313,8 +313,8 @@ object RuntimeTypes {
             val AwsHttpSigner = symbol("AwsHttpSigner")
             val SigV4AuthScheme = symbol("SigV4AuthScheme")
             val mergeAuthOptions = symbol("mergeAuthOptions")
-            val sigv4 = symbol("sigv4")
-            val sigv4A = symbol("sigv4A")
+            val sigV4 = symbol("sigV4")
+            val sigV4A = symbol("sigV4A")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -317,6 +317,7 @@ object RuntimeTypes {
             val SigV4AuthScheme = symbol("SigV4AuthScheme")
             val mergeAuthOptions = symbol("mergeAuthOptions")
             val sigv4 = symbol("sigv4")
+            val toAuthOption = symbol("toAuthOption")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -199,11 +199,8 @@ object RuntimeTypes {
             val EndpointProvider = symbol("EndpointProvider")
             val Endpoint = symbol("Endpoint")
             val EndpointProviderException = symbol("EndpointProviderException")
-            val SigningContext = symbol("SigningContext")
             val SigningContextAttributeKey = symbol("SigningContextAttributeKey")
-
-            @get:JvmName("getSigningContextExtMethod")
-            val signingContext = symbol("signingContext")
+            val authOptions = symbol("authOptions")
             object Functions : RuntimeTypePackage(KotlinDependency.SMITHY_CLIENT, "endpoints.functions") {
                 val substring = symbol("substring")
                 val isValidHostLabel = symbol("isValidHostLabel")
@@ -317,7 +314,7 @@ object RuntimeTypes {
             val SigV4AuthScheme = symbol("SigV4AuthScheme")
             val mergeAuthOptions = symbol("mergeAuthOptions")
             val sigv4 = symbol("sigv4")
-            val toAuthOption = symbol("toAuthOption")
+            val sigv4A = symbol("sigv4A")
         }
     }
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -35,6 +35,7 @@ object RuntimeTypes {
         object Request : RuntimeTypePackage(KotlinDependency.HTTP, "request") {
             val HttpRequest = symbol("HttpRequest")
             val HttpRequestBuilder = symbol("HttpRequestBuilder")
+            val immutableView = symbol("immutableView")
             val url = symbol("url")
             val headers = symbol("headers")
             val toBuilder = symbol("toBuilder")
@@ -314,6 +315,7 @@ object RuntimeTypes {
         object HttpAuthAws : RuntimeTypePackage(KotlinDependency.HTTP_AUTH_AWS) {
             val AwsHttpSigner = symbol("AwsHttpSigner")
             val SigV4AuthScheme = symbol("SigV4AuthScheme")
+            val mergeAuthOptions = symbol("mergeAuthOptions")
             val sigv4 = symbol("sigv4")
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ServiceClientConfigGenerator.kt
@@ -130,7 +130,13 @@ class ServiceClientConfigGenerator(
             .map { it.additionalServiceConfigProps(ctx).byName() }
             .forEach(allPropsByName::putAll)
 
+        writer.pushState()
+        // Service client config is always nested inside the service client interface. Its visibility is taken
+        // from that type. If the interface is `internal` then trying to use `internal` as the visibility on the
+        // nested config class is a compilation error.
+        writer.putContext("visibility", "public")
         super.render(ctx, allPropsByName.values.toList(), writer)
+        writer.popState()
     }
 
     override fun renderBuilderBuildMethod(writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -89,20 +89,17 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
                     baseClass = symbol
                 }.build()
 
-            val props = mutableListOf(operationName)
-            if (ctx.settings.api.enableEndpointAuthProvider) {
-                val endpointParamsProperty = ConfigProperty {
-                    name = "endpointParameters"
-                    this.symbol = EndpointParametersGenerator.getSymbol(ctx.settings).asNullable()
-                    baseClass = symbol
-                    documentation = """
-                        The parameters used for endpoint resolution. The default implementation of this interface 
-                        relies on endpoint metadata to resolve auth scheme candidates.
-                    """.trimIndent()
-                }
-                props.add(endpointParamsProperty)
-            }
+            val endpointParamsProperty = ConfigProperty {
+                name = "endpointParameters"
+                this.symbol = EndpointParametersGenerator.getSymbol(ctx.settings).asNullable()
+                baseClass = symbol
+                documentation = """
+                    The parameters used for endpoint resolution. The default implementation of this interface 
+                    relies on endpoint metadata to resolve auth scheme candidates.
+                """.trimIndent()
+            }.takeIf { ctx.settings.api.enableEndpointAuthProvider }
 
+            val props = listOfNotNull(operationName, endpointParamsProperty)
             render(codegenCtx, props, writer)
         }
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -77,7 +77,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
         writer.write("")
         renderEquals(ctx, props, writer)
         writer.write("")
-        renderHashCode(ctx, props, writer)
+        renderHashCode(props, writer)
         writer.write("")
         renderCopy(ctx, props, writer)
     }
@@ -101,8 +101,8 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
         }
     }
 
-    private fun renderHashCode(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
-        writer.withBlock("public override fun hashCode(): Int {", "}") {
+    private fun renderHashCode(props: List<ConfigProperty>, writer: KotlinWriter) {
+        writer.withBlock("$visibility override fun hashCode(): Int {", "}") {
             if (props.isEmpty()) {
                 write("return this::class.hashCode()")
                 return@withBlock

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -83,7 +83,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
     }
 
     private fun renderEquals(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
-        writer.withBlock("$visibility override fun equals(other: Any?): Boolean {", "}") {
+        writer.withBlock("override fun equals(other: Any?): Boolean {", "}") {
             write("if (this === other) return true")
             write("if (other !is #T) return false", getSymbol(ctx.settings))
             props.forEach { prop ->
@@ -93,7 +93,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
         }
     }
     private fun renderToString(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
-        writer.withBlock("$visibility override fun toString(): String = buildString {", "}") {
+        writer.withBlock("override fun toString(): String = buildString {", "}") {
             write("append(\"#L(\")", getSymbol(ctx.settings).name)
             props.forEachIndexed { idx, prop ->
                 write("""append("#1L=$#1L#2L")""", prop.propertyName, if (idx < props.size - 1) "," else ")")
@@ -102,7 +102,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
     }
 
     private fun renderHashCode(props: List<ConfigProperty>, writer: KotlinWriter) {
-        writer.withBlock("$visibility override fun hashCode(): Int {", "}") {
+        writer.withBlock("override fun hashCode(): Int {", "}") {
             if (props.isEmpty()) {
                 write("return this::class.hashCode()")
                 return@withBlock
@@ -118,7 +118,7 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
 
     private fun renderCopy(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
         val symbol = getSymbol(ctx.settings)
-        writer.withBlock("public fun copy(block: Builder.() -> Unit = {}): #T {", "}", symbol) {
+        writer.withBlock("#visibility:L fun copy(block: Builder.() -> Unit = {}): #T {", "}", symbol) {
             withBlock("return Builder().apply {", "}") {
                 props.forEach {
                     write("#1L = this@#2L.#1L", it.propertyName, symbol.name)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeParametersGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinSettings
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
+import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.core.clientName
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -32,45 +33,13 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             namespace = "${settings.pkg.name}.auth"
             definitionFile = "$name.kt"
         }
-
-        fun getImplementationSymbol(settings: KotlinSettings): Symbol = buildSymbol {
-            val prefix = clientName(settings.sdkId)
-            name = "${prefix}AuthSchemeParametersImpl"
-            namespace = "${settings.pkg.name}.auth"
-            definitionFile = "$name.kt"
-        }
     }
-
-    override val visibility: String = "internal"
 
     fun render(ctx: ProtocolGenerator.GenerationContext) {
         val symbol = getSymbol(ctx.settings)
-        val implSymbol = getImplementationSymbol(ctx.settings)
 
         ctx.delegator.useSymbolWriter(symbol) { writer ->
-            writer.withBlock(
-                "#L interface #T {",
-                "}",
-                ctx.settings.api.visibility,
-                symbol,
-            ) {
-                dokka("The name of the operation currently being invoked.")
-                write("public val operationName: String")
-                if (ctx.settings.api.enableEndpointAuthProvider) {
-                    dokka(
-                        """
-                        |The parameters used for endpoint resolution. The default implementation of this interface 
-                        |relies on endpoint metadata to resolve auth scheme candidates.
-                        |
-                        """.trimMargin(),
-                    )
-                    write("public val endpointParameters: #P", EndpointParametersGenerator.getSymbol(ctx.settings).asNullable())
-                }
-            }
-        }
-
-        ctx.delegator.useSymbolWriter(implSymbol) { writer ->
-            writer.putContext("configClass.name", implSymbol.name)
+            writer.putContext("configClass.name", symbol.name)
 
             val codegenCtx = object : CodegenContext {
                 override val model: Model = ctx.model
@@ -86,13 +55,11 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
             ).toBuilder()
                 .apply {
                     propertyType = ConfigPropertyType.Required("operationName is a required auth scheme parameter")
-                    baseClass = symbol
                 }.build()
 
             val endpointParamsProperty = ConfigProperty {
                 name = "endpointParameters"
                 this.symbol = EndpointParametersGenerator.getSymbol(ctx.settings).asNullable()
-                baseClass = symbol
                 documentation = """
                     The parameters used for endpoint resolution. The default implementation of this interface 
                     relies on endpoint metadata to resolve auth scheme candidates.
@@ -101,6 +68,64 @@ class AuthSchemeParametersGenerator : AbstractConfigGenerator() {
 
             val props = listOfNotNull(operationName, endpointParamsProperty)
             render(codegenCtx, props, writer)
+        }
+    }
+
+    override fun renderAdditionalMethods(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
+        writer.write("")
+        renderToString(ctx, props, writer)
+        writer.write("")
+        renderEquals(ctx, props, writer)
+        writer.write("")
+        renderHashCode(ctx, props, writer)
+        writer.write("")
+        renderCopy(ctx, props, writer)
+    }
+
+    private fun renderEquals(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
+        writer.withBlock("$visibility override fun equals(other: Any?): Boolean {", "}") {
+            write("if (this === other) return true")
+            write("if (other !is #T) return false", getSymbol(ctx.settings))
+            props.forEach { prop ->
+                write("if (this.#1L != other.#1L) return false", prop.propertyName)
+            }
+            write("return true")
+        }
+    }
+    private fun renderToString(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
+        writer.withBlock("$visibility override fun toString(): String = buildString {", "}") {
+            write("append(\"#L(\")", getSymbol(ctx.settings).name)
+            props.forEachIndexed { idx, prop ->
+                write("""append("#1L=$#1L#2L")""", prop.propertyName, if (idx < props.size - 1) "," else ")")
+            }
+        }
+    }
+
+    private fun renderHashCode(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
+        writer.withBlock("public override fun hashCode(): Int {", "}") {
+            if (props.isEmpty()) {
+                write("return this::class.hashCode()")
+                return@withBlock
+            }
+
+            write("var result = #L?.hashCode() ?: 0", props[0].propertyName)
+            props.drop(1).forEach {
+                write("result = 31 * result + (#L?.hashCode() ?: 0)", it.propertyName)
+            }
+            write("return result")
+        }
+    }
+
+    private fun renderCopy(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
+        val symbol = getSymbol(ctx.settings)
+        writer.withBlock("public fun copy(block: Builder.() -> Unit = {}): #T {", "}", symbol) {
+            withBlock("return Builder().apply {", "}") {
+                props.forEach {
+                    write("#1L = this@#2L.#1L", it.propertyName, symbol.name)
+                }
+                write("block()")
+            }
+            write(".build()")
         }
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderAdapterGenerator.kt
@@ -45,7 +45,7 @@ class AuthSchemeProviderAdapterGenerator {
                     RuntimeTypes.HttpClient.Operation.SdkHttpRequest,
                     RuntimeTypes.Auth.Identity.AuthOption,
                 ) {
-                    withBlock("val params = #T {", "}", AuthSchemeParametersGenerator.getImplementationSymbol(ctx.settings)) {
+                    withBlock("val params = #T {", "}", AuthSchemeParametersGenerator.getSymbol(ctx.settings)) {
                         addImport(RuntimeTypes.Core.Utils.get)
                         write("operationName = request.context[#T.OperationName]", RuntimeTypes.SmithyClient.SdkClientOption)
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderConfigIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderConfigIntegration.kt
@@ -16,13 +16,20 @@ class AuthSchemeProviderConfigIntegration : KotlinIntegration {
     override fun additionalServiceConfigProps(ctx: CodegenContext): List<ConfigProperty> {
         if (ctx.protocolGenerator == null) return super.additionalServiceConfigProps(ctx)
         val defaultProvider = AuthSchemeProviderGenerator.getDefaultSymbol(ctx.settings)
+
         return listOf(
             ConfigProperty {
                 name = "authSchemeProvider"
                 symbol = AuthSchemeProviderGenerator.getSymbol(ctx.settings)
                 documentation = "Configure the provider used to resolve the authentication scheme to use for a particular operation."
                 additionalImports = listOf(defaultProvider)
-                propertyType = ConfigPropertyType.RequiredWithDefault(defaultProvider.name)
+                if (ctx.settings.api.enableEndpointAuthProvider) {
+                    propertyType = ConfigPropertyType.RequiredWithDefault("${defaultProvider.name}(endpointProvider)")
+                } else {
+                    propertyType = ConfigPropertyType.RequiredWithDefault("${defaultProvider.name}()")
+                }
+                // needs to come after endpointProvider
+                order = 100
             },
         )
     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -118,8 +118,7 @@ open class AuthSchemeProviderGenerator {
                     withBlock("val endpointAuthOptions = params.endpointParameters?.let {", "} ?: emptyList()") {
                         // FIXME - this should use the endpoint provider from config
                         write("val endpoint = #T().resolveEndpoint(params.endpointParameters!!)", DefaultEndpointProviderGenerator.getSymbol(ctx.settings))
-                        write("val signingContext = endpoint.attributes.getOrNull(#T) ?: emptyList()", RuntimeTypes.SmithyClient.Endpoints.SigningContextAttributeKey)
-                        write("signingContext.map(#T::#T)", RuntimeTypes.SmithyClient.Endpoints.SigningContext, RuntimeTypes.Auth.HttpAuthAws.toAuthOption)
+                        write("endpoint.#T", RuntimeTypes.SmithyClient.Endpoints.authOptions)
                     }
                     write("")
                     write("return #T(modeledAuthOptions, endpointAuthOptions)", RuntimeTypes.Auth.HttpAuthAws.mergeAuthOptions)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/AuthSchemeProviderGenerator.kt
@@ -115,13 +115,14 @@ open class AuthSchemeProviderGenerator {
 
                 if (ctx.settings.api.enableEndpointAuthProvider) {
                     write("")
-                    withBlock("val endpointAuthContext = params.endpointParameters?.let {", "} ?: emptyList()") {
+                    withBlock("val endpointAuthOptions = params.endpointParameters?.let {", "} ?: emptyList()") {
                         // FIXME - this should use the endpoint provider from config
                         write("val endpoint = #T().resolveEndpoint(params.endpointParameters!!)", DefaultEndpointProviderGenerator.getSymbol(ctx.settings))
-                        write("endpoint.attributes.getOrNull(#T) ?: emptyList()", RuntimeTypes.SmithyClient.Endpoints.SigningContextAttributeKey)
+                        write("val signingContext = endpoint.attributes.getOrNull(#T) ?: emptyList()", RuntimeTypes.SmithyClient.Endpoints.SigningContextAttributeKey)
+                        write("signingContext.map(#T::#T)", RuntimeTypes.SmithyClient.Endpoints.SigningContext, RuntimeTypes.Auth.HttpAuthAws.toAuthOption)
                     }
                     write("")
-                    write("return #T(modeledAuthOptions, endpointAuthContext)", RuntimeTypes.Auth.HttpAuthAws.mergeAuthOptions)
+                    write("return #T(modeledAuthOptions, endpointAuthOptions)", RuntimeTypes.Auth.HttpAuthAws.mergeAuthOptions)
                 } else {
                     write("return modeledAuthOptions")
                 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/SigV4AuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/SigV4AuthSchemeIntegration.kt
@@ -29,7 +29,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 /**
  * Register support for the `aws.auth#sigv4` auth scheme.
  */
-class Sigv4AuthSchemeIntegration : KotlinIntegration {
+class SigV4AuthSchemeIntegration : KotlinIntegration {
     // Allow integrations to customize the service config props, later integrations take precedence
     override val order: Byte = -50
 

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/auth/Sigv4AuthSchemeIntegration.kt
@@ -86,7 +86,7 @@ open class SigV4AuthSchemeHandler : AuthSchemeHandler {
         } else {
             "#T()"
         }
-        writer.write(expr, RuntimeTypes.Auth.HttpAuthAws.sigv4)
+        writer.write(expr, RuntimeTypes.Auth.HttpAuthAws.sigV4)
     }
 
     override fun instantiateAuthSchemeExpr(ctx: ProtocolGenerator.GenerationContext, writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolClientGenerator.kt
@@ -120,7 +120,7 @@ abstract class HttpProtocolClientGenerator(
 
             write("toMap()")
         }
-        writer.write("private val authSchemeAdapter = #T(config.authSchemeProvider)", AuthSchemeProviderAdapterGenerator.getSymbol(ctx.settings))
+        writer.write("private val authSchemeAdapter = #T(config)", AuthSchemeProviderAdapterGenerator.getSymbol(ctx.settings))
 
         writer.write("private val telemetryScope = #S", ctx.settings.pkg.name)
         writer.write("private val opMetrics = #T(telemetryScope, config.telemetryProvider)", RuntimeTypes.HttpClient.Operation.OperationMetrics)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
@@ -60,9 +60,16 @@ abstract class AbstractConfigGenerator {
             renderCompanionObject(writer)
             renderToBuilder(sortedProps, writer)
             renderBuilder(sortedProps, writer)
+            renderAdditionalMethods(ctx, sortedProps, writer)
         }
 
         writer.removeContext("configClass.name")
+    }
+
+    /**
+     * Hook to render additional methods on the generated type
+     */
+    protected open fun renderAdditionalMethods(ctx: CodegenContext, props: List<ConfigProperty>, writer: KotlinWriter) {
     }
 
     protected open fun renderCompanionObject(writer: KotlinWriter) {

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/util/AbstractConfigGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.kotlin.codegen.core.CodegenContext
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
+import software.amazon.smithy.kotlin.codegen.core.putMissingContext
 import software.amazon.smithy.kotlin.codegen.core.withBlock
 import software.amazon.smithy.kotlin.codegen.model.PropertyTypeMutability
 import software.amazon.smithy.kotlin.codegen.model.propertyTypeMutability
@@ -32,20 +33,14 @@ import software.amazon.smithy.kotlin.codegen.model.propertyTypeMutability
  */
 abstract class AbstractConfigGenerator {
 
-    /**
-     * The generated type visibility e.g. `public`, `internal`, `private`.
-     */
-    open val visibility: String = "public"
-
     open fun render(
         ctx: CodegenContext,
         props: Collection<ConfigProperty>,
         writer: KotlinWriter,
     ) {
-        if (writer.getContext("configClass.name") == null) {
-            // push context to be used throughout generation of the class
-            writer.putContext("configClass.name", "Config")
-        }
+        writer.pushState()
+        writer.putMissingContext("configClass.name", "Config")
+        writer.putMissingContext("visibility", ctx.settings.api.visibility)
 
         addPropertyImports(props, writer)
 
@@ -53,7 +48,7 @@ abstract class AbstractConfigGenerator {
         val formattedBaseClasses = props.formattedBaseClasses { it.baseClass to it.baseClassDelegate }
 
         writer.withBlock(
-            "$visibility class #configClass.name:L private constructor(builder: Builder)$formattedBaseClasses {",
+            "#visibility:L class #configClass.name:L private constructor(builder: Builder)$formattedBaseClasses {",
             "}",
         ) {
             renderImmutableProperties(sortedProps, writer)
@@ -63,7 +58,7 @@ abstract class AbstractConfigGenerator {
             renderAdditionalMethods(ctx, sortedProps, writer)
         }
 
-        writer.removeContext("configClass.name")
+        writer.popState()
     }
 
     /**
@@ -73,8 +68,8 @@ abstract class AbstractConfigGenerator {
     }
 
     protected open fun renderCompanionObject(writer: KotlinWriter) {
-        writer.withBlock("$visibility companion object {", "}") {
-            write("$visibility inline operator fun invoke(block: Builder.() -> kotlin.Unit): #configClass.name:L = Builder().apply(block).build()")
+        writer.withBlock("#visibility:L companion object {", "}") {
+            write("#visibility:L inline operator fun invoke(block: Builder.() -> kotlin.Unit): #configClass.name:L = Builder().apply(block).build()")
         }
     }
 
@@ -126,7 +121,7 @@ abstract class AbstractConfigGenerator {
 
     protected open fun renderToBuilder(props: Collection<ConfigProperty>, writer: KotlinWriter) {
         writer.write("")
-            .withBlock("$visibility fun toBuilder(): Builder = Builder().apply {", "}") {
+            .withBlock("#visibility:L fun toBuilder(): Builder = Builder().apply {", "}") {
                 props
                     .filter { it.propertyType !is ConfigPropertyType.ConstantValue }
                     .forEach { prop ->
@@ -139,7 +134,7 @@ abstract class AbstractConfigGenerator {
         val formattedBaseClasses = props.formattedBaseClasses { it.builderBaseClass to it.builderBaseClassDelegate }
 
         writer.write("")
-            .withBlock("$visibility class Builder$formattedBaseClasses {", "}") {
+            .withBlock("#visibility:L class Builder$formattedBaseClasses {", "}") {
                 // override DSL properties
                 props
                     .filter { it.propertyType !is ConfigPropertyType.ConstantValue }

--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -3,7 +3,7 @@ software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor
 software.amazon.smithy.kotlin.codegen.model.SetRefactorPreprocessor
 software.amazon.smithy.kotlin.codegen.rendering.PaginatorGenerator
 software.amazon.smithy.kotlin.codegen.rendering.waiters.ServiceWaitersGenerator
-software.amazon.smithy.kotlin.codegen.rendering.auth.Sigv4AuthSchemeIntegration
+software.amazon.smithy.kotlin.codegen.rendering.auth.SigV4AuthSchemeIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.AuthSchemeProviderConfigIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.AnonymousAuthSchemeIntegration
 software.amazon.smithy.kotlin.codegen.rendering.auth.BearerTokenAuthSchemeIntegration

--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -35,15 +35,15 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttribute
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes;
 	public final fun getCredentialsProvider ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getHashSpecification ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getNormalizeUriPath ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getRequestSignature ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSignedBodyHeader ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSigner ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSigningDate ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSigningRegion ()Laws/smithy/kotlin/runtime/util/AttributeKey;
+	public final fun getSigningRegionSet ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 	public final fun getSigningService ()Laws/smithy/kotlin/runtime/util/AttributeKey;
-}
-
-public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributesKt {
+	public final fun getUseDoubleUriEncode ()Laws/smithy/kotlin/runtime/util/AttributeKey;
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig {

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -4,13 +4,9 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning
 
-import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import aws.smithy.kotlin.runtime.client.endpoints.SigningContext
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.util.AttributeKey
-import aws.smithy.kotlin.runtime.util.MutableAttributes
-import aws.smithy.kotlin.runtime.util.setIfValueNotNull
 import kotlinx.coroutines.CompletableDeferred
 
 /**
@@ -77,28 +73,4 @@ public object AwsSigningAttributes {
      * Flag indicating whether to enable double URI encoding. See [AwsSigningConfig.useDoubleUriEncode] for more details.
      */
     public val EnableDoubleUriEncode: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin#EnableDoubleUriEncode")
-}
-
-/**
- * Merges this signing context into the given [MutableAttributes].
- * @param attributes The attributes into which to merge the values from this signing context.
- */
-@InternalApi
-public fun SigningContext.mergeInto(attributes: MutableAttributes) {
-    when (this) {
-        is SigningContext.SigV4 -> {
-            attributes.setUnlessBlank(AwsSigningAttributes.SigningService, signingName)
-            attributes.setUnlessBlank(AwsSigningAttributes.SigningRegion, signingRegion)
-            attributes.setIfValueNotNull(AwsSigningAttributes.EnableDoubleUriEncode, !disableDoubleEncoding)
-        }
-        is SigningContext.SigV4A -> {
-            attributes.setUnlessBlank(AwsSigningAttributes.SigningService, signingName)
-            attributes[AwsSigningAttributes.SigningRegionSet] = signingRegionSet.toSet()
-            attributes.setIfValueNotNull(AwsSigningAttributes.EnableDoubleUriEncode, !disableDoubleEncoding)
-        }
-    }
-}
-
-private fun MutableAttributes.setUnlessBlank(key: AttributeKey<String>, value: String?) {
-    if (!value.isNullOrBlank()) set(key, value)
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -16,30 +16,30 @@ public object AwsSigningAttributes {
     /**
      * The signer implementation to use
      */
-    public val Signer: AttributeKey<AwsSigner> = AttributeKey("aws.smithy.kotlin#Signer")
+    public val Signer: AttributeKey<AwsSigner> = AttributeKey("aws.smithy.kotlin.signing#Signer")
 
     /**
      * AWS region to be used for signing the request
      */
-    public val SigningRegion: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#AwsSigningRegion")
+    public val SigningRegion: AttributeKey<String> = AttributeKey("aws.smithy.kotlin.signing#AwsSigningRegion")
 
     /**
      * The AWS region-set used for computing the signature.
      */
-    public val SigningRegionSet: AttributeKey<Set<String>> = AttributeKey("aws.smithy.kotlin#AwsSigningRegionSet")
+    public val SigningRegionSet: AttributeKey<Set<String>> = AttributeKey("aws.smithy.kotlin.signing#AwsSigningRegionSet")
 
     /**
      * The signature version 4 service signing name to use in the credential scope when signing requests.
      * See: https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html
      */
-    public val SigningService: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#AwsSigningService")
+    public val SigningService: AttributeKey<String> = AttributeKey("aws.smithy.kotlin.signing#AwsSigningService")
 
     /**
      * Override the date to complete the signing process with. Defaults to current time when not specified.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val SigningDate: AttributeKey<Instant> = AttributeKey("aws.smithy.kotlin#SigningDate")
+    public val SigningDate: AttributeKey<Instant> = AttributeKey("aws.smithy.kotlin.signing#SigningDate")
 
     /**
      * The [CredentialsProvider] to complete the signing process with. Defaults to the provider configured
@@ -47,30 +47,35 @@ public object AwsSigningAttributes {
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val CredentialsProvider: AttributeKey<CredentialsProvider> = AttributeKey("aws.smithy.kotlin#CredentialsProvider")
+    public val CredentialsProvider: AttributeKey<CredentialsProvider> = AttributeKey("aws.smithy.kotlin.signing#CredentialsProvider")
 
     /**
      * The specification for determining the hash value for the request.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val HashSpecification: AttributeKey<HashSpecification> = AttributeKey("aws.smithy.kotlin#HashSpecification")
+    public val HashSpecification: AttributeKey<HashSpecification> = AttributeKey("aws.smithy.kotlin.signing#HashSpecification")
 
     /**
      * The signed body header type.
      *
      * **Note**: This is an advanced configuration option that does not normally need to be set manually.
      */
-    public val SignedBodyHeader: AttributeKey<AwsSignedBodyHeader> = AttributeKey("aws.smithy.kotlin#SignedBodyHeader")
+    public val SignedBodyHeader: AttributeKey<AwsSignedBodyHeader> = AttributeKey("aws.smithy.kotlin.signing#SignedBodyHeader")
 
     /**
      * The signature of the HTTP request. The signer will complete this once the request has been signed.
      * Operation middleware is responsible for resetting the completable deferred value.
      */
-    public val RequestSignature: AttributeKey<CompletableDeferred<ByteArray>> = AttributeKey("aws.smithy.kotlin#RequestSignature")
+    public val RequestSignature: AttributeKey<CompletableDeferred<ByteArray>> = AttributeKey("aws.smithy.kotlin.signing#RequestSignature")
 
     /**
      * Flag indicating whether to enable double URI encoding. See [AwsSigningConfig.useDoubleUriEncode] for more details.
      */
-    public val EnableDoubleUriEncode: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin#EnableDoubleUriEncode")
+    public val UseDoubleUriEncode: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#UseDoubleUriEncode")
+
+    /**
+     * Flag indicating whether to normalize the URI path. See [AwsSigningConfig.normalizeUriPath] for more details.
+     */
+    public val NormalizeUriPath: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#NormalizeUriPath")
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -24,7 +24,7 @@ public object AwsSigningAttributes {
     public val SigningRegion: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#AwsSigningRegion")
 
     /**
-     *
+     * The AWS region-set used for computing the signature.
      */
     public val SigningRegionSet: AttributeKey<Set<String>> = AttributeKey("aws.smithy.kotlin#AwsSigningRegionSet")
 

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -5,8 +5,9 @@
 package aws.smithy.kotlin.runtime.auth.awssigning
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import aws.smithy.kotlin.runtime.client.endpoints.signingContext
+import aws.smithy.kotlin.runtime.client.endpoints.authOptions
 import aws.smithy.kotlin.runtime.http.*
 import aws.smithy.kotlin.runtime.http.operation.EndpointResolver
 import aws.smithy.kotlin.runtime.http.operation.ResolveEndpointRequest
@@ -15,6 +16,8 @@ import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.header
 import aws.smithy.kotlin.runtime.net.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+import aws.smithy.kotlin.runtime.util.get
 
 @InternalApi
 public suspend fun presignRequest(
@@ -30,13 +33,13 @@ public suspend fun presignRequest(
     val credentials = credentialsProvider.resolve()
     val eprRequest = ResolveEndpointRequest(ctx, unsignedRequestBuilder.build(), credentials)
     val endpoint = endpointResolver.resolve(eprRequest)
-    val signingContext = endpoint.signingContext
+    val signingContext = endpoint.authOptions.firstOrNull { it.schemeId == AuthSchemeId.AwsSigV4 }?.attributes ?: emptyAttributes()
 
     val unsignedRequest = unsignedRequestBuilder.apply { header("host", endpoint.uri.host.toString()) }.build()
 
     val config = AwsSigningConfig {
-        signingContext?.signingName?.let { service = it }
-        signingContext?.signingRegion?.let { region = it }
+        region = signingContext.getOrNull(AwsSigningAttributes.SigningRegion)
+        service = signingContext.getOrNull(AwsSigningAttributes.SigningService)
         this.credentials = credentials
         signedBodyHeader = AwsSignedBodyHeader.X_AMZ_CONTENT_SHA256
         signatureType = AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS

--- a/runtime/auth/http-auth-aws/api/http-auth-aws.api
+++ b/runtime/auth/http-auth-aws/api/http-auth-aws.api
@@ -1,3 +1,9 @@
+public final class aws/smithy/kotlin/runtime/http/auth/EndpointAuthKt {
+}
+
+public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthSchemeKt {
+}
+
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthSchemeKt {
 }
 

--- a/runtime/auth/http-auth-aws/api/http-auth-aws.api
+++ b/runtime/auth/http-auth-aws/api/http-auth-aws.api
@@ -1,7 +1,27 @@
 public final class aws/smithy/kotlin/runtime/http/auth/EndpointAuthKt {
 }
 
+public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
+	public fun <init> (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Ljava/lang/String;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Config;)V
+	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
+	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner;
+	public synthetic fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
+	public fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
+}
+
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthSchemeKt {
+}
+
+public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
+	public fun <init> (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Ljava/lang/String;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Config;)V
+	public fun getSchemeId-DepwgT4 ()Ljava/lang/String;
+	public fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner;
+	public synthetic fun getSigner ()Laws/smithy/kotlin/runtime/http/auth/HttpSigner;
+	public fun identityProvider (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthSchemeKt {

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -119,21 +119,21 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
         // favor attributes from the current request context
         val contextHashSpecification = attributes.getOrNull(AwsSigningAttributes.HashSpecification)
         val contextSignedBodyHeader = attributes.getOrNull(AwsSigningAttributes.SignedBodyHeader)
-        val contextRegion = attributes[AwsSigningAttributes.SigningRegion]
-        val contextRegionSet = attributes.getOrNull(AwsSigningAttributes.SigningRegionSet)
+        val contextSigningRegion = attributes[AwsSigningAttributes.SigningRegion]
+        val contextSigningRegionSet = attributes.getOrNull(AwsSigningAttributes.SigningRegionSet)
         val contextUseDoubleUriEncode = attributes.getOrNull(AwsSigningAttributes.UseDoubleUriEncode)
         val contextNormalizeUriPath = attributes.getOrNull(AwsSigningAttributes.NormalizeUriPath)
-        val contextServiceName = attributes.getOrNull(AwsSigningAttributes.SigningService)
+        val contextSigningServiceName = attributes.getOrNull(AwsSigningAttributes.SigningService)
 
         // operation signing config is baseConfig + operation specific config/overrides
         val signingConfig = AwsSigningConfig {
-            service = contextServiceName ?: checkNotNull(config.service)
+            service = contextSigningServiceName ?: checkNotNull(config.service)
             credentials = signingRequest.identity as Credentials
             algorithm = config.algorithm
 
             region = when {
-                algorithm == AwsSigningAlgorithm.SIGV4_ASYMMETRIC && !contextRegionSet.isNullOrEmpty() -> contextRegionSet.joinToString(",")
-                else -> contextRegion
+                algorithm == AwsSigningAlgorithm.SIGV4_ASYMMETRIC && !contextSigningRegionSet.isNullOrEmpty() -> contextSigningRegionSet.joinToString(",")
+                else -> contextSigningRegion
             }
 
             // apply clock skew if applicable

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -135,7 +135,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
             signatureType = config.signatureType
             omitSessionToken = config.omitSessionToken
             normalizeUriPath = config.normalizeUriPath
-            useDoubleUriEncode = config.useDoubleUriEncode
+            useDoubleUriEncode = attributes.getOrNull(AwsSigningAttributes.EnableDoubleUriEncode) ?: config.useDoubleUriEncode
             expiresAfter = config.expiresAfter
             shouldSignHeader = config.shouldSignHeader
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
@@ -6,12 +6,7 @@ package aws.smithy.kotlin.runtime.http.auth
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
-import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.auth.awssigning.mergeInto
-import aws.smithy.kotlin.runtime.client.endpoints.SigningContext
-import aws.smithy.kotlin.runtime.util.merge
-import aws.smithy.kotlin.runtime.util.mutableAttributes
-import aws.smithy.kotlin.runtime.util.toMutableAttributes
+import aws.smithy.kotlin.runtime.util.*
 
 /**
  * Merge the list of modeled auth options with the auth schemes from the resolved endpoint context.
@@ -35,19 +30,9 @@ public fun mergeAuthOptions(modeled: List<AuthOption>, endpointOptions: List<Aut
     }
 
     // tack on auth options that only exist in modeled list
-    val mergedById = merged.associateBy(AuthOption::schemeId)
+    val mergedById = merged.map(AuthOption::schemeId).toSet()
     val modelOnlyOptions = modeled.filterNot { mergedById.contains(it.schemeId) }
     merged.addAll(modelOnlyOptions)
 
     return merged
-}
-
-@InternalApi
-public fun SigningContext.toAuthOption(): AuthOption {
-    val attrs = mutableAttributes()
-    mergeInto(attrs)
-    return when (this) {
-        is SigningContext.SigV4 -> AuthOption(AuthSchemeId.AwsSigV4, attrs)
-        is SigningContext.SigV4A -> AuthOption(AuthSchemeId.AwsSigV4Asymmetric, attrs)
-    }
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
@@ -17,16 +17,7 @@ import aws.smithy.kotlin.runtime.util.toMutableAttributes
  * Merge the list of modeled auth options with the auth schemes from the resolved endpoint context.
  */
 @InternalApi
-public fun mergeAuthOptions(modeled: List<AuthOption>, endpointContext: List<SigningContext>): List<AuthOption> {
-    val endpointOptions = endpointContext.map {
-        val attrs = mutableAttributes()
-        it.mergeInto(attrs)
-        when (it) {
-            is SigningContext.SigV4 -> AuthOption(AuthSchemeId.AwsSigV4, attrs)
-            is SigningContext.SigV4A -> AuthOption(AuthSchemeId.AwsSigV4Asymmetric, attrs)
-        }
-    }
-
+public fun mergeAuthOptions(modeled: List<AuthOption>, endpointOptions: List<AuthOption>): List<AuthOption> {
     // merge the two lists, preferring the priority order from endpoints
     val modeledById = modeled.associateBy(AuthOption::schemeId)
     val merged = mutableListOf<AuthOption>()
@@ -49,4 +40,14 @@ public fun mergeAuthOptions(modeled: List<AuthOption>, endpointContext: List<Sig
     merged.addAll(modelOnlyOptions)
 
     return merged
+}
+
+@InternalApi
+public fun SigningContext.toAuthOption(): AuthOption {
+    val attrs = mutableAttributes()
+    mergeInto(attrs)
+    return when (this) {
+        is SigningContext.SigV4 -> AuthOption(AuthSchemeId.AwsSigV4, attrs)
+        is SigningContext.SigV4A -> AuthOption(AuthSchemeId.AwsSigV4Asymmetric, attrs)
+    }
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/EndpointAuth.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.auth
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.AuthOption
+import aws.smithy.kotlin.runtime.auth.AuthSchemeId
+import aws.smithy.kotlin.runtime.auth.awssigning.mergeInto
+import aws.smithy.kotlin.runtime.client.endpoints.SigningContext
+import aws.smithy.kotlin.runtime.util.merge
+import aws.smithy.kotlin.runtime.util.mutableAttributes
+import aws.smithy.kotlin.runtime.util.toMutableAttributes
+
+/**
+ * Merge the list of modeled auth options with the auth schemes from the resolved endpoint context.
+ */
+@InternalApi
+public fun mergeAuthOptions(modeled: List<AuthOption>, endpointContext: List<SigningContext>): List<AuthOption> {
+    val endpointOptions = endpointContext.map {
+        val attrs = mutableAttributes()
+        it.mergeInto(attrs)
+        when (it) {
+            is SigningContext.SigV4 -> AuthOption(AuthSchemeId.AwsSigV4, attrs)
+            is SigningContext.SigV4A -> AuthOption(AuthSchemeId.AwsSigV4Asymmetric, attrs)
+        }
+    }
+
+    // merge the two lists, preferring the priority order from endpoints
+    val modeledById = modeled.associateBy(AuthOption::schemeId)
+    val merged = mutableListOf<AuthOption>()
+    endpointOptions.forEach {
+        val modeledOption = modeledById[it.schemeId]
+        val option = if (modeledOption != null && !modeledOption.attributes.isEmpty) {
+            val attrs = modeledOption.attributes.toMutableAttributes()
+            attrs.merge(it.attributes)
+            AuthOption(it.schemeId, attrs)
+        } else {
+            it
+        }
+
+        merged.add(option)
+    }
+
+    // tack on auth options that only exist in modeled list
+    val mergedById = merged.associateBy(AuthOption::schemeId)
+    val modelOnlyOptions = modeled.filterNot { mergedById.contains(it.schemeId) }
+    merged.addAll(modelOnlyOptions)
+
+    return merged
+}

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme.kt
@@ -18,7 +18,6 @@ import aws.smithy.kotlin.runtime.util.mutableAttributes
 /**
  * HTTP auth scheme for AWS signature version 4 Asymmetric
  */
-@InternalApi
 public class SigV4AsymmetricAuthScheme(
     config: AwsHttpSigner.Config,
 ) : AuthScheme {

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme.kt
@@ -7,21 +7,45 @@ package aws.smithy.kotlin.runtime.http.auth
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
+import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAlgorithm
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
 import aws.smithy.kotlin.runtime.auth.awssigning.HashSpecification
 import aws.smithy.kotlin.runtime.util.emptyAttributes
 import aws.smithy.kotlin.runtime.util.mutableAttributes
 
 /**
- * Create a new [AuthOption] for the [SigV4AsymetricAuthScheme]
+ * HTTP auth scheme for AWS signature version 4 Asymmetric
+ */
+@InternalApi
+public class SigV4AsymmetricAuthScheme(
+    config: AwsHttpSigner.Config,
+) : AuthScheme {
+    public constructor(
+        awsSigner: AwsSigner,
+        serviceName: String? = null,
+    ) : this(
+        AwsHttpSigner.Config().apply {
+            signer = awsSigner
+            service = serviceName
+            algorithm = AwsSigningAlgorithm.SIGV4_ASYMMETRIC
+        },
+    )
+
+    override val schemeId: AuthSchemeId = AuthSchemeId.AwsSigV4Asymmetric
+    override val signer: AwsHttpSigner = AwsHttpSigner(config)
+}
+
+/**
+ * Create a new [AuthOption] for the [SigV4AsymmetricAuthScheme]
  * @param unsignedPayload set the signing attribute to indicate the signer should use unsigned payload.
  * @param serviceName override the service name to sign for
  * @param signingRegionSet override the signing region set to sign for
  * @param disableDoubleUriEncode disable double URI encoding
- * @return auth scheme option representing the [SigV4AsymetricAuthScheme]
+ * @return auth scheme option representing the [SigV4AsymmetricAuthScheme]
  */
 @InternalApi
-public fun sigv4A(
+public fun sigV4A(
     unsignedPayload: Boolean = false,
     serviceName: String? = null,
     signingRegionSet: List<String>? = null,
@@ -41,7 +65,7 @@ public fun sigv4A(
         mutAttrs.setNotBlank(AwsSigningAttributes.SigningService, serviceName)
 
         if (disableDoubleUriEncode != null) {
-            mutAttrs[AwsSigningAttributes.EnableDoubleUriEncode] = !disableDoubleUriEncode
+            mutAttrs[AwsSigningAttributes.UseDoubleUriEncode] = !disableDoubleUriEncode
         }
 
         mutAttrs

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -11,8 +11,7 @@ import aws.smithy.kotlin.runtime.auth.AuthSchemeId
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
 import aws.smithy.kotlin.runtime.auth.awssigning.HashSpecification
-import aws.smithy.kotlin.runtime.util.attributesOf
-import aws.smithy.kotlin.runtime.util.emptyAttributes
+import aws.smithy.kotlin.runtime.util.*
 
 /**
  * HTTP auth scheme for AWS signature version 4

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -37,6 +37,7 @@ public class SigV4AuthScheme(
  * @param serviceName override the service name to sign for
  * @param signingRegion override the signing region to sign for
  * @param disableDoubleUriEncode disable double URI encoding
+ * @param normalizeUriPath flag indicating if the URI path should be normalized when forming the canonical request
  * @return auth scheme option representing the [SigV4AuthScheme]
  */
 @InternalApi
@@ -45,18 +46,12 @@ public fun sigV4(
     serviceName: String? = null,
     signingRegion: String? = null,
     disableDoubleUriEncode: Boolean? = null,
+    normalizeUriPath: Boolean? = null,
 ): AuthOption {
-    val attrs = if (unsignedPayload || serviceName != null || signingRegion != null || disableDoubleUriEncode != null) {
+    val attrs = if (unsignedPayload || serviceName != null || signingRegion != null || disableDoubleUriEncode != null || normalizeUriPath != null) {
         val mutAttrs = mutableAttributes()
-
-        if (unsignedPayload) {
-            mutAttrs[AwsSigningAttributes.HashSpecification] = HashSpecification.UnsignedPayload
-        }
         mutAttrs.setNotBlank(AwsSigningAttributes.SigningRegion, signingRegion)
-        mutAttrs.setNotBlank(AwsSigningAttributes.SigningService, serviceName)
-        if (disableDoubleUriEncode != null) {
-            mutAttrs[AwsSigningAttributes.UseDoubleUriEncode] = !disableDoubleUriEncode
-        }
+        setCommonSigV4Attrs(mutAttrs, unsignedPayload, serviceName, disableDoubleUriEncode, normalizeUriPath)
 
         mutAttrs
     } else {
@@ -67,4 +62,24 @@ public fun sigV4(
 
 internal fun MutableAttributes.setNotBlank(key: AttributeKey<String>, value: String?) {
     if (!value.isNullOrBlank()) set(key, value)
+}
+
+internal fun setCommonSigV4Attrs(
+    attrs: MutableAttributes,
+    unsignedPayload: Boolean = false,
+    serviceName: String? = null,
+    disableDoubleUriEncode: Boolean? = null,
+    normalizeUriPath: Boolean? = null,
+) {
+    if (unsignedPayload) {
+        attrs[AwsSigningAttributes.HashSpecification] = HashSpecification.UnsignedPayload
+    }
+    attrs.setNotBlank(AwsSigningAttributes.SigningService, serviceName)
+    if (disableDoubleUriEncode != null) {
+        attrs[AwsSigningAttributes.UseDoubleUriEncode] = !disableDoubleUriEncode
+    }
+
+    if (normalizeUriPath != null) {
+        attrs[AwsSigningAttributes.NormalizeUriPath] = normalizeUriPath
+    }
 }

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -16,7 +16,6 @@ import aws.smithy.kotlin.runtime.util.*
 /**
  * HTTP auth scheme for AWS signature version 4
  */
-@InternalApi
 public class SigV4AuthScheme(
     config: AwsHttpSigner.Config,
 ) : AuthScheme {

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme.kt
@@ -20,7 +20,7 @@ import aws.smithy.kotlin.runtime.util.*
 public class SigV4AuthScheme(
     config: AwsHttpSigner.Config,
 ) : AuthScheme {
-    public constructor(awsSigner: AwsSigner, serviceName: String) : this(
+    public constructor(awsSigner: AwsSigner, serviceName: String? = null) : this(
         AwsHttpSigner.Config().apply {
             signer = awsSigner
             service = serviceName
@@ -40,7 +40,7 @@ public class SigV4AuthScheme(
  * @return auth scheme option representing the [SigV4AuthScheme]
  */
 @InternalApi
-public fun sigv4(
+public fun sigV4(
     unsignedPayload: Boolean = false,
     serviceName: String? = null,
     signingRegion: String? = null,
@@ -55,7 +55,7 @@ public fun sigv4(
         mutAttrs.setNotBlank(AwsSigningAttributes.SigningRegion, signingRegion)
         mutAttrs.setNotBlank(AwsSigningAttributes.SigningService, serviceName)
         if (disableDoubleUriEncode != null) {
-            mutAttrs[AwsSigningAttributes.EnableDoubleUriEncode] = !disableDoubleUriEncode
+            mutAttrs[AwsSigningAttributes.UseDoubleUriEncode] = !disableDoubleUriEncode
         }
 
         mutAttrs

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/Sigv4AsymetricAuthScheme.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/Sigv4AsymetricAuthScheme.kt
@@ -2,58 +2,44 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package aws.smithy.kotlin.runtime.http.auth
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigner
 import aws.smithy.kotlin.runtime.auth.awssigning.AwsSigningAttributes
 import aws.smithy.kotlin.runtime.auth.awssigning.HashSpecification
-import aws.smithy.kotlin.runtime.util.*
+import aws.smithy.kotlin.runtime.util.emptyAttributes
+import aws.smithy.kotlin.runtime.util.mutableAttributes
 
 /**
- * HTTP auth scheme for AWS signature version 4
- */
-@InternalApi
-public class SigV4AuthScheme(
-    config: AwsHttpSigner.Config,
-) : AuthScheme {
-    public constructor(awsSigner: AwsSigner, serviceName: String) : this(
-        AwsHttpSigner.Config().apply {
-            signer = awsSigner
-            service = serviceName
-        },
-    )
-
-    override val schemeId: AuthSchemeId = AuthSchemeId.AwsSigV4
-    override val signer: AwsHttpSigner = AwsHttpSigner(config)
-}
-
-/**
- * Create a new [AuthOption] for the [SigV4AuthScheme]
+ * Create a new [AuthOption] for the [SigV4AsymetricAuthScheme]
  * @param unsignedPayload set the signing attribute to indicate the signer should use unsigned payload.
  * @param serviceName override the service name to sign for
- * @param signingRegion override the signing region to sign for
+ * @param signingRegionSet override the signing region set to sign for
  * @param disableDoubleUriEncode disable double URI encoding
- * @return auth scheme option representing the [SigV4AuthScheme]
+ * @return auth scheme option representing the [SigV4AsymetricAuthScheme]
  */
 @InternalApi
-public fun sigv4(
+public fun sigv4A(
     unsignedPayload: Boolean = false,
     serviceName: String? = null,
-    signingRegion: String? = null,
+    signingRegionSet: List<String>? = null,
     disableDoubleUriEncode: Boolean? = null,
 ): AuthOption {
-    val attrs = if (unsignedPayload || serviceName != null || signingRegion != null || disableDoubleUriEncode != null) {
+    val attrs = if (unsignedPayload || serviceName != null || signingRegionSet != null || disableDoubleUriEncode != null) {
         val mutAttrs = mutableAttributes()
 
         if (unsignedPayload) {
             mutAttrs[AwsSigningAttributes.HashSpecification] = HashSpecification.UnsignedPayload
         }
-        mutAttrs.setNotBlank(AwsSigningAttributes.SigningRegion, signingRegion)
+
+        if (!signingRegionSet.isNullOrEmpty()) {
+            mutAttrs[AwsSigningAttributes.SigningRegionSet] = signingRegionSet.toSet()
+        }
+
         mutAttrs.setNotBlank(AwsSigningAttributes.SigningService, serviceName)
+
         if (disableDoubleUriEncode != null) {
             mutAttrs[AwsSigningAttributes.EnableDoubleUriEncode] = !disableDoubleUriEncode
         }
@@ -62,9 +48,5 @@ public fun sigv4(
     } else {
         emptyAttributes()
     }
-    return AuthOption(AuthSchemeId.AwsSigV4, attrs)
-}
-
-internal fun MutableAttributes.setNotBlank(key: AttributeKey<String>, value: String?) {
-    if (!value.isNullOrBlank()) set(key, value)
+    return AuthOption(AuthSchemeId.AwsSigV4Asymmetric, attrs)
 }

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/EndpointAuthTest.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/EndpointAuthTest.kt
@@ -6,7 +6,6 @@ package aws.smithy.kotlin.runtime.http.auth
 
 import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.auth.AuthSchemeId
-import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.attributesOf
 import aws.smithy.kotlin.runtime.util.get
 import kotlin.test.Test
@@ -34,11 +33,7 @@ class EndpointAuthTest {
         expected.forEachIndexed { idx, expectedOption ->
             val actualOption = actual[idx]
             assertEquals(expectedOption.schemeId, actualOption.schemeId)
-            assertEquals(expectedOption.attributes.keys.map { it.name }.toSet(), actualOption.attributes.keys.map { it.name }.toSet())
-            expectedOption.attributes.keys.forEach {
-                val key = it as AttributeKey<Any>
-                assertEquals(expectedOption.attributes[key], actualOption.attributes[key])
-            }
+            assertEquals(expectedOption.attributes, actualOption.attributes)
         }
     }
 }

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/EndpointAuthTest.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/EndpointAuthTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.auth
+
+import aws.smithy.kotlin.runtime.auth.AuthOption
+import aws.smithy.kotlin.runtime.auth.AuthSchemeId
+import aws.smithy.kotlin.runtime.util.AttributeKey
+import aws.smithy.kotlin.runtime.util.attributesOf
+import aws.smithy.kotlin.runtime.util.get
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EndpointAuthTest {
+    @Test
+    fun testMerge() {
+        val modeledOptions = listOf(
+            AuthOption(AuthSchemeId.AwsSigV4, attributesOf { "k1" to "v1"; "k4" to "v4" }),
+        )
+
+        val endpointOptions = listOf(
+            AuthOption(AuthSchemeId.AwsSigV4Asymmetric),
+            AuthOption(AuthSchemeId.AwsSigV4, attributesOf { "k1" to "v2"; "k2" to "v3" }),
+        )
+
+        val actual = mergeAuthOptions(modeledOptions, endpointOptions)
+        val expected = listOf(
+            AuthOption(AuthSchemeId.AwsSigV4Asymmetric),
+            AuthOption(AuthSchemeId.AwsSigV4, attributesOf { "k1" to "v2"; "k2" to "v3"; "k4" to "v4" }),
+        )
+
+        assertEquals(expected.size, actual.size)
+        expected.forEachIndexed { idx, expectedOption ->
+            val actualOption = actual[idx]
+            assertEquals(expectedOption.schemeId, actualOption.schemeId)
+            assertEquals(expectedOption.attributes.keys.map { it.name }.toSet(), actualOption.attributes.keys.map { it.name }.toSet())
+            expectedOption.attributes.keys.forEach {
+                val key = it as AttributeKey<Any>
+                assertEquals(expectedOption.attributes[key], actualOption.attributes[key])
+            }
+        }
+    }
+}

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.operation
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.LogMode
+import aws.smithy.kotlin.runtime.client.endpoints.authOptions
 import aws.smithy.kotlin.runtime.client.logMode
 import aws.smithy.kotlin.runtime.http.HttpCall
 import aws.smithy.kotlin.runtime.http.HttpHandler
@@ -32,6 +33,7 @@ import aws.smithy.kotlin.runtime.telemetry.logging.logger
 import aws.smithy.kotlin.runtime.telemetry.logging.trace
 import aws.smithy.kotlin.runtime.telemetry.metrics.measureSeconds
 import aws.smithy.kotlin.runtime.util.attributesOf
+import aws.smithy.kotlin.runtime.util.emptyAttributes
 import aws.smithy.kotlin.runtime.util.merge
 import kotlin.coroutines.coroutineContext
 import aws.smithy.kotlin.runtime.io.middleware.decorate as decorateHandler
@@ -289,6 +291,9 @@ internal class AuthHandler<Input, Output>(
             }
             coroutineContext.debug<AuthHandler<*, *>> { "resolved endpoint: $endpoint" }
             setResolvedEndpoint(request, endpoint)
+            // update the request context with endpoint specific auth signing context
+            val endpointAuthAttributes = endpoint.authOptions.firstOrNull { it.schemeId == authScheme.schemeId }?.attributes ?: emptyAttributes()
+            request.context.merge(endpointAuthAttributes)
         }
 
         val modified = interceptors.modifyBeforeSigning(request.subject.immutableView(true))

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -143,6 +143,7 @@ private class AttributesImpl constructor(seed: Attributes) : MutableAttributes {
         get() = map.keys
 
     override fun equals(other: Any?): Boolean {
+        if (this === other) return true
         if (other == null) return false
         if (other !is Attributes) return false
         if (keys.size != other.keys.size) return false

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -141,6 +141,19 @@ private class AttributesImpl constructor(seed: Attributes) : MutableAttributes {
 
     override val keys: Set<AttributeKey<*>>
         get() = map.keys
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is Attributes) return false
+        if (keys.size != other.keys.size) return false
+
+        return keys.all {
+            @Suppress("UNCHECKED_CAST")
+            contains(it) && getOrNull(it as AttributeKey<Any>) == other.getOrNull(it)
+        }
+    }
+
+    override fun hashCode(): Int = map.hashCode()
 }
 
 private object EmptyAttributes : Attributes {

--- a/runtime/smithy-client/build.gradle.kts
+++ b/runtime/smithy-client/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":runtime:runtime-core"))
+                api(project(":runtime:auth:identity-api"))
             }
         }
         commonTest {

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/Endpoint.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/Endpoint.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.client.endpoints
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.net.Url
-import aws.smithy.kotlin.runtime.util.AttributeKey
 import aws.smithy.kotlin.runtime.util.Attributes
 import aws.smithy.kotlin.runtime.util.ValuesMap
 import aws.smithy.kotlin.runtime.util.emptyAttributes
@@ -52,14 +51,7 @@ public data class Endpoint @InternalApi constructor(
         other is Endpoint &&
             uri == other.uri &&
             headers == other.headers &&
-            attributesEqual(other)
-
-    private fun attributesEqual(other: Endpoint): Boolean =
-        attributes.keys.size == other.attributes.keys.size &&
-            attributes.keys.all {
-                @Suppress("UNCHECKED_CAST")
-                attributes.contains(it) && attributes.getOrNull(it as AttributeKey<Any>) == other.attributes.getOrNull(it)
-            }
+            attributes == other.attributes
 
     override fun hashCode(): Int {
         var result = uri.hashCode()

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/SigningContext.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/SigningContext.kt
@@ -33,6 +33,7 @@ public sealed class SigningContext {
     ) : SigningContext()
 }
 
+// FIXME - remove or refactor
 /**
  * Sugar extension to pull an auth scheme out of the attribute set.
  *

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/SigningContext.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/SigningContext.kt
@@ -5,41 +5,18 @@
 package aws.smithy.kotlin.runtime.client.endpoints
 
 import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.auth.AuthOption
 import aws.smithy.kotlin.runtime.util.AttributeKey
 
 /**
- * Static attribute key for AWS endpoint auth schemes.
+ * Static attribute key for AWS endpoint auth schemes that can influence the signing context
  */
 @InternalApi
-public val SigningContextAttributeKey: AttributeKey<List<SigningContext>> = AttributeKey("authSchemes")
+public val SigningContextAttributeKey: AttributeKey<List<AuthOption>> = AttributeKey("aws.smithy.kotlin#endpointAuthSchemes")
 
 /**
- * A set of signing constraints for an AWS endpoint.
+ * Sugar extension to pull the auth option(s) out of the endpoint attributes.
  */
 @InternalApi
-public sealed class SigningContext {
-    @InternalApi
-    public data class SigV4(
-        public val signingName: String?,
-        public val disableDoubleEncoding: Boolean,
-        public val signingRegion: String?,
-    ) : SigningContext()
-
-    @InternalApi
-    public data class SigV4A(
-        public val signingName: String?,
-        public val disableDoubleEncoding: Boolean,
-        public val signingRegionSet: List<String>,
-    ) : SigningContext()
-}
-
-// FIXME - remove or refactor
-/**
- * Sugar extension to pull an auth scheme out of the attribute set.
- *
- * FUTURE: Right now we only support sigv4. The auth scheme property can include multiple schemes, for now we only pull
- * out the sigv4 one if present.
- */
-@InternalApi
-public val Endpoint.signingContext: SigningContext.SigV4?
-    get() = attributes.getOrNull(SigningContextAttributeKey)?.filterIsInstance<SigningContext.SigV4>()?.firstOrNull()
+public val Endpoint.authOptions: List<AuthOption>
+    get() = attributes.getOrNull(SigningContextAttributeKey) ?: emptyList()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Enable endpoint based auth scheme resolution as an opt-in codegen setting.
* Introduce sigv4A types in the runtime for `AuthOption` and `AuthScheme`.
* Thread more signing context through the execution context/signer context rather than require it be set on the middleware at construction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
