### PR TITLE
feat: emit metrics from CRT HTTP engine

### DIFF
--- a/.changes/e7c3c7ab-749e-4371-8b25-42ea76aa870d.json
+++ b/.changes/e7c3c7ab-749e-4371-8b25-42ea76aa870d.json
@@ -1,0 +1,8 @@
+{
+    "id": "e7c3c7ab-749e-4371-8b25-42ea76aa870d",
+    "type": "feature",
+    "description": "Emit metrics from CRT HTTP engine",
+    "issues": [
+        "https://github.com/awslabs/smithy-kotlin/issues/893"
+    ]
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/RequestUtil.kt
@@ -18,10 +18,13 @@ import aws.smithy.kotlin.runtime.crt.SdkSourceBodyStream
 import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
+import aws.smithy.kotlin.runtime.http.engine.crt.io.reportingTo
+import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.io.SdkBuffer
 import aws.smithy.kotlin.runtime.io.buffer
 import aws.smithy.kotlin.runtime.io.readToByteArray
+import aws.smithy.kotlin.runtime.io.source
 import kotlinx.coroutines.job
 import kotlin.coroutines.CoroutineContext
 
@@ -42,7 +45,10 @@ internal val HttpRequest.uri: Uri
         }
     }
 
-internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.kotlin.crt.http.HttpRequest {
+internal fun HttpRequest.toCrtRequest(
+    callContext: CoroutineContext,
+    metrics: HttpClientMetrics,
+): aws.sdk.kotlin.crt.http.HttpRequest {
     val body = this.body
     check(!body.isDuplex) { "CrtHttpEngine does not yet support full duplex streams" }
     val bodyStream = if (isChunked) {
@@ -50,10 +56,16 @@ internal fun HttpRequest.toCrtRequest(callContext: CoroutineContext): aws.sdk.ko
     } else {
         when (body) {
             is HttpBody.Empty -> null
-            is HttpBody.Bytes -> HttpRequestBodyStream.fromByteArray(body.bytes())
-            is HttpBody.ChannelContent -> ReadChannelBodyStream(body.readFrom(), callContext)
+            is HttpBody.Bytes -> {
+                val source = body.bytes().source().reportingTo(metrics.bytesSent)
+                SdkSourceBodyStream(source)
+            }
+            is HttpBody.ChannelContent -> {
+                val source = body.readFrom().reportingTo(metrics.bytesSent)
+                ReadChannelBodyStream(source, callContext)
+            }
             is HttpBody.SourceContent -> {
-                val source = body.readFrom()
+                val source = body.readFrom().reportingTo(metrics.bytesSent)
                 callContext.job.invokeOnCompletion {
                     source.close()
                 }
@@ -85,10 +97,10 @@ internal val HttpRequest.isChunked: Boolean get() = (this.body is HttpBody.Sourc
  * Send a chunked body using the CRT writeChunk bindings.
  * @param body an HTTP body that has a chunked content encoding. Must be [HttpBody.SourceContent] or [HttpBody.ChannelContent]
  */
-internal suspend fun HttpStream.sendChunkedBody(body: HttpBody) {
+internal suspend fun HttpStream.sendChunkedBody(body: HttpBody, metrics: HttpClientMetrics) {
     when (body) {
         is HttpBody.SourceContent -> {
-            val source = body.readFrom()
+            val source = body.readFrom().reportingTo(metrics.bytesSent)
             val bufferedSource = source.buffer()
 
             while (!bufferedSource.exhausted()) {
@@ -97,7 +109,7 @@ internal suspend fun HttpStream.sendChunkedBody(body: HttpBody) {
             }
         }
         is HttpBody.ChannelContent -> {
-            val chan = body.readFrom()
+            val chan = body.readFrom().reportingTo(metrics.bytesSent)
             var buffer = SdkBuffer()
             val nextBuffer = SdkBuffer()
             var sentFirstChunk = false

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/io/ReportingByteReadChannel.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/io/ReportingByteReadChannel.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.engine.crt.io
+
+import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
+import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
+
+private class ReportingByteReadChannel(
+    val delegate: SdkByteReadChannel,
+    val metric: MonotonicCounter,
+) : SdkByteReadChannel by delegate {
+    override suspend fun read(sink: SdkBuffer, limit: Long): Long = delegate.read(sink, limit).also {
+        if (it > 0) metric.add(it)
+    }
+}
+
+internal fun SdkByteReadChannel.reportingTo(metric: MonotonicCounter): SdkByteReadChannel =
+    ReportingByteReadChannel(this, metric)

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/io/ReportingSource.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/src/aws/smithy/kotlin/runtime/http/engine/crt/io/ReportingSource.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.http.engine.crt.io
+
+import aws.smithy.kotlin.runtime.io.SdkBuffer
+import aws.smithy.kotlin.runtime.io.SdkSource
+import aws.smithy.kotlin.runtime.telemetry.metrics.MonotonicCounter
+
+private class ReportingSource(val delegate: SdkSource, val metric: MonotonicCounter) : SdkSource by delegate {
+    override fun read(sink: SdkBuffer, limit: Long): Long = delegate.read(sink, limit).also {
+        if (it > 0) metric.add(it)
+    }
+}
+
+internal fun SdkSource.reportingTo(metric: MonotonicCounter): SdkSource = ReportingSource(this, metric)

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/RequestConversionTest.kt
@@ -8,15 +8,19 @@ package aws.smithy.kotlin.runtime.http.engine.crt
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.crt.ReadChannelBodyStream
 import aws.smithy.kotlin.runtime.http.*
+import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.SdkSource
 import aws.smithy.kotlin.runtime.io.source
 import aws.smithy.kotlin.runtime.net.url.Url
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
+
+private val metrics = HttpClientMetrics("", TelemetryProvider.None)
 
 class RequestConversionTest {
     private fun byteStreamFromContents(contents: String): ByteStream =
@@ -48,7 +52,7 @@ class RequestConversionTest {
             body,
         )
 
-        val crtRequest = request.toCrtRequest(EmptyCoroutineContext)
+        val crtRequest = request.toCrtRequest(EmptyCoroutineContext, metrics)
         assertEquals("POST", crtRequest.method)
         assertFalse(crtRequest.body is ReadChannelBodyStream)
     }
@@ -65,7 +69,7 @@ class RequestConversionTest {
         )
 
         val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
+        val crtRequest = request.toCrtRequest(testContext, metrics)
         assertEquals("POST", crtRequest.method)
         val crtBody = crtRequest.body as ReadChannelBodyStream
         crtBody.cancel()
@@ -83,7 +87,7 @@ class RequestConversionTest {
         )
 
         val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
+        val crtRequest = request.toCrtRequest(testContext, metrics)
         assertEquals("6", crtRequest.headers["Content-Length"])
 
         val crtBody = crtRequest.body as ReadChannelBodyStream
@@ -100,7 +104,7 @@ class RequestConversionTest {
         )
 
         val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
+        val crtRequest = request.toCrtRequest(testContext, metrics)
         assertEquals("0", crtRequest.headers["Content-Length"])
     }
 
@@ -119,7 +123,7 @@ class RequestConversionTest {
         )
 
         val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
+        val crtRequest = request.toCrtRequest(testContext, metrics)
         assertNotNull(request.body)
         assertNull(crtRequest.body)
     }
@@ -139,7 +143,7 @@ class RequestConversionTest {
         )
 
         val testContext = EmptyCoroutineContext + Job()
-        val crtRequest = request.toCrtRequest(testContext)
+        val crtRequest = request.toCrtRequest(testContext, metrics)
         assertNotNull(request.body)
         assertNull(crtRequest.body)
     }

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/jvm/test/aws/smithy/kotlin/runtime/http/engine/crt/SendChunkedBodyTest.kt
@@ -6,12 +6,16 @@
 package aws.smithy.kotlin.runtime.http.engine.crt
 
 import aws.sdk.kotlin.crt.http.HttpStream
+import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.http.toHttpBody
 import aws.smithy.kotlin.runtime.io.SdkByteReadChannel
 import aws.smithy.kotlin.runtime.io.readToByteArray
 import aws.smithy.kotlin.runtime.io.source
+import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
+
+private val metrics = HttpClientMetrics("", TelemetryProvider.None)
 
 class SendChunkedBodyTest {
     private class MockHttpStream(override val responseStatusCode: Int) : HttpStream {
@@ -33,7 +37,7 @@ class SendChunkedBodyTest {
 
         val source = chunkedBytes.source()
 
-        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()))
+        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()), metrics)
 
         // source should be fully consumed with 1 chunk written
         assertEquals(0, source.readToByteArray().size)
@@ -52,7 +56,7 @@ class SendChunkedBodyTest {
 
         val source = chunkedBytes.source()
 
-        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()))
+        stream.sendChunkedBody(source.toHttpBody(chunkedBytes.size.toLong()), metrics)
 
         // source should be fully consumed
         assertEquals(0, source.readToByteArray().size)
@@ -71,7 +75,7 @@ class SendChunkedBodyTest {
 
         val channel = SdkByteReadChannel(chunkedBytes)
 
-        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()))
+        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()), metrics)
 
         // channel should be fully consumed with 1 chunk written
         assertEquals(0, channel.availableForRead)
@@ -91,7 +95,7 @@ class SendChunkedBodyTest {
 
         val channel = SdkByteReadChannel(chunkedBytes)
 
-        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()))
+        stream.sendChunkedBody(channel.toHttpBody(chunkedBytes.size.toLong()), metrics)
 
         // source should be fully consumed
         assertEquals(0, channel.availableForRead)

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/src/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpEngine.kt
@@ -40,7 +40,9 @@ public class OkHttpEngine(
         override val engineConstructor: (OkHttpEngineConfig.Builder.() -> Unit) -> OkHttpEngine = ::invoke
     }
 
-    private val metrics = HttpClientMetrics(TELEMETRY_SCOPE, config.telemetryProvider)
+    private val metrics = HttpClientMetrics(TELEMETRY_SCOPE, config.telemetryProvider).apply {
+        requestConcurrencyLimit = config.maxConcurrency.toLong()
+    }
     private val client = config.buildClient(metrics)
 
     override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EngineAttributes.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/EngineAttributes.kt
@@ -7,6 +7,7 @@ package aws.smithy.kotlin.runtime.http.engine
 
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.collections.AttributeKey
+import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.time.Duration
 
 /**
@@ -15,8 +16,8 @@ import kotlin.time.Duration
 @InternalApi
 public object EngineAttributes {
     /**
-     * The time between sending the request completely and receiving the first byte of the response. This effectively
-     * measures the time spent waiting on a response.
+     * The interval between sending the request completely and receiving the first byte of the response. This
+     * effectively measures the time spent waiting on a response.
      */
     public val TimeToFirstByte: AttributeKey<Duration> = AttributeKey("aws.smithy.kotlin#TimeToFirstByte")
 }

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics.kt
@@ -176,6 +176,20 @@ public class HttpClientMetrics(
             _inFlightRequests.update { value }
         }
 
+    /**
+     * Atomically increase the number of inflight requests by 1.
+     */
+    public fun incrementInflightRequests() {
+        _inFlightRequests.incrementAndGet()
+    }
+
+    /**
+     * Atomically decrease the number of inflight requests by 1.
+     */
+    public fun decrementInflightRequests() {
+        _inFlightRequests.decrementAndGet()
+    }
+
     private fun recordRequestsState(measurement: LongAsyncMeasurement) {
         measurement.record(inFlightRequests, HttpClientMetricAttributes.InFlightRequest)
         measurement.record(queuedRequests, HttpClientMetricAttributes.QueuedRequest)

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1537,6 +1537,7 @@ public final class aws/smithy/kotlin/runtime/time/Instant : java/lang/Comparable
 	public final fun getEpochSeconds ()J
 	public final fun getNanosecondsOfSecond ()I
 	public fun hashCode ()I
+	public final fun minus-5sfh64U (Laws/smithy/kotlin/runtime/time/Instant;)J
 	public final fun minus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public final fun plus-LRDsOJo (J)Laws/smithy/kotlin/runtime/time/Instant;
 	public fun toString ()Ljava/lang/String;
@@ -1555,6 +1556,7 @@ public final class aws/smithy/kotlin/runtime/time/Instant$Companion {
 
 public final class aws/smithy/kotlin/runtime/time/InstantKt {
 	public static final fun fromEpochMilliseconds (Laws/smithy/kotlin/runtime/time/Instant$Companion;J)Laws/smithy/kotlin/runtime/time/Instant;
+	public static final fun fromEpochNanoseconds (Laws/smithy/kotlin/runtime/time/Instant$Companion;J)Laws/smithy/kotlin/runtime/time/Instant;
 	public static final fun getEpochMilliseconds (Laws/smithy/kotlin/runtime/time/Instant;)J
 	public static final fun toEpochDouble (Laws/smithy/kotlin/runtime/time/Instant;)D
 	public static final fun until (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;)J

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/time/Instant.kt
@@ -44,6 +44,13 @@ public expect class Instant : Comparable<Instant> {
      */
     public operator fun minus(duration: Duration): Instant
 
+    /**
+     * Returns a duration representing the amount of time between this and [other]. If [other] is before this instant,
+     * the resulting duration will be negative.
+     * @param other The [Instant] marking the end of the duration
+     */
+    public operator fun minus(other: Instant): Duration
+
     public companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]
@@ -101,5 +108,8 @@ public fun Instant.Companion.fromEpochMilliseconds(milliseconds: Long): Instant 
     val ns = (milliseconds - secs * MILLISEC_PER_SEC) * NS_PER_MILLISEC
     return fromEpochSeconds(secs, ns.toInt())
 }
+
+public fun Instant.Companion.fromEpochNanoseconds(ns: Long): Instant =
+    fromEpochSeconds(ns / NS_PER_SEC, ns.mod(NS_PER_SEC))
 
 public fun Instant.until(other: Instant): Duration = (other.epochMilliseconds - epochMilliseconds).milliseconds

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/time/InstantJVM.kt
@@ -22,6 +22,7 @@ import java.time.format.SignStyle
 import java.time.temporal.ChronoField
 import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 import java.time.Instant as jtInstant
 
 public actual class Instant(internal val value: jtInstant) : Comparable<Instant> {
@@ -56,6 +57,18 @@ public actual class Instant(internal val value: jtInstant) : Comparable<Instant>
      * If the [duration] is negative, the returned instant is later than this instant.
      */
     public actual operator fun minus(duration: Duration): Instant = plus(-duration)
+
+    private val ns: Long get() = value.epochSecond * NS_PER_SEC + value.nano
+
+    /**
+     * Returns a duration representing the amount of time between this and [other]. If [other] is before this instant,
+     * the resulting duration will be negative.
+     * @param other The [Instant] marking the end of the duration
+     */
+    public actual operator fun minus(other: Instant): Duration {
+        val delta = this.ns - other.ns
+        return delta.nanoseconds
+    }
 
     /**
      * Encode the [Instant] as a string into the format specified by [TimestampFormat]

--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/InstantNative.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/time/InstantNative.kt
@@ -40,6 +40,15 @@ public actual class Instant : Comparable<Instant> {
         TODO("Not yet implemented")
     }
 
+    /**
+     * Returns a duration representing the amount of time between this and [other]. If [other] is before this instant,
+     * the resulting duration will be negative.
+     * @param other The [Instant] marking the end of the duration
+     */
+    public actual operator fun minus(other: Instant): Duration {
+        TODO("Not yet implemented")
+    }
+
     public actual companion object {
         /**
          * Parse an ISO-8601 formatted string into an [Instant]


### PR DESCRIPTION
## Issue \#

https://github.com/awslabs/smithy-kotlin/issues/893

## Description of changes

This change emits metrics from the CRT HTTP engine similar to the ones emitted by the OkHttp engine.

**Companion PRs**: https://github.com/awslabs/aws-crt-java/pull/738, https://github.com/awslabs/aws-crt-kotlin/pull/86

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
