### PR TITLE
fix: windows ci flakey test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,111 +16,38 @@ env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
 jobs:
-#  jvm:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        # we build with a specific JDK version but source/target compatibility should ensure the jar is usable by
-#        # the target versions we want to support
-#        java-version:
-#          - 8
-#          - 11
-#          - 17
-#          - 21
-#    steps:
-#      - name: Checkout sources
-#        uses: actions/checkout@v4
-#      - name: Configure JDK
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'corretto'
-#          java-version: 17
-#          cache: 'gradle'
-#      - name: Test
-#        shell: bash
-#        run: |
-#          ./gradlew -Ptest.java.version=${{ matrix.java-version }} jvmTest --stacktrace
-#
-#  all-platforms:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [ ubuntu-latest, macos-latest, windows-latest ]
-#    steps:
-#      - name: Checkout sources
-#        uses: actions/checkout@v4
-#      - name: Configure JDK
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'corretto'
-#          java-version: 17
-#          cache: 'gradle'
-#      - name: Test
-#        shell: bash
-#        run: |
-#          echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-#          ./gradlew apiCheck
-#          ./gradlew test jvmTest
-#      - name: Save Test Reports
-#        if: failure()
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: test-reports
-#          path: '**/build/reports'
-#
-#  downstream:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout sources
-#      uses: actions/checkout@v4
-#      with:
-#        path: 'smithy-kotlin'
-#    - name: Checkout tools
-#      uses: actions/checkout@v4
-#      with:
-#        path: 'aws-kotlin-repo-tools'
-#        repository: 'awslabs/aws-kotlin-repo-tools'
-#        ref: '0.2.3'
-#        sparse-checkout: |
-#          .github
-#    - name: Checkout aws-sdk-kotlin
-#      uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
-#      with:
-#        # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
-#        path: 'aws-sdk-kotlin'
-#        repository: 'awslabs/aws-sdk-kotlin'
-#    - name: Configure JDK
-#      uses: actions/setup-java@v3
-#      with:
-#        distribution: 'corretto'
-#        java-version: 17
-#        cache: 'gradle'
-#    - name: Build and Test aws-sdk-kotlin downstream
-#      run: |
-#        # TODO - JVM only
-#        cd $GITHUB_WORKSPACE/smithy-kotlin
-#        ./gradlew --parallel publishToMavenLocal
-#        SMITHY_KOTLIN_RUNTIME_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
-#        SMITHY_KOTLIN_CODEGEN_VERSION=$(grep codegenVersion= gradle.properties | cut -d = -f 2)
-#        cd $GITHUB_WORKSPACE/aws-sdk-kotlin
-#        # replace smithy-kotlin-runtime-version and smithy-kotlin-codegen-version to be
-#        # whatever we are testing such that the protocol test projects don't fail with a
-#        # version that doesn't exist locally or in maven central. Otherwise the generated
-#        # protocol test projects will use whatever the SDK thinks the version of
-#        # smithy-kotlin should be
-#        sed -i "s/smithy-kotlin-runtime-version = .*$/smithy-kotlin-runtime-version = \"$SMITHY_KOTLIN_RUNTIME_VERSION\"/" gradle/libs.versions.toml
-#        sed -i "s/smithy-kotlin-codegen-version = .*$/smithy-kotlin-codegen-version = \"$SMITHY_KOTLIN_CODEGEN_VERSION\"/" gradle/libs.versions.toml
-#        ./gradlew --parallel publishToMavenLocal
-#        ./gradlew test jvmTest
-#        ./gradlew testAllProtocols
-  windows:
+  jvm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # we build with a specific JDK version but source/target compatibility should ensure the jar is usable by
+        # the target versions we want to support
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+          cache: 'gradle'
+      - name: Test
+        shell: bash
+        run: |
+          ./gradlew -Ptest.java.version=${{ matrix.java-version }} jvmTest --stacktrace
+
+  all-platforms:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -134,10 +61,57 @@ jobs:
         shell: bash
         run: |
           echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-          ./gradlew :runtime:protocol:http-client:jvmTest
