### PR TITLE
fix: optimize splitOnWordBoundaries

### DIFF
--- a/.changes/e8825e61-8155-4da0-a9c9-eae9a0d786d4.json
+++ b/.changes/e8825e61-8155-4da0-a9c9-eae9a0d786d4.json
@@ -1,5 +1,0 @@
-{
-    "id": "e8825e61-8155-4da0-a9c9-eae9a0d786d4",
-    "type": "misc",
-    "description": "Optimize `splitOnWordBoundaries` implementation"
-}

--- a/.changes/e8825e61-8155-4da0-a9c9-eae9a0d786d4.json
+++ b/.changes/e8825e61-8155-4da0-a9c9-eae9a0d786d4.json
@@ -1,0 +1,5 @@
+{
+    "id": "e8825e61-8155-4da0-a9c9-eae9a0d786d4",
+    "type": "misc",
+    "description": "Optimize `splitOnWordBoundaries` implementation"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/utils/CaseUtils.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.kotlin.codegen.utils
 
+// These are whole words but cased differently, e.g. `IPv4`, `MiB`, `GiB`, `TtL`
 private val completeWords = listOf("ipv4", "ipv6", "sigv4", "mib", "gib", "kib", "ttl", "iot", "s3")
 
 /**
@@ -15,7 +16,6 @@ fun String.splitOnWordBoundaries(): List<String> {
     // https://github.com/aws/aws-sdk-java-v2/blob/2.20.162/utils/src/main/java/software/amazon/awssdk/utils/internal/CodegenNamingUtils.java#L36
     // but this has some edge cases it doesn't handle well
     val out = mutableListOf<String>()
-    // These are whole words but cased differently, e.g. `IPv4`, `MiB`, `GiB`, `TtL`
     var currentWord = ""
     var computeWordInProgress = true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
First pass at optimizing `splitOnWordBoundaries` which was refactored in #975.  Avoids re-computation of "is start of word" when we already know it isn't the start of a word.

Follows after the similar Rust PR: https://github.com/smithy-lang/smithy-rs/pull/3140

Timings before and after for camel casing everything in `all-names-test-output.csv`:

```
// BEFORE
took 2634 milliseconds
took 1990 milliseconds
took 2211 milliseconds
took 1822 milliseconds
took 2038 milliseconds

// AFTER
took 487 milliseconds
took 392 milliseconds
took 353 milliseconds
took 352 milliseconds
took 346 milliseconds
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
