### PR TITLE
feat: expand use of `chunked` content encoding

### DIFF
--- a/.changes/0b435166-944d-4836-8683-964034b823cc.json
+++ b/.changes/0b435166-944d-4836-8683-964034b823cc.json
@@ -1,0 +1,5 @@
+{
+    "id": "0b435166-944d-4836-8683-964034b823cc",
+    "type": "feature",
+    "description": "Re-use SHA256 checksum during signing"
+}

--- a/.changes/0b435166-944d-4836-8683-964034b823cc.json
+++ b/.changes/0b435166-944d-4836-8683-964034b823cc.json
@@ -1,5 +1,5 @@
 {
     "id": "0b435166-944d-4836-8683-964034b823cc",
     "type": "feature",
-    "description": "Re-use SHA256 checksum during signing"
+    "description": "Enable `aws-chunked` content encoding for streaming requests without a content length"
 }

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
@@ -43,8 +43,8 @@ internal fun SdkBuffer.writeTrailerSignature(signature: String) {
  */
 @InternalApi
 public val HttpBody.isEligibleForAwsChunkedStreaming: Boolean
-    get() = (this is HttpBody.SourceContent || this is HttpBody.ChannelContent) && contentLength != null &&
-        (isOneShot || contentLength!! > AWS_CHUNKED_THRESHOLD)
+    get() = (this is HttpBody.SourceContent || this is HttpBody.ChannelContent) &&
+        (isOneShot || (contentLength?.compareTo(AWS_CHUNKED_THRESHOLD) ?: 0) > 0)
 
 /**
  * @return a boolean representing if the signing configuration is configured (via [HashSpecification]) for aws-chunked content encoding

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
@@ -193,9 +193,6 @@ internal class DefaultCanonicalizer(private val sha256Supplier: HashSupplier = :
     }
 }
 
-/** The number of bytes to read at a time during SHA256 calculation on streaming bodies. */
-private const val STREAM_CHUNK_BYTES = 16384 // 16KB
-
 /**
  * Canonicalizes a path from this [Url.Builder].
  * @param config The signing configuration to use

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -165,12 +165,6 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
                         HashSpecification.StreamingAws4HmacSha256Payload
                     }
                 }
-                request.headers["x-amz-checksum-sha256"] != null -> {
-                    // Re-use flexible checksums SHA256 if it's set
-                    HashSpecification.Precalculated(
-                        request.headers["x-amz-checksum-sha256"]!!.decodeBase64Bytes().encodeToHex(),
-                    )
-                }
                 config.isUnsignedPayload -> HashSpecification.UnsignedPayload
                 // use the payload to compute the hash
                 else -> HashSpecification.CalculateFromPayload

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -18,8 +18,6 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
-import aws.smithy.kotlin.runtime.text.encoding.decodeBase64Bytes
-import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.time.Duration
 

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -166,7 +166,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
                     }
                 }
                 request.headers["x-amz-checksum-sha256"] != null -> {
-                    // If it's set, reuse flexible checksums SHA256
+                    // Re-use flexible checksums SHA256 if it's set
                     HashSpecification.Precalculated(
                         request.headers["x-amz-checksum-sha256"]!!.decodeBase64Bytes().encodeToHex()
                     )

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -168,7 +168,7 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
                 request.headers["x-amz-checksum-sha256"] != null -> {
                     // Re-use flexible checksums SHA256 if it's set
                     HashSpecification.Precalculated(
-                        request.headers["x-amz-checksum-sha256"]!!.decodeBase64Bytes().encodeToHex()
+                        request.headers["x-amz-checksum-sha256"]!!.decodeBase64Bytes().encodeToHex(),
                     )
                 }
                 config.isUnsignedPayload -> HashSpecification.UnsignedPayload

--- a/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
+++ b/runtime/auth/http-auth-aws/common/src/aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner.kt
@@ -18,6 +18,8 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.text.encoding.decodeBase64Bytes
+import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlin.time.Duration
 
@@ -162,6 +164,12 @@ public class AwsHttpSigner(private val config: Config) : HttpSigner {
                     } else {
                         HashSpecification.StreamingAws4HmacSha256Payload
                     }
+                }
+                request.headers["x-amz-checksum-sha256"] != null -> {
+                    // If it's set, reuse flexible checksums SHA256
+                    HashSpecification.Precalculated(
+                        request.headers["x-amz-checksum-sha256"]!!.decodeBase64Bytes().encodeToHex()
+                    )
                 }
                 config.isUnsignedPayload -> HashSpecification.UnsignedPayload
                 // use the payload to compute the hash

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor.kt
@@ -114,8 +114,8 @@ public class FlexibleChecksumsRequestInterceptor<I>(
 
     // FIXME this duplicates the logic from aws-signing-common, but can't import from there due to circular import.
     private val HttpBody.isEligibleForAwsChunkedStreaming: Boolean
-        get() = (this is HttpBody.SourceContent || this is HttpBody.ChannelContent) && contentLength != null &&
-            (isOneShot || contentLength!! > 65536 * 16)
+        get() = (this is HttpBody.SourceContent || this is HttpBody.ChannelContent) &&
+            (isOneShot || (contentLength?.compareTo(65_536 * 16) ?: 0) > 0)
 
     /**
      * @return if the [HashFunction] is supported by flexible checksums


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
If a streaming body with an undefined content length is provided, upload it with `chunked` to ensure the hash can be properly calculated. This reduces occurrences of exceptions claiming `Stream must be replayable to calculate a body hash` 
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
Addresses an issue in https://github.com/awslabs/aws-sdk-kotlin/issues/1157

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