+          ./gradlew apiCheck
+          ./gradlew test jvmTest
       - name: Save Test Reports
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: test-reports-${{ matrix.os }}
+          name: test-reports
           path: '**/build/reports'
+
+  downstream:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+      with:
+        path: 'smithy-kotlin'
+    - name: Checkout tools
+      uses: actions/checkout@v4
+      with:
+        path: 'aws-kotlin-repo-tools'
+        repository: 'awslabs/aws-kotlin-repo-tools'
+        ref: '0.2.3'
+        sparse-checkout: |
+          .github
+    - name: Checkout aws-sdk-kotlin
+      uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
+      with:
+        # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
+        path: 'aws-sdk-kotlin'
+        repository: 'awslabs/aws-sdk-kotlin'
+    - name: Configure JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'
+        java-version: 17
+        cache: 'gradle'
+    - name: Build and Test aws-sdk-kotlin downstream
+      run: |
+        # TODO - JVM only
+        cd $GITHUB_WORKSPACE/smithy-kotlin
+        ./gradlew --parallel publishToMavenLocal
+        SMITHY_KOTLIN_RUNTIME_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
+        SMITHY_KOTLIN_CODEGEN_VERSION=$(grep codegenVersion= gradle.properties | cut -d = -f 2)
+        cd $GITHUB_WORKSPACE/aws-sdk-kotlin
+        # replace smithy-kotlin-runtime-version and smithy-kotlin-codegen-version to be
+        # whatever we are testing such that the protocol test projects don't fail with a
+        # version that doesn't exist locally or in maven central. Otherwise the generated
+        # protocol test projects will use whatever the SDK thinks the version of
+        # smithy-kotlin should be
+        sed -i "s/smithy-kotlin-runtime-version = .*$/smithy-kotlin-runtime-version = \"$SMITHY_KOTLIN_RUNTIME_VERSION\"/" gradle/libs.versions.toml
+        sed -i "s/smithy-kotlin-codegen-version = .*$/smithy-kotlin-codegen-version = \"$SMITHY_KOTLIN_CODEGEN_VERSION\"/" gradle/libs.versions.toml
+        ./gradlew --parallel publishToMavenLocal
+        ./gradlew test jvmTest
+        ./gradlew testAllProtocols

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -139,5 +139,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: '**/build/reports'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,7 +67,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: '**/build/reports'
 
   downstream:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,38 +16,111 @@ env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
 jobs:
