### PR TITLE
fix: correctly sign special characters (e.g., "@") in URL paths

### DIFF
--- a/.changes/57a9f297-a562-4d70-a0f1-1821816a54eb.json
+++ b/.changes/57a9f297-a562-4d70-a0f1-1821816a54eb.json
@@ -1,0 +1,8 @@
+{
+    "id": "57a9f297-a562-4d70-a0f1-1821816a54eb",
+    "type": "bugfix",
+    "description": "Correctly sign special characters (e.g., \"@\") in URL paths",
+    "issues": [
+        "awslabs/smtihy-kotlin#1008"
+    ]
+}

--- a/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
+++ b/runtime/auth/aws-signing-default/common/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultCanonicalizerTest.kt
@@ -104,8 +104,8 @@ class DefaultCanonicalizerTest {
         }
 
         val uri = Url.Builder()
-        uri.path.encoded = "/foo/bar/baz%3Cqux%3Aquux"
-        assertEquals("/foo/bar/baz%253Cqux%253Aquux", uri.canonicalPath(config))
+        uri.path.encoded = "/foo/@bar/baz%3Cqux%3Aquux"
+        assertEquals("/foo/%40bar/baz%253Cqux%253Aquux", uri.canonicalPath(config))
     }
 
     @Test
@@ -114,11 +114,11 @@ class DefaultCanonicalizerTest {
             parameters {
                 decodedParameters {
                     addAll("foo", listOf("banana", "apple", "cherry"))
-                    addAll("bar", listOf("elderberry", "date"))
+                    addAll("bar", listOf("elderberry", "d@te"))
                 }
-                assertEquals("?foo=banana&foo=apple&foo=cherry&bar=elderberry&bar=date", decoded)
+                assertEquals("?foo=banana&foo=apple&foo=cherry&bar=elderberry&bar=d@te", decoded)
             }
-            assertEquals("bar=date&bar=elderberry&foo=apple&foo=banana&foo=cherry", canonicalQueryParams())
+            assertEquals("bar=d%40te&bar=elderberry&foo=apple&foo=banana&foo=cherry", canonicalQueryParams())
         }
     }
 

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -271,7 +271,11 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
         val extraHeaders = actual.headers.lowerKeys() - expected.headers.lowerKeys()
         assertEquals(0, extraHeaders.size, "Found extra headers in request: $extraHeaders")
 
