### PR TITLE
feat: generate operation samples

### DIFF
--- a/.changes/295410ec-cc32-4a9c-a30a-aaeda9996c0f.json
+++ b/.changes/295410ec-cc32-4a9c-a30a-aaeda9996c0f.json
@@ -1,0 +1,5 @@
+{
+    "id": "295410ec-cc32-4a9c-a30a-aaeda9996c0f",
+    "type": "feature",
+    "description": "Generate KDoc samples from modeled examples"
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -25,7 +25,7 @@ class ShapeValueGenerator(
 ) {
 
     /**
-     * Renders the generation of a shape value declaration for the given parameters inline
+     * Renders a shape value declaration for the given parameters inline
      * with the current writer.
      *
      * @param writer writer to write generated code with.

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -206,7 +206,7 @@ class ShapeValueGenerator(
                         val variantName = memberName.replaceFirstChar { c -> c.uppercaseChar() }
                         writer.writeInline("${currSymbol.name}.$variantName(")
                         generator.instantiateShapeInline(writer, memberShape, valueNode)
-                        writer.write(")")
+                        writer.writeInline(")")
                     }
                     else -> throw CodegenException("unexpected shape type " + currShape.type)
                 }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -34,8 +34,12 @@ class ShapeValueGenerator(
      */
     fun instantiateShapeInline(writer: KotlinWriter, shape: Shape, params: Node) {
         if (shape.isStructureShape) {
-            classDeclaration(writer, shape.asStructureShape().get()) {
+            if (params.isNullNode) {
                 writeShapeValuesInline(writer, shape, params)
+            } else {
+                classDeclaration(writer, shape.asStructureShape().get()) {
+                    writeShapeValuesInline(writer, shape, params)
+                }
             }
         } else {
             writeShapeValuesInline(writer, shape, params)

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGenerator.kt
@@ -74,7 +74,8 @@ class ShapeValueGenerator(
     private fun classDeclaration(writer: KotlinWriter, shape: StructureShape, block: () -> Unit) {
         val symbol = symbolProvider.toSymbol(shape)
         // invoke the generated DSL builder for the class
-        writer.writeInline("#L {\n", symbol.name)
+        writer.writeInline("#L {", symbol.name)
+            .ensureNewline()
             .indent()
             .call { block() }
             .dedent()
@@ -88,7 +89,8 @@ class ShapeValueGenerator(
 
         val collectionGeneratorFunction = symbolProvider.toSymbol(shape).expectProperty(SymbolProperty.IMMUTABLE_COLLECTION_FUNCTION)
 
-        writer.writeInline("$collectionGeneratorFunction(\n")
+        writer.writeInline("$collectionGeneratorFunction(")
+            .ensureNewline()
             .indent()
             .call { block() }
             .dedent()
@@ -108,7 +110,8 @@ class ShapeValueGenerator(
         collectionSymbol.references.forEach {
             writer.addImport(it.symbol)
         }
-        writer.writeInline("$generatorFn(\n")
+        writer.writeInline("$generatorFn(")
+            .ensureNewline()
             .indent()
             .call { block() }
             .dedent()
@@ -158,7 +161,8 @@ class ShapeValueGenerator(
         override fun objectNode(node: ObjectNode) {
             if (currShape.type == ShapeType.DOCUMENT) {
                 writer
-                    .writeInline("#T {\n", RuntimeTypes.Core.Content.buildDocument)
+                    .writeInline("#T {", RuntimeTypes.Core.Content.buildDocument)
+                    .ensureNewline()
                     .indent()
             }
 
@@ -187,14 +191,15 @@ class ShapeValueGenerator(
                         } else {
                             generator.instantiateShapeInline(writer, memberShape, valueNode)
                             if (i < node.members.size - 1) {
-                                writer.writeInline(",\n")
+                                writer.writeInline(",")
+                                    .ensureNewline()
                             }
                         }
                     }
                     is DocumentShape -> {
                         writer.writeInline("#S to ", keyNode.value)
                         generator.instantiateShapeInline(writer, currShape, valueNode)
-                        writer.writeInline("\n")
+                        writer.ensureNewline()
                     }
                     is UnionShape -> {
                         val member = currShape.getMember(keyNode.value).orElseThrow {
@@ -256,7 +261,8 @@ class ShapeValueGenerator(
                             node.elements.forEach {
                                 generator.instantiateShapeInline(writer, currShape, it)
                                 writer.unwrite(writer.newline)
-                                writer.writeInline(",\n")
+                                writer.writeInline(",")
+                                    .ensureNewline()
                             }
                         }
                     }

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestRequestGenerator.kt
@@ -101,7 +101,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                     writer.writeInline("\nval input = ")
                         .indent()
                         .call {
-                            ShapeValueGenerator(model, symbolProvider).writeShapeValueInline(writer, inputShape, test.params)
+                            ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, inputShape, test.params)
                         }
                         .dedent()
                         .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/protocol/HttpProtocolUnitTestResponseGenerator.kt
@@ -80,7 +80,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
                     .call {
                         outputShape?.let {
                             writer.writeInline("\nresponse = ")
-                            ShapeValueGenerator(model, symbolProvider).writeShapeValueInline(writer, it, test.params)
+                            ShapeValueGenerator(model, symbolProvider).instantiateShapeInline(writer, it, test.params)
                         }
                     }
                     .write("")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
@@ -76,7 +76,7 @@ class KDocSamplesGenerator : KotlinIntegration {
             sampleFunctionName(index),
         ).joinToString(separator = ".")
 
-    private fun sampleFunctionName(index: Int): String = "sample" + if (index > 0) "$index" else ""
+    private fun sampleFunctionName(index: Int): String = "sample" + if (index > 0) "${index + 1}" else ""
     private fun sampleClassName(op: OperationShape): String = op.id.name
 
     private fun samplePackage(settings: KotlinSettings): String = settings.pkg.subpackage("samples")

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.rendering.samples
+
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.core.*
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.model.expectTrait
+import software.amazon.smithy.kotlin.codegen.model.hasTrait
+import software.amazon.smithy.kotlin.codegen.rendering.ShapeValueGenerator
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.TopDownIndex
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.DocumentationTrait
+import software.amazon.smithy.model.traits.ExamplesTrait
+import software.amazon.smithy.model.traits.ExamplesTrait.Example
+import software.amazon.smithy.model.transform.ModelTransformer
+import java.util.*
+import kotlin.jvm.optionals.getOrDefault
+
+// FIXME - add to default integrations (after documentation pre-processor)
+
+// FIXME: This renders using the playground by default which won't actually work
+//  see https://github.com/Kotlin/dokka/issues/3041
+//  Probably hold off merging until fixed
+
+/**
+ * [KotlinIntegration] that renders [KDoc samples](https://kotlinlang.org/docs/kotlin-doc.html#sample-identifier)
+ * and pre-processes the documentation to insert references to the generated sample identifiers for operations
+ * that have [examples](https://smithy.io/2.0/spec/documentation-traits.html#smithy-api-examples-trait)
+ */
+class KDocSamplesGenerator : KotlinIntegration {
+    override fun enabledForService(model: Model, settings: KotlinSettings): Boolean {
+        val topDownIndex = TopDownIndex.of(model)
+        val operations = topDownIndex.getContainedOperations(settings.service)
+        return operations.any { it.hasTrait<ExamplesTrait>() }
+    }
+
+    /**
+     * This should run _after_ [software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor]
+     */
+    override fun preprocessModel(model: Model, settings: KotlinSettings): Model {
+        val transformer = ModelTransformer.create()
+        return transformer.mapTraits(model) { shape, trait ->
+            when {
+                shape is OperationShape && shape.hasTrait<ExamplesTrait>() && trait is DocumentationTrait -> {
+                    val examplesTrait = shape.expectTrait<ExamplesTrait>()
+                    val kdocSampleIdentifiers =
+                        (0 until examplesTrait.examples.size).joinToString(separator = "\n") { idx ->
+                            val identifier = sampleIdentifier(settings, shape, idx)
+                            "@sample $identifier"
+                        }
+
+                    val updatedDocs = trait.value + "\n\n" + kdocSampleIdentifiers
+                    DocumentationTrait(updatedDocs, trait.sourceLocation)
+                }
+                else -> trait
+            }
+        }
+    }
+
+    private fun sampleIdentifier(settings: KotlinSettings, op: OperationShape, index: Int): String =
+        listOf(
+            samplePackage(settings),
+            sampleClassName(op),
+            sampleFunctionName(index),
+        ).joinToString(separator = ".")
+
+    private fun sampleFunctionName(index: Int): String = "sample${index + 1}"
+    private fun sampleClassName(op: OperationShape): String = op.id.name
+
+    private fun samplePackage(settings: KotlinSettings): String = settings.pkg.subpackage("samples")
+    override fun writeAdditionalFiles(ctx: CodegenContext, delegator: KotlinDelegator) {
+        val topDownIndex = TopDownIndex.of(ctx.model)
+        val operations = topDownIndex.getContainedOperations(ctx.settings.service)
+        operations.filter { it.hasTrait<ExamplesTrait>() }
+            .forEach { op ->
+                val examples = op.expectTrait<ExamplesTrait>()
+
+                val writer = KotlinWriter(samplePackage(ctx.settings))
+                writer.withBlock("class #L {", "}", sampleClassName(op)) {
+                    examples.examples.forEachIndexed { idx, example ->
+                        write("")
+                        write("@Sample")
+                        withBlock("fun #L() {", "}", sampleFunctionName(idx)) {
+                            val docs = example.documentation.getOrDefault(example.title)
+                            // TODO - cleanup formatting on docs
+                            write("// #L", docs)
+                            if (example.error.isPresent) {
+                                renderErrorExample()
+                            } else {
+                                renderNormalExample(ctx, writer, op, example)
+                            }
+                        }
+                        write("")
+                    }
+                }
+                val contents = writer.toString()
+                delegator.fileManifest.writeFile("samples/${op.id.name}.kt", contents)
+            }
+    }
+
+    private fun renderNormalExample(ctx: CodegenContext, writer: KotlinWriter, op: OperationShape, example: Example) {
+        val clientName = clientName(ctx.settings.sdkId).replaceFirstChar { it.lowercase(Locale.getDefault()) }
+        val respPrefix = if (example.output.isPresent) "val resp = " else ""
+
+        writer.withBlock("#L#LClient.#L {", "}", respPrefix, clientName, op.defaultName()) {
+            val input = ctx.model.expectShape(op.inputShape)
+            ShapeValueGenerator(ctx.model, ctx.symbolProvider).writeShapeValues(writer, input, example.input)
+        }
+
+        // TODO - echo outputs if applicable
+    }
+
+    private fun renderErrorExample() {
+        // TODO - error samples
+    }
+}

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
@@ -21,12 +21,6 @@ import software.amazon.smithy.model.transform.ModelTransformer
 import java.util.*
 import kotlin.jvm.optionals.getOrDefault
 
-// FIXME - add to default integrations (after documentation pre-processor)
-
-// FIXME: This renders using the playground by default which won't actually work
-//  see https://github.com/Kotlin/dokka/issues/3041
-//  Probably hold off merging until fixed
-
 /**
  * [KotlinIntegration] that renders [KDoc samples](https://kotlinlang.org/docs/kotlin-doc.html#sample-identifier)
  * and pre-processes the documentation to insert references to the generated sample identifiers for operations

--- a/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
+++ b/codegen/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGenerator.kt
@@ -50,7 +50,6 @@ class KDocSamplesGenerator : KotlinIntegration {
                         "@sample $identifier"
                     }
 
-                    shape.getTrait<DocumentationTrait>()?.sourceLocation
                     val existingDocs = shape.getTrait<DocumentationTrait>()
                     val updatedDocs = buildString {
                         if (existingDocs != null) {

--- a/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -1,5 +1,6 @@
 software.amazon.smithy.kotlin.codegen.lang.BuiltinPreprocessor
 software.amazon.smithy.kotlin.codegen.lang.DocumentationPreprocessor
+software.amazon.smithy.kotlin.codegen.rendering.samples.KDocSamplesGenerator
 software.amazon.smithy.kotlin.codegen.model.SetRefactorPreprocessor
 software.amazon.smithy.kotlin.codegen.rendering.PaginatorGenerator
 software.amazon.smithy.kotlin.codegen.rendering.waiters.ServiceWaitersGenerator

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -79,8 +79,6 @@ listOf<String>(
         contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    // TODO - nested map tests
-
     @Test
     fun `it renders nested lists`() {
         val model = """

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -194,6 +194,31 @@ MyStruct {
     }
 
     @Test
+    fun `it renders null structs`() {
+        val model = """
+            structure MyStruct {
+                stringMember: String,
+            }
+        """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
+
+        val structShape = model.expectShape(ShapeId.from("foo.bar#MyStruct"))
+        val writer = KotlinWriter("test")
+
+        val params = Node.nullNode()
+
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, structShape, params)
+        val contents = writer.toString()
+
+        val expected = """
+            null
+        """.trimIndent()
+
+        contents.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    @Test
     fun `it renders unions`() {
         val model = """
             structure Nested {

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/ShapeValueGeneratorTest.kt
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.kotlin.codegen.rendering
 
-import io.kotest.matchers.string.shouldContainOnlyOnce
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin
 import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
@@ -37,10 +36,9 @@ class ShapeValueGeneratorTest {
             .withMember("k3", 3)
             .build()
 
-        ShapeValueGenerator(model, provider).writeShapeValueInline(writer, mapShape, params)
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, mapShape, params)
         val contents = writer.toString()
 
-        // FIXME - can't seem to get indentation quite right in our node visitor...
         val expected = """
 mapOf<String, Int>(
     "k1" to 1,
@@ -49,7 +47,7 @@ mapOf<String, Int>(
 )
 """
 
-        contents.shouldContainOnlyOnce(expected)
+        contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
     @Test
@@ -61,13 +59,13 @@ mapOf<String, Int>(
         """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
 
         val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
-        val mapShape = model.expectShape(ShapeId.from("foo.bar#MyList"))
+        val listShape = model.expectShape(ShapeId.from("foo.bar#MyList"))
         val writer = KotlinWriter("test")
 
         val values: Array<Node> = listOf("v1", "v2", "v3").map(Node::from).toTypedArray()
         val params = Node.arrayNode(*values)
 
-        ShapeValueGenerator(model, provider).writeShapeValueInline(writer, mapShape, params)
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, listShape, params)
         val contents = writer.toString()
 
         val expected = """
@@ -78,7 +76,54 @@ listOf<String>(
 )
         """.trimIndent()
 
-        contents.shouldContainOnlyOnce(expected)
+        contents.shouldContainOnlyOnceWithDiff(expected)
+    }
+
+    // TODO - nested map tests
+
+    @Test
+    fun `it renders nested lists`() {
+        val model = """
+            list MyList {
+                member: NestedList,
+            }
+            list NestedList {
+                member: String
+            }
+        """.prependNamespaceAndService(namespace = "foo.bar").toSmithyModel()
+
+        val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(model, rootNamespace = "foo.bar")
+        val listShape = model.expectShape(ShapeId.from("foo.bar#MyList"))
+        val writer = KotlinWriter("test")
+
+        val values = listOf(
+            listOf("v1", "v2", "v3"),
+            listOf("v4", "v5", "v6"),
+        ).map {
+            Node.arrayNode(*it.map(Node::from).toTypedArray())
+        }.toTypedArray()
+
+        val params = Node.arrayNode(*values)
+
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, listShape, params)
+        val contents = writer.toString()
+
+        val expected = """
+listOf<List<String>>(
+    listOf<String>(
+        "v1",
+        "v2",
+        "v3"
+    ),
+    listOf<String>(
+        "v4",
+        "v5",
+        "v6"
+    )
+)
+        """.trimIndent()
+
+        contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
     @Test
@@ -129,7 +174,7 @@ listOf<String>(
             .withMember("nullMember", Node.nullNode())
             .build()
 
-        ShapeValueGenerator(model, provider).writeShapeValueInline(writer, structShape, params)
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, structShape, params)
         val contents = writer.toString()
 
         val expected = """
@@ -140,7 +185,6 @@ MyStruct {
     structMember = Nested {
         tsMember = Instant.fromEpochSeconds(11223344, 0)
     }
-
     enumMember = MyEnum.fromValue("fooey")
     floatMember = 2.toFloat()
     doubleMember = 3.0.toDouble()
@@ -148,7 +192,7 @@ MyStruct {
 }
         """.trimIndent()
 
-        contents.shouldContainOnlyOnce(expected)
+        contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
     @Test
@@ -187,14 +231,14 @@ MyStruct {
             .withMember("stringMember", "v1")
             .build()
 
-        ShapeValueGenerator(model, provider).writeShapeValueInline(writer, unionShape, params)
+        ShapeValueGenerator(model, provider).instantiateShapeInline(writer, unionShape, params)
         val contents = writer.toString()
 
         val expected = """
 MyUnion.StringMember("v1")
         """.trimIndent()
 
-        contents.shouldContainOnlyOnce(expected)
+        contents.shouldContainOnlyOnceWithDiff(expected)
     }
 
     @Test
@@ -246,7 +290,7 @@ MyUnion.StringMember("v1")
                 .withMember("member", nodeValue)
                 .build()
 
-            gen.writeShapeValueInline(writer, shape, node)
+            gen.instantiateShapeInline(writer, shape, node)
             val contents = writer.toString()
 
             val expected = """
@@ -254,7 +298,7 @@ MyUnion.StringMember("v1")
                     member = $serialization
                 }
             """.trimIndent()
-            contents.shouldContainOnlyOnce(expected)
+            contents.shouldContainOnlyOnceWithDiff(expected)
         }
     }
 }

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
@@ -99,7 +99,7 @@ class KDocSamplesGeneratorTest {
             This is documentation for GetFoo
             
             @sample test.samples.GetFoo.sample
-            @sample test.samples.GetFoo.sample1
+            @sample test.samples.GetFoo.sample2
         """.trimIndent()
         assertEquals(expected, docs)
     }
@@ -122,7 +122,7 @@ class KDocSamplesGeneratorTest {
         val docs = modified.expectShape<OperationShape>("com.test#GetFoo").expectTrait<DocumentationTrait>().value
         val expected = """
             @sample test.samples.GetFoo.sample
-            @sample test.samples.GetFoo.sample1
+            @sample test.samples.GetFoo.sample2
         """.trimIndent()
         assertEquals(expected, docs)
     }
@@ -145,7 +145,7 @@ class KDocSamplesGeneratorTest {
                 }
 
                 @Sample
-                fun sample1() {
+                fun sample2() {
                     // Invoke GetFoo example 2
                     val resp = fooClient.getFoo {
                         member1 = "qux"

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.kotlin.codegen.rendering.samples
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.model.expectShape
+import software.amazon.smithy.kotlin.codegen.model.expectTrait
+import software.amazon.smithy.kotlin.codegen.test.newTestContext
+import software.amazon.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
+import software.amazon.smithy.kotlin.codegen.test.toCodegenContext
+import software.amazon.smithy.kotlin.codegen.test.toSmithyModel
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.DocumentationTrait
+import kotlin.test.assertEquals
+
+class KDocSamplesGeneratorTest {
+    private val model = """
+        namespace com.test
+        
+        service FooService {
+            version: "1.0.0"
+            operations: [GetFoo]
+        }
+        
+        @documentation("This is documentation for GetFoo")
+        operation GetFoo {
+            input: GetFooInput
+            output: GetFooOutput
+        }
+        
+        structure GetFooInput { 
+            member1: String
+        }
+        
+        structure GetFooOutput { }
+        
+        apply GetFoo @examples([
+            {
+                title: "Invoke GetFoo"
+                input: {
+                    member1: "bar"
+                }
+                output: {}
+            },
+            {
+                title: "Invoke GetFoo example 2"
+                input: {
+                    member1: "qux"
+                }
+                output: {}
+            }
+        ])
+        """.toSmithyModel()
+
+    private val settings = KotlinSettings(
+        ShapeId.from("com.test#FooService"),
+        KotlinSettings.PackageSettings(
+            "test",
+            "1.0",
+            "",
+        ),
+        "Foo",
+    )
+
+    @Test
+    fun itPreprocessesDocTraits() {
+        val integration = KDocSamplesGenerator()
+        val modified = integration.preprocessModel(model, settings)
+
+        val docs = modified.expectShape<OperationShape>("com.test#GetFoo").expectTrait<DocumentationTrait>().value
+        val expected = """
+            This is documentation for GetFoo
+            
+            @sample test.samples.GetFoo.sample1
+            @sample test.samples.GetFoo.sample2
+        """.trimIndent()
+        assertEquals(expected, docs)
+    }
+
+    @Test
+    fun testSamplesAreGenerated() {
+        val integration = KDocSamplesGenerator()
+        val testCtx = model.newTestContext("FooService", settings = settings, integrations = listOf(integration))
+
+        integration.writeAdditionalFiles(testCtx.toCodegenContext(), testCtx.generationCtx.delegator)
+        val expectedContents = """
+            class GetFoo {
+
+                @Sample
+                fun sample1() {
+                    // Invoke GetFoo
+                    val resp = fooClient.getFoo {
+                        member1 = "bar"
+                    }
+                }
+
+                @Sample
+                fun sample2() {
+                    // Invoke GetFoo example 2
+                    val resp = fooClient.getFoo {
+                        member1 = "qux"
+                    }
+                }
+
+            }
+
+        """.trimIndent()
+
+        testCtx.generationCtx.delegator.flushWriters()
+
+        val actualContents = testCtx.manifest.expectFileString("samples/GetFoo.kt")
+        actualContents.shouldContainOnlyOnceWithDiff(expectedContents)
+        actualContents.shouldContainOnlyOnceWithDiff("package test.samples")
+    }
+
+    // TODO - test error generation
+}

--- a/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
+++ b/codegen/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
@@ -30,6 +30,13 @@ class KDocSamplesGeneratorTest {
         operation GetFoo {
             input: GetFooInput
             output: GetFooOutput
+            errors: [MyOperationError]
+        }
+        
+        @error("client")
+        structure MyOperationError {
+            @required
+            message: String
         }
         
         structure GetFooInput { 
@@ -52,6 +59,19 @@ class KDocSamplesGeneratorTest {
                     member1: "qux"
                 }
                 output: {}
+            },
+            {
+                title: "Error example for MyOperation"
+                input: {
+                    member1: "!"
+                }
+                error: {
+                    shapeId: MyOperationError
+                    content: {
+                        message: "Invalid 'foo'. Special character not allowed."
+                    }
+                },
+                allowConstraintErrors: true
             }
         ])
         """.toSmithyModel()
@@ -112,10 +132,8 @@ class KDocSamplesGeneratorTest {
 
         testCtx.generationCtx.delegator.flushWriters()
 
-        val actualContents = testCtx.manifest.expectFileString("samples/GetFoo.kt")
+        val actualContents = testCtx.manifest.expectFileString("src/samples/GetFoo.kt")
         actualContents.shouldContainOnlyOnceWithDiff(expectedContents)
         actualContents.shouldContainOnlyOnceWithDiff("package test.samples")
     }
-
-    // TODO - test error generation
 }

--- a/docs/dokka-presets/css/aws-styles.css
+++ b/docs/dokka-presets/css/aws-styles.css
@@ -55,3 +55,11 @@
 .symbol {
     overflow-wrap: break-word;
 }
+
+/*
+    Disable the playground run button for generated samples
+    https://github.com/Kotlin/dokka/issues/3041
+*/
+div .compiler-info, .fold-button, .run-button {
+    display: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/239

downstream: https://github.com/awslabs/aws-sdk-kotlin/pull/1143

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Implements support for generating samples from the [examples trait](https://smithy.io/2.0/spec/documentation-traits.html#smithy-api-examples-trait).
* Cleans up `ShapeValueGenerator` a bit to make the output formatting nicer (we previously only used it for generating protocol tests so minor formatting issues weren't a big deal but they should be cleaner for docs).

### Notes
1. Code is output to `src/samples` directory. Samples are not automatically included by dokka, you have to update the configuration to get them included.
2. We decided to omit doing anything with the `output` of the examples trait and to omit error examples. It isn't clear what customer benefit there is to including them and instead decided to focus samples on making a request for the given operation.
3. This renders using the playground by default which won't actually work, see https://github.com/Kotlin/dokka/issues/3041. We will likely hold off merging this until that is disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