-  jvm:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # we build with a specific JDK version but source/target compatibility should ensure the jar is usable by
-        # the target versions we want to support
-        java-version:
-          - 8
-          - 11
-          - 17
-          - 21
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Configure JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: 17
-          cache: 'gradle'
-      - name: Test
-        shell: bash
-        run: |
-          ./gradlew -Ptest.java.version=${{ matrix.java-version }} jvmTest --stacktrace
-
-  all-platforms:
+#  jvm:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        # we build with a specific JDK version but source/target compatibility should ensure the jar is usable by
+#        # the target versions we want to support
+#        java-version:
+#          - 8
+#          - 11
+#          - 17
+#          - 21
+#    steps:
+#      - name: Checkout sources
+#        uses: actions/checkout@v4
+#      - name: Configure JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'corretto'
+#          java-version: 17
+#          cache: 'gradle'
+#      - name: Test
+#        shell: bash
+#        run: |
+#          ./gradlew -Ptest.java.version=${{ matrix.java-version }} jvmTest --stacktrace
+#
+#  all-platforms:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ ubuntu-latest, macos-latest, windows-latest ]
+#    steps:
+#      - name: Checkout sources
+#        uses: actions/checkout@v4
+#      - name: Configure JDK
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'corretto'
+#          java-version: 17
+#          cache: 'gradle'
+#      - name: Test
+#        shell: bash
+#        run: |
+#          echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
+#          ./gradlew apiCheck
+#          ./gradlew test jvmTest
+#      - name: Save Test Reports
+#        if: failure()
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: test-reports
+#          path: '**/build/reports'
+#
+#  downstream:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Checkout sources
+#      uses: actions/checkout@v4
+#      with:
+#        path: 'smithy-kotlin'
+#    - name: Checkout tools
+#      uses: actions/checkout@v4
+#      with:
+#        path: 'aws-kotlin-repo-tools'
+#        repository: 'awslabs/aws-kotlin-repo-tools'
+#        ref: '0.2.3'
+#        sparse-checkout: |
+#          .github
+#    - name: Checkout aws-sdk-kotlin
+#      uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
+#      with:
+#        # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
+#        path: 'aws-sdk-kotlin'
+#        repository: 'awslabs/aws-sdk-kotlin'
+#    - name: Configure JDK
+#      uses: actions/setup-java@v3
+#      with:
+#        distribution: 'corretto'
+#        java-version: 17
+#        cache: 'gradle'
+#    - name: Build and Test aws-sdk-kotlin downstream
+#      run: |
+#        # TODO - JVM only
+#        cd $GITHUB_WORKSPACE/smithy-kotlin
+#        ./gradlew --parallel publishToMavenLocal
+#        SMITHY_KOTLIN_RUNTIME_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
+#        SMITHY_KOTLIN_CODEGEN_VERSION=$(grep codegenVersion= gradle.properties | cut -d = -f 2)
+#        cd $GITHUB_WORKSPACE/aws-sdk-kotlin
+#        # replace smithy-kotlin-runtime-version and smithy-kotlin-codegen-version to be
+#        # whatever we are testing such that the protocol test projects don't fail with a
+#        # version that doesn't exist locally or in maven central. Otherwise the generated
+#        # protocol test projects will use whatever the SDK thinks the version of
+#        # smithy-kotlin should be
+#        sed -i "s/smithy-kotlin-runtime-version = .*$/smithy-kotlin-runtime-version = \"$SMITHY_KOTLIN_RUNTIME_VERSION\"/" gradle/libs.versions.toml
+#        sed -i "s/smithy-kotlin-codegen-version = .*$/smithy-kotlin-codegen-version = \"$SMITHY_KOTLIN_CODEGEN_VERSION\"/" gradle/libs.versions.toml
+#        ./gradlew --parallel publishToMavenLocal
+#        ./gradlew test jvmTest
+#        ./gradlew testAllProtocols
+  windows:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ windows-latest ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -61,57 +134,10 @@ jobs:
         shell: bash
         run: |
           echo "kotlinWarningsAsErrors=true" >> $GITHUB_WORKSPACE/local.properties
-          ./gradlew apiCheck
-          ./gradlew test jvmTest
+          ./gradlew :runtime:protocol:http-client:jvmTest
       - name: Save Test Reports
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: test-reports
           path: '**/build/reports'