-        assertEquals(expected.url.parameters, actual.url.parameters)
+        if (expected.url.parameters != actual.url.parameters) {
+            fun dumpParams(request: HttpRequest) =
+                request.url.parameters.entryValues.joinToString("\n", "\n") { (key, value) -> "  $key = $value" }
+            fail("\nTest case parameters: ${dumpParams(expected)}\n\nActual parameters: ${dumpParams(actual)}\n")
+        }
 
         when (val expectedBody = expected.body) {
             is HttpBody.Empty -> assertIs<HttpBody.Empty>(actual.body)

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1480,6 +1480,7 @@ public final class aws/smithy/kotlin/runtime/text/encoding/Encodable {
 	public final fun isEmpty ()Z
 	public final fun isNotEmpty ()Z
 	public final fun reencode ()Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public final fun reencode (Laws/smithy/kotlin/runtime/text/encoding/Encoding;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Encodable.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/encoding/Encodable.kt
@@ -54,7 +54,12 @@ public class Encodable internal constructor(
      * Returns a new [Encodable] derived from re-encoding this instance's [decoded] data. This _may_ be different from
      * the current instance's [encoded] data if the object was created with a non-canonical encoding.
      */
-    public fun reencode(): Encodable = encoding.encodableFromDecoded(decoded)
+    public fun reencode(): Encodable = reencode(encoding)
+
+    /**
+     * Returns a new [Encodable] derived from re-encoding this instance's [decoded] data with [newEncoding].
+     */
+    public fun reencode(newEncoding: Encoding): Encodable = newEncoding.encodableFromDecoded(decoded)
 
     override fun toString(): String = buildString {
         append("Encodable(decoded=")

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/QueryParametersTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/QueryParametersTest.kt
@@ -22,25 +22,25 @@ class QueryParametersTest {
     fun testDecodedParametersAlternateEncoding() {
         val paramString = QueryParameters {
             decodedParameters {
-                add("a", "green:apple")
-                add("b", "yellow:banana")
+                add("a", "one green:apple")
+                add("b", "two yellow:bananas")
             }
 
             decodedParameters(PercentEncoding.FormUrl) {
-                add("a", "red:apple")
+                add("a", "three red:apples")
             }
 
             val allValues = entryValues.toSet()
             listOf(
-                "a" to "green:apple",
-                "b" to "yellow:banana",
-                "a" to "red%3Aapple",
+                "a" to "one%20green:apple",
+                "b" to "two%20yellow:bananas",
+                "a" to "three%20red%3Aapples",
             ).forEach { (key, value) ->
                 assertTrue(allValues.any { it.key.encoded == key && it.value.encoded == value }, dumpMultiMap())
             }
         }.toString()
 
-        assertEquals("?a=green:apple&a=red%3Aapple&b=yellow:banana", paramString)
+        assertEquals("?a=one%20green:apple&a=three%20red%3Aapples&b=two%20yellow:bananas", paramString)
     }
 }
 

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/QueryParametersTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/QueryParametersTest.kt
@@ -22,25 +22,25 @@ class QueryParametersTest {
     fun testDecodedParametersAlternateEncoding() {
         val paramString = QueryParameters {
             decodedParameters {
-                add("a", "green apple")
-                add("b", "yellow banana")
+                add("a", "green:apple")
+                add("b", "yellow:banana")
             }
 
             decodedParameters(PercentEncoding.FormUrl) {
-                add("a", "red apple")
+                add("a", "red:apple")
             }
 
             val allValues = entryValues.toSet()
             listOf(
-                "a" to "green%20apple",
-                "b" to "yellow%20banana",
-                "a" to "red+apple",
+                "a" to "green:apple",
+                "b" to "yellow:banana",
+                "a" to "red%3Aapple",
             ).forEach { (key, value) ->
                 assertTrue(allValues.any { it.key.encoded == key && it.value.encoded == value }, dumpMultiMap())
             }
         }.toString()
 
-        assertEquals("?a=green%20apple&a=red+apple&b=yellow%20banana", paramString)
+        assertEquals("?a=green:apple&a=red%3Aapple&b=yellow:banana", paramString)
     }
 }
 

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
@@ -377,4 +377,4 @@ private fun SdkFieldDescriptor.copyWithNewSerialName(newName: String): SdkFieldD
     return SdkFieldDescriptor(kind, newTraits)
 }
 
-private fun String.encode() = PercentEncoding.Query.encode(this)
+private fun String.encode() = PercentEncoding.FormUrl.encode(this)

--- a/runtime/serde/serde-form-url/common/test/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializerTest.kt
+++ b/runtime/serde/serde-form-url/common/test/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializerTest.kt
@@ -6,6 +6,8 @@
 package aws.smithy.kotlin.runtime.serde.formurl
 
 import aws.smithy.kotlin.runtime.serde.*
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.TimestampFormat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,6 +23,7 @@ class FormUrlSerializerTest {
         val double: Double = 6.2,
         val char: Char = 'c',
         val string: String = "foo",
+        val timestamp: Instant = Instant.fromEpochSeconds(0),
         val listInt: List<Int> = listOf(5, 6, 7),
 
     ) : SdkSerializable {
@@ -34,6 +37,7 @@ class FormUrlSerializerTest {
             val descriptorDouble = SdkFieldDescriptor(SerialKind.Double, FormUrlSerialName("double"))
             val descriptorChar = SdkFieldDescriptor(SerialKind.Char, FormUrlSerialName("char"))
             val descriptorString = SdkFieldDescriptor(SerialKind.String, FormUrlSerialName("string"))
+            val descriptorTimstamp = SdkFieldDescriptor(SerialKind.Timestamp, FormUrlSerialName("timestamp"))
             val descriptorListInt = SdkFieldDescriptor(SerialKind.List, FormUrlSerialName("listInt"))
         }
 
@@ -50,6 +54,7 @@ class FormUrlSerializerTest {
                 field(descriptorDouble, double)
                 field(descriptorChar, char)
                 field(descriptorString, string)
+                field(descriptorTimstamp, timestamp, TimestampFormat.ISO_8601)
                 listField(descriptorListInt) {
                     for (value in listInt) {
                         serializeInt(value)
@@ -108,6 +113,7 @@ class FormUrlSerializerTest {
             &double=6.2
             &char=c
             &string=foo
+            &timestamp=1970-01-01T00%3A00%3A00Z
             &listInt.member.1=5
             &listInt.member.2=6
             &listInt.member.3=7

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/functions/Functions.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/endpoints/functions/Functions.kt
@@ -30,7 +30,7 @@ public fun isValidHostLabel(value: String?, allowSubdomains: Boolean): Boolean =
     } ?: false
 
 @InternalApi
-public fun uriEncode(value: String): String = PercentEncoding.Query.encode(value)
+public fun uriEncode(value: String): String = PercentEncoding.SmithyLabel.encode(value)
 
 @InternalApi
 public fun parseUrl(value: String?): Url? =


### PR DESCRIPTION
## Issue \#

Closes #1008 

## Description of changes

This update fixes encoding and signing problems around special characters in URL paths and query parameters. The root of the problem is that some characters (e.g., `@`) are valid in paths and queries according to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) but are [required to be escaped for the purposes of URL signing](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request). Prior code didn't properly differentiate the character sets that must be escaped in both situations and instead treated them as identical.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
