### PR TITLE
misc: revert runtime/codegen versioning split

### DIFF
--- a/.changes/cf638060-f5d7-48f2-9e68-651a11e4c033.json
+++ b/.changes/cf638060-f5d7-48f2-9e68-651a11e4c033.json
@@ -1,5 +1,0 @@
-{
-    "id": "cf638060-f5d7-48f2-9e68-651a11e4c033",
-    "type": "misc",
-    "description": "Separate codegen project versioning"
-}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -102,16 +102,12 @@ jobs:
         # TODO - JVM only
         cd $GITHUB_WORKSPACE/smithy-kotlin
         ./gradlew --parallel publishToMavenLocal
-        SMITHY_KOTLIN_RUNTIME_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
-        SMITHY_KOTLIN_CODEGEN_VERSION=$(grep codegenVersion= gradle.properties | cut -d = -f 2)
+        SMITHY_KOTLIN_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
         cd $GITHUB_WORKSPACE/aws-sdk-kotlin
-        # replace smithy-kotlin-runtime-version and smithy-kotlin-codegen-version to be
-        # whatever we are testing such that the protocol test projects don't fail with a
-        # version that doesn't exist locally or in maven central. Otherwise the generated
-        # protocol test projects will use whatever the SDK thinks the version of
-        # smithy-kotlin should be
-        sed -i "s/smithy-kotlin-runtime-version = .*$/smithy-kotlin-runtime-version = \"$SMITHY_KOTLIN_RUNTIME_VERSION\"/" gradle/libs.versions.toml
-        sed -i "s/smithy-kotlin-codegen-version = .*$/smithy-kotlin-codegen-version = \"$SMITHY_KOTLIN_CODEGEN_VERSION\"/" gradle/libs.versions.toml
+        # replace smithy-kotlin-version to be whatever we are testing such that the protocol test projects
+        # don't fail with a version that doesn't exist locally or in maven central. Otherwise
+        # the generated protocol test projects will use whatever the SDK thinks the version of smithy-kotlin should be
+        sed -i "s/smithy-kotlin-version = .*$/smithy-kotlin-version = \"$SMITHY_KOTLIN_VERSION\"/" gradle/libs.versions.toml
         ./gradlew --parallel publishToMavenLocal
         ./gradlew test jvmTest
         ./gradlew testAllProtocols

--- a/codegen/smithy-kotlin-codegen-testutils/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen-testutils/build.gradle.kts
@@ -13,9 +13,9 @@ description = "Provides common test utilities for Smithy-Kotlin code generation"
 extra["displayName"] = "Smithy :: Kotlin :: Codegen Utils"
 extra["moduleName"] = "software.amazon.smithy.kotlin.codegen.test"
 
-val codegenVersion: String by project
+val sdkVersion: String by project
 group = "software.amazon.smithy.kotlin"
-version = codegenVersion
+version = sdkVersion
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))

--- a/codegen/smithy-kotlin-codegen/build.gradle.kts
+++ b/codegen/smithy-kotlin-codegen/build.gradle.kts
@@ -13,9 +13,9 @@ description = "Generates Kotlin code from Smithy models"
 extra["displayName"] = "Smithy :: Kotlin :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.kotlin.codegen"
 
-val codegenVersion: String by project
+val sdkVersion: String by project
 group = "software.amazon.smithy.kotlin"
-version = codegenVersion
+version = sdkVersion
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,5 @@ org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G
 # SDK
 sdkVersion=0.28.2-SNAPSHOT
 
-# codegen
-codegenVersion=0.28.2-SNAPSHOT
-
 # kotlin
 kotlinVersion=1.9.10


### PR DESCRIPTION
This reverts commit ad34f2ae3a9c9619317f6df9569d649bdb8c09a8.

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