-
-  downstream:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
-      with:
-        path: 'smithy-kotlin'
-    - name: Checkout tools
-      uses: actions/checkout@v4
-      with:
-        path: 'aws-kotlin-repo-tools'
-        repository: 'awslabs/aws-kotlin-repo-tools'
-        ref: '0.2.3'
-        sparse-checkout: |
-          .github
-    - name: Checkout aws-sdk-kotlin
-      uses: ./aws-kotlin-repo-tools/.github/actions/checkout-head
-      with:
-        # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
-        path: 'aws-sdk-kotlin'
-        repository: 'awslabs/aws-sdk-kotlin'
-    - name: Configure JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'corretto'
-        java-version: 17
-        cache: 'gradle'
-    - name: Build and Test aws-sdk-kotlin downstream
-      run: |
-        # TODO - JVM only
-        cd $GITHUB_WORKSPACE/smithy-kotlin
-        ./gradlew --parallel publishToMavenLocal
-        SMITHY_KOTLIN_RUNTIME_VERSION=$(grep sdkVersion= gradle.properties | cut -d = -f 2)
-        SMITHY_KOTLIN_CODEGEN_VERSION=$(grep codegenVersion= gradle.properties | cut -d = -f 2)
-        cd $GITHUB_WORKSPACE/aws-sdk-kotlin
-        # replace smithy-kotlin-runtime-version and smithy-kotlin-codegen-version to be
-        # whatever we are testing such that the protocol test projects don't fail with a
-        # version that doesn't exist locally or in maven central. Otherwise the generated
-        # protocol test projects will use whatever the SDK thinks the version of
-        # smithy-kotlin should be
-        sed -i "s/smithy-kotlin-runtime-version = .*$/smithy-kotlin-runtime-version = \"$SMITHY_KOTLIN_RUNTIME_VERSION\"/" gradle/libs.versions.toml
-        sed -i "s/smithy-kotlin-codegen-version = .*$/smithy-kotlin-codegen-version = \"$SMITHY_KOTLIN_CODEGEN_VERSION\"/" gradle/libs.versions.toml
-        ./gradlew --parallel publishToMavenLocal
-        ./gradlew test jvmTest
-        ./gradlew testAllProtocols

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -99,6 +99,11 @@ class FlexibleChecksumsRequestInterceptorTest {
     }
 
     @Test
+    fun testFailureReports() {
+        fail("test failure")
+    }
+
+    @Test
     fun itRemovesChecksumHeadersForAwsChunked() = runTest {
         val data = ByteArray(1024 * 1024 * 128) { 'a'.code.toByte() }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -100,10 +100,12 @@ class FlexibleChecksumsRequestInterceptorTest {
 
     @Test
     fun itRemovesChecksumHeadersForAwsChunked() = runTest {
+        val data = ByteArray(1024 * 1024 * 128) { "a".toByte() }
+
         val req = HttpRequestBuilder().apply {
             body = object : HttpBody.SourceContent() {
-                override val contentLength: Long = 1024 * 1024 * 128
-                override fun readFrom(): SdkSource = "a".repeat(contentLength.toInt()).encodeToByteArray().source()
+                override val contentLength: Long = data.size.toLong()
+                override fun readFrom(): SdkSource = data.source()
                 override val isOneShot: Boolean get() = false
             }
         }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -99,11 +99,6 @@ class FlexibleChecksumsRequestInterceptorTest {
     }
 
     @Test
-    fun testFailureReports() {
-        fail("test failure")
-    }
-
-    @Test
     fun itRemovesChecksumHeadersForAwsChunked() = runTest {
         val data = ByteArray(1024 * 1024 * 128) { 'a'.code.toByte() }
 

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -100,7 +100,7 @@ class FlexibleChecksumsRequestInterceptorTest {
 
     @Test
     fun itRemovesChecksumHeadersForAwsChunked() = runTest {
-        val data = ByteArray(1024 * 1024 * 128) { "a".toByte() }
+        val data = ByteArray(1024 * 1024 * 128) { 'a'.code.toByte() }
 
         val req = HttpRequestBuilder().apply {
             body = object : HttpBody.SourceContent() {

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptorTest.kt
@@ -100,7 +100,7 @@ class FlexibleChecksumsRequestInterceptorTest {
 
     @Test
     fun itRemovesChecksumHeadersForAwsChunked() = runTest {
-        val data = ByteArray(1024 * 1024 * 128) { 'a'.code.toByte() }
+        val data = ByteArray(65536 * 32) { 'a'.code.toByte() }
 
         val req = HttpRequestBuilder().apply {
             body = object : HttpBody.SourceContent() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Fix CI issue on windows where test runner is running out of memory. 

I didn't spend a ton of time debugging this but we are allocating 128M string and then immediately converting it to a `ByteArray` of same size. With a 256M total allocation it's possible the test runner is just running closer to it's limit on windows and toppling over.


Also added the OS name to the test report artifact to disambiguate if there are failures on more than one platform. This was just a miss in the original workflow definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
