### PR TITLE
fix: `AttributeKey` code generation

### DIFF
--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -12,6 +12,9 @@ import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.defaultName
 import software.amazon.smithy.model.SourceLocation
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType
+import software.amazon.smithy.rulesengine.language.evaluation.type.IntegerType
+import software.amazon.smithy.rulesengine.language.evaluation.type.StringType
 import software.amazon.smithy.rulesengine.language.syntax.Identifier
 import software.amazon.smithy.rulesengine.language.syntax.ToExpression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.*
@@ -180,7 +183,13 @@ class DefaultEndpointProviderGenerator(
 
                             // otherwise, we just traverse the value like any other rules expression, object values will
                             // be rendered as Documents
-                            writeInline("#T(#S) to ", RuntimeTypes.Core.Collections.AttributeKey, kStr)
+                            // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
+                            writeInline("#T.create(#S, ",
+                                RuntimeTypes.Core.Collections.AttributeKey,
+                                kStr
+                            )
+                            renderExpression(v)
+                            writeInline(") to ")
                             renderExpression(v)
                             ensureNewline()
                         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -12,9 +12,6 @@ import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.defaultName
 import software.amazon.smithy.model.SourceLocation
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
-import software.amazon.smithy.rulesengine.language.evaluation.type.BooleanType
-import software.amazon.smithy.rulesengine.language.evaluation.type.IntegerType
-import software.amazon.smithy.rulesengine.language.evaluation.type.StringType
 import software.amazon.smithy.rulesengine.language.syntax.Identifier
 import software.amazon.smithy.rulesengine.language.syntax.ToExpression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.*
@@ -184,9 +181,10 @@ class DefaultEndpointProviderGenerator(
                             // otherwise, we just traverse the value like any other rules expression, object values will
                             // be rendered as Documents
                             // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
-                            writeInline("#T.create(#S, ",
+                            writeInline(
+                                "#T.create(#S, ",
                                 RuntimeTypes.Core.Collections.AttributeKey,
-                                kStr
+                                kStr,
                             )
                             renderExpression(v)
                             writeInline(") to ")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGenerator.kt
@@ -180,14 +180,7 @@ class DefaultEndpointProviderGenerator(
 
                             // otherwise, we just traverse the value like any other rules expression, object values will
                             // be rendered as Documents
-                            // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
-                            writeInline(
-                                "#T.create(#S, ",
-                                RuntimeTypes.Core.Collections.AttributeKey,
-                                kStr,
-                            )
-                            renderExpression(v)
-                            writeInline(") to ")
+                            writeInline("#S to ", kStr)
                             renderExpression(v)
                             ensureNewline()
                         }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -127,7 +127,8 @@ class DefaultEndpointProviderTestGenerator(
                         }
 
                         // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
-                        writeInline("#T.create(#S, ",
+                        writeInline(
+                            "#T.create(#S, ",
                             RuntimeTypes.Core.Collections.AttributeKey,
                             k,
                         )

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -126,14 +126,7 @@ class DefaultEndpointProviderTestGenerator(
                             return@forEach
                         }
 
-                        // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
-                        writeInline(
-                            "#T.create(#S, ",
-                            RuntimeTypes.Core.Collections.AttributeKey,
-                            k,
-                        )
-                        renderExpression(Expression.fromNode(v))
-                        writeInline(") to ")
+                        writeInline("#S to ", k)
                         renderExpression(Expression.fromNode(v))
                         ensureNewline()
                     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderTestGenerator.kt
@@ -126,7 +126,13 @@ class DefaultEndpointProviderTestGenerator(
                             return@forEach
                         }
 
-                        writeInline("#T(#S) to ", RuntimeTypes.Core.Collections.AttributeKey, k)
+                        // FIXME Refactor to avoid using .create(). Still need to pass the type of V (e.g. AttributeKey<typeOf(v)>)
+                        writeInline("#T.create(#S, ",
+                            RuntimeTypes.Core.Collections.AttributeKey,
+                            k,
+                        )
+                        renderExpression(Expression.fromNode(v))
+                        writeInline(") to ")
                         renderExpression(Expression.fromNode(v))
                         ensureNewline()
                     }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -217,17 +217,13 @@ class DefaultEndpointProviderGeneratorTest {
                     append("fooheader", "barheader")
                 },
                 attributes = attributesOf {
-                    AttributeKey.create("foo", "bar") to "bar"
-                    AttributeKey.create("fooInt", 7) to 7
-                    AttributeKey.create("fooBoolean", true) to true
-                    AttributeKey.create("fooObject", buildDocument {
-                        "fooObjectFoo" to "bar"
-                    }) to buildDocument {
+                    "foo" to "bar"
+                    "fooInt" to 7
+                    "fooBoolean" to true
+                    "fooObject" to buildDocument {
                         "fooObjectFoo" to "bar"
                     }
-                    AttributeKey.create("fooArray", listOf(
-                        "\"fooArrayBar\"",
-                    )) to listOf(
+                    "fooArray" to listOf(
                         "\"fooArrayBar\"",
                     )
                 },

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/endpoints/DefaultEndpointProviderGeneratorTest.kt
@@ -217,13 +217,17 @@ class DefaultEndpointProviderGeneratorTest {
                     append("fooheader", "barheader")
                 },
                 attributes = attributesOf {
-                    AttributeKey("foo") to "bar"
-                    AttributeKey("fooInt") to 7
-                    AttributeKey("fooBoolean") to true
-                    AttributeKey("fooObject") to buildDocument {
+                    AttributeKey.create("foo", "bar") to "bar"
+                    AttributeKey.create("fooInt", 7) to 7
+                    AttributeKey.create("fooBoolean", true) to true
+                    AttributeKey.create("fooObject", buildDocument {
+                        "fooObjectFoo" to "bar"
+                    }) to buildDocument {
                         "fooObjectFoo" to "bar"
                     }
-                    AttributeKey("fooArray") to listOf(
+                    AttributeKey.create("fooArray", listOf(
+                        "\"fooArrayBar\"",
+                    )) to listOf(
                         "\"fooArrayBar\"",
                     )
                 },

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -71,7 +71,6 @@ public final class aws/smithy/kotlin/runtime/ServiceException$ErrorType : java/l
 }
 
 public final class aws/smithy/kotlin/runtime/collections/AttributeKey {
-	public static final field Companion Laws/smithy/kotlin/runtime/collections/AttributeKey$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/collections/AttributeKey;

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -71,6 +71,7 @@ public final class aws/smithy/kotlin/runtime/ServiceException$ErrorType : java/l
 }
 
 public final class aws/smithy/kotlin/runtime/collections/AttributeKey {
+	public static final field Companion Laws/smithy/kotlin/runtime/collections/AttributeKey$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/collections/AttributeKey;
@@ -79,6 +80,9 @@ public final class aws/smithy/kotlin/runtime/collections/AttributeKey {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/collections/AttributeKey$Companion {
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/collections/Attributes {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -81,9 +81,6 @@ public final class aws/smithy/kotlin/runtime/collections/AttributeKey {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class aws/smithy/kotlin/runtime/collections/AttributeKey$Companion {
-}
-
 public abstract interface class aws/smithy/kotlin/runtime/collections/Attributes {
 	public abstract fun contains (Laws/smithy/kotlin/runtime/collections/AttributeKey;)Z
 	public abstract fun getKeys ()Ljava/util/Set;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
@@ -5,8 +5,6 @@
 
 package aws.smithy.kotlin.runtime.collections
 
-import aws.smithy.kotlin.runtime.InternalApi
-
 /**
  * Specifies a key for an attribute
  *
@@ -18,11 +16,6 @@ public data class AttributeKey<T>(public val name: String) {
         require(name.isNotBlank()) { "AttributeKey name must not be blank" }
     }
     override fun toString(): String = "AttributeKey($name)"
-
-    public companion object {
-        @InternalApi
-        public fun <T> create(name: String, @Suppress("UNUSED_PARAMETER") value: T): AttributeKey<T> = AttributeKey(name)
-    }
 }
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
@@ -5,10 +5,12 @@
 
 package aws.smithy.kotlin.runtime.collections
 
+import aws.smithy.kotlin.runtime.InternalApi
+
 /**
  * Specifies a key for an attribute
  *
- * @param T is the type of the vale stored in the attribute
+ * @param T is the type of the value stored in the attribute
  * @param name the name of the attribute (for diagnostics)
  */
 public data class AttributeKey<T>(public val name: String) {
@@ -16,6 +18,11 @@ public data class AttributeKey<T>(public val name: String) {
         require(name.isNotBlank()) { "AttributeKey name must not be blank" }
     }
     override fun toString(): String = "AttributeKey($name)"
+
+    public companion object {
+        @InternalApi
+        public fun <T> create(name: String, value: T): AttributeKey<T> = AttributeKey(name)
+    }
 }
 
 /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/collections/Attributes.kt
@@ -21,7 +21,7 @@ public data class AttributeKey<T>(public val name: String) {
 
     public companion object {
         @InternalApi
-        public fun <T> create(name: String, value: T): AttributeKey<T> = AttributeKey(name)
+        public fun <T> create(name: String, @Suppress("UNUSED_PARAMETER") value: T): AttributeKey<T> = AttributeKey(name)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Usage of `AttributeKey` in endpoints  code generation fails with `Not enough information to infer type variable T`.

Example usage:
```kt
return Endpoint(
    Url.parse("${url?.scheme}://${url?.authority}/${uriEncodedBucket}${url?.path}"),
    attributes = attributesOf {
        AttributeKey("backend") to "FOOBAR" // Not enough information to infer type variable T
        SigningContextAttributeKey to listOf(
            sigV4(
                serviceName = "s3",
                disableDoubleUriEncode = true,
                signingRegion = "${params.region}",
            ),
        )
    },
)
```

The fix is to provide the type for `AttributeKey<T>`.  New codegen will look like:
```kt
AttributeKey.create("backend", "FOOBAR") to "FOOBAR"
```
This is done to avoid type-parsing at codegen and just let the Kotlin compiler work it out.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
