### PR TITLE
account id routing and credentials interface

### DIFF
--- a/.changes/6467a679-d9c3-4741-8219-28d7d32abf5f.json
+++ b/.changes/6467a679-d9c3-4741-8219-28d7d32abf5f.json
@@ -1,0 +1,5 @@
+{
+    "id": "6467a679-d9c3-4741-8219-28d7d32abf5f",
+    "type": "misc",
+    "description": "refactor: make `Credentials` an interface"
+}

--- a/.changes/6467a679-d9c3-4741-8219-28d7d32abf5f.json
+++ b/.changes/6467a679-d9c3-4741-8219-28d7d32abf5f.json
@@ -1,5 +1,6 @@
 {
     "id": "6467a679-d9c3-4741-8219-28d7d32abf5f",
     "type": "misc",
-    "description": "refactor: make `Credentials` an interface"
+    "description": "**BREAKING**: make `Credentials` an interface",
+    "requiresMinorVersionBump": true
 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/SectionWriter.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/integration/SectionWriter.kt
@@ -35,6 +35,25 @@ fun interface SectionWriter {
 }
 
 /**
+ * A [SectionWriter] that always appends to the existing section contents (if any).
+ */
+fun interface AppendingSectionWriter : SectionWriter {
+    override fun write(writer: KotlinWriter, previousValue: String?) {
+        if (!previousValue.isNullOrBlank()) {
+            writer.write(previousValue)
+        }
+        append(writer)
+    }
+
+    /**
+     * This function writes code for the bound section.
+     * @param writer the writer used to write contents to for the active section, contents are always appended
+     * in the case of multiple section writers being bound to the same section.
+     */
+    fun append(writer: KotlinWriter)
+}
+
+/**
  * Binds a [SectionId] to a specific [SectionWriter]. Integrations may provide
  * lists of these bindings to allow overriding of codegen output at defined points
  * in where [CodeWriter.markSection()] has been called.

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,10 @@ kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G
 
 # SDK
-sdkVersion=0.29.0-SNAPSHOT
+sdkVersion=0.28.3-SNAPSHOT
 
 # codegen
-codegenVersion=0.29.0-SNAPSHOT
+codegenVersion=0.28.3-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.9.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,10 @@ kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Xmx2G -XX:MaxMetaspaceSize=1G
 
 # SDK
-sdkVersion=0.28.3-SNAPSHOT
+sdkVersion=0.29.0-SNAPSHOT
 
 # codegen
-codegenVersion=0.28.2
+codegenVersion=0.29.0-SNAPSHOT
 
 # kotlin
 kotlinVersion=1.9.20

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ slf4j-v1x-version = "1.7.36"
 crt-kotlin-version = "0.8.2"
 
 # codegen
-smithy-version = "1.41.0"
+smithy-version = "1.41.1"
 smithy-gradle-version = "0.7.0"
 
 # testing

--- a/runtime/auth/aws-credentials/api/aws-credentials.api
+++ b/runtime/auth/aws-credentials/api/aws-credentials.api
@@ -13,10 +13,16 @@ public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/Cl
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials : aws/smithy/kotlin/runtime/identity/Identity {
+	public static final field Companion Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Companion;
 	public abstract fun getAccessKeyId ()Ljava/lang/String;
 	public abstract fun getProviderName ()Ljava/lang/String;
 	public abstract fun getSecretAccessKey ()Ljava/lang/String;
 	public abstract fun getSessionToken ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Companion {
+	public final fun invoke (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
+	public static synthetic fun invoke$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$DefaultImpls {
@@ -25,8 +31,6 @@ public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$Def
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsKt {
-	public static final fun Credentials (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
-	public static synthetic fun Credentials$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 	public static final fun copy (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 }

--- a/runtime/auth/aws-credentials/api/aws-credentials.api
+++ b/runtime/auth/aws-credentials/api/aws-credentials.api
@@ -12,26 +12,23 @@ public final class aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentia
 public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/CloseableCredentialsProvider : aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider, java/io/Closeable {
 }
 
-public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials : aws/smithy/kotlin/runtime/identity/Identity {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Laws/smithy/kotlin/runtime/time/Instant;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
-	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAccessKeyId ()Ljava/lang/String;
-	public synthetic fun getAttributes ()Laws/smithy/kotlin/runtime/util/Attributes;
-	public fun getAttributes ()Laws/smithy/kotlin/runtime/util/MutableAttributes;
-	public fun getExpiration ()Laws/smithy/kotlin/runtime/time/Instant;
-	public final fun getProviderName ()Ljava/lang/String;
-	public final fun getSecretAccessKey ()Ljava/lang/String;
-	public final fun getSessionToken ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials : aws/smithy/kotlin/runtime/identity/Identity {
+	public abstract fun getAccessKeyId ()Ljava/lang/String;
+	public abstract fun getProviderName ()Ljava/lang/String;
+	public abstract fun getSecretAccessKey ()Ljava/lang/String;
+	public abstract fun getSessionToken ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/awscredentials/Credentials$DefaultImpls {
+	public static fun getProviderName (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;)Ljava/lang/String;
+	public static fun getSessionToken (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsKt {
+	public static final fun Credentials (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
+	public static synthetic fun Credentials$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
+	public static final fun copy (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Ljava/lang/String;Laws/smithy/kotlin/runtime/util/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awscredentials/Credentials;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider : aws/smithy/kotlin/runtime/identity/IdentityProvider {

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -61,9 +61,10 @@ public class CachedCredentialsProvider(
         return cachedCredentials.getOrLoad {
             coroutineContext.trace<CachedCredentialsProvider> { "refreshing credentials cache" }
             val providerCreds = source.resolve()
-            val expiration = listOfNotNull(providerCreds.expiration, clock.now() + expireCredentialsAfter).min()
-            val creds = providerCreds.copy(expiration = expiration)
-            ExpiringValue(creds, expiration)
+            val cacheExpiration = listOfNotNull(providerCreds.expiration, clock.now() + expireCredentialsAfter).min()
+            val credsExpiration = providerCreds.expiration ?: cacheExpiration
+            val creds = providerCreds.copy(expiration = credsExpiration)
+            ExpiringValue(creds, cacheExpiration)
         }
     }
 

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -62,7 +62,7 @@ public class CachedCredentialsProvider(
             coroutineContext.trace<CachedCredentialsProvider> { "refreshing credentials cache" }
             val providerCreds = source.resolve()
             if (providerCreds.expiration != null) {
-                val expiration = minOf(providerCreds.expiration, (clock.now() + expireCredentialsAfter))
+                val expiration = minOf(providerCreds.expiration!!, (clock.now() + expireCredentialsAfter))
                 ExpiringValue(providerCreds, expiration)
             } else {
                 val expiration = clock.now() + expireCredentialsAfter

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/CachedCredentialsProvider.kt
@@ -61,14 +61,9 @@ public class CachedCredentialsProvider(
         return cachedCredentials.getOrLoad {
             coroutineContext.trace<CachedCredentialsProvider> { "refreshing credentials cache" }
             val providerCreds = source.resolve()
-            if (providerCreds.expiration != null) {
-                val expiration = minOf(providerCreds.expiration!!, (clock.now() + expireCredentialsAfter))
-                ExpiringValue(providerCreds, expiration)
-            } else {
-                val expiration = clock.now() + expireCredentialsAfter
-                val creds = providerCreds.copy(expiration = expiration)
-                ExpiringValue(creds, expiration)
-            }
+            val expiration = listOfNotNull(providerCreds.expiration, clock.now() + expireCredentialsAfter).min()
+            val creds = providerCreds.copy(expiration = expiration)
+            ExpiringValue(creds, expiration)
         }
     }
 

--- a/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
+++ b/runtime/auth/aws-credentials/common/src/aws/smithy/kotlin/runtime/auth/awscredentials/Credentials.kt
@@ -7,26 +7,82 @@ package aws.smithy.kotlin.runtime.auth.awscredentials
 import aws.smithy.kotlin.runtime.identity.Identity
 import aws.smithy.kotlin.runtime.identity.IdentityAttributes
 import aws.smithy.kotlin.runtime.time.Instant
-import aws.smithy.kotlin.runtime.util.MutableAttributes
-import aws.smithy.kotlin.runtime.util.mutableAttributes
+import aws.smithy.kotlin.runtime.util.*
 
 /**
  * Represents a set of AWS credentials
  *
  * For more information see [AWS security credentials](https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html#AccessKeys)
  */
-// FIXME - should probably be an interface
-public data class Credentials(
-    val accessKeyId: String,
-    val secretAccessKey: String,
-    val sessionToken: String? = null,
-    override val expiration: Instant? = null,
-    val providerName: String? = null,
-) : Identity {
-    override val attributes: MutableAttributes = mutableAttributes()
-    init {
-        providerName?.let {
-            attributes[IdentityAttributes.ProviderName] = it
-        }
+public interface Credentials : Identity {
+    /**
+     * Identifies the user interacting with services
+     */
+    public val accessKeyId: String
+
+    /**
+     * Secret key used to authenticate the user and sign requests
+     */
+    public val secretAccessKey: String
+
+    /**
+     * Session token associated with short term credentials with an expiration.
+     */
+    public val sessionToken: String?
+        get() = null
+
+    /**
+     * The name of the credentials provider that sourced these credentials (if known).
+     */
+    public val providerName: String?
+        get() = attributes.getOrNull(IdentityAttributes.ProviderName)
+}
+
+public fun Credentials.copy(
+    accessKeyId: String = this.accessKeyId,
+    secretAccessKey: String = this.secretAccessKey,
+    sessionToken: String? = this.sessionToken,
+    expiration: Instant? = this.expiration,
+    providerName: String? = this.providerName,
+    attributes: Attributes? = this.attributes,
+): Credentials {
+    val updatedAttributes = if (this.providerName != null && providerName == null) {
+        // if provider name was previously set and is updated to null we need to remove it from the current attributes
+        attributes?.toMutableAttributes()?.apply {
+            remove(IdentityAttributes.ProviderName)
+        }?.takeIf(Attributes::isNotEmpty)
+    } else {
+        attributes
     }
+    return Credentials(accessKeyId, secretAccessKey, sessionToken, expiration, providerName, updatedAttributes)
+}
+
+private data class CredentialsImpl(
+    override val accessKeyId: String,
+    override val secretAccessKey: String,
+    override val sessionToken: String? = null,
+    override val expiration: Instant? = null,
+    override val attributes: Attributes = emptyAttributes(),
+) : Credentials
+
+/**
+ * Create a new [Credentials] instance
+ */
+public fun Credentials(
+    accessKeyId: String,
+    secretAccessKey: String,
+    sessionToken: String? = null,
+    expiration: Instant? = null,
+    providerName: String? = null,
+    attributes: Attributes? = null,
+): Credentials {
+    val resolvedAttributes = if (providerName != null && attributes?.getOrNull(IdentityAttributes.ProviderName) != providerName) {
+        val merged = attributes?.toMutableAttributes() ?: mutableAttributes()
+        merged.setIfValueNotNull(IdentityAttributes.ProviderName, providerName)
+        merged
+    } else {
+        attributes ?: emptyAttributes()
+    }
+
+    return CredentialsImpl(accessKeyId, secretAccessKey, sessionToken, expiration, resolvedAttributes)
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1300,6 +1300,7 @@ public final class aws/smithy/kotlin/runtime/util/AttributesKt {
 	public static final fun attributesOf (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/util/Attributes;
 	public static final fun emptyAttributes ()Laws/smithy/kotlin/runtime/util/Attributes;
 	public static final fun get (Laws/smithy/kotlin/runtime/util/Attributes;Laws/smithy/kotlin/runtime/util/AttributeKey;)Ljava/lang/Object;
+	public static final fun isNotEmpty (Laws/smithy/kotlin/runtime/util/Attributes;)Z
 	public static final fun merge (Laws/smithy/kotlin/runtime/util/MutableAttributes;Laws/smithy/kotlin/runtime/util/Attributes;)V
 	public static final fun mutableAttributes ()Laws/smithy/kotlin/runtime/util/MutableAttributes;
 	public static final fun mutableAttributesOf (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/util/MutableAttributes;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -13,7 +13,7 @@ package aws.smithy.kotlin.runtime.util
  */
 public data class AttributeKey<T>(public val name: String) {
     init {
-        require(name.isNotBlank()) { "AttributeKey name (`$name`) cannot be blank" }
+        require(name.isNotBlank()) { "AttributeKey name must not be blank" }
     }
     override fun toString(): String = "AttributeKey($name)"
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Attributes.kt
@@ -12,7 +12,10 @@ package aws.smithy.kotlin.runtime.util
  * @param name the name of the attribute (for diagnostics)
  */
 public data class AttributeKey<T>(public val name: String) {
-    override fun toString(): String = if (name.isBlank()) super.toString() else "ExecutionAttributeKey: $name"
+    init {
+        require(name.isNotBlank()) { "AttributeKey name (`$name`) cannot be blank" }
+    }
+    override fun toString(): String = "AttributeKey($name)"
 }
 
 /**
@@ -59,6 +62,12 @@ public interface MutableAttributes : Attributes {
      */
     public fun <T : Any> computeIfAbsent(key: AttributeKey<T>, block: () -> T): T
 }
+
+/**
+ * Flag indicating if attributes is not empty
+ */
+public val Attributes.isNotEmpty: Boolean
+    get() = !isEmpty
 
 /**
  * Gets a value of the attribute for the specified [key] or throws an [IllegalStateException] if key does not exist
@@ -155,6 +164,7 @@ private class AttributesImpl constructor(seed: Attributes) : MutableAttributes {
     }
 
     override fun hashCode(): Int = map.hashCode()
+    override fun toString(): String = map.toString()
 }
 
 private object EmptyAttributes : Attributes {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a
downstream: https://github.com/awslabs/aws-sdk-kotlin/pull/1111

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Refactors `Credentials` to be an interface. 

Miscellaneous support for upstream account ID based routing PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
