### PR TITLE
chore: refactor build to use custom smithy build plugin

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -53,7 +53,7 @@ fun createBomConstraintsAndVersionCatalog() {
 fun Project.artifactId(target: KotlinTarget): String = when (target) {
     is KotlinMetadataTarget -> name
     is KotlinJsTarget -> "$name-js"
-    else -> "$name-${target.targetName.toLowerCase(Locale.ROOT)}"
+    else -> "$name-${target.targetName.lowercase()}"
 }
 
 /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,9 +13,15 @@ buildscript {
         classpath(libs.kotlinx.atomicfu.plugin)
 
         // Add our custom gradle plugin(s) to buildscript classpath (comes from github source)
+        // NOTE: Anything included in our build plugin is added to the classpath for all projects,
+        // this includes bundled plugins and their versions. As an example the smithy gradle base
+        // plugin is used by the smithybuild plugin which means you can't apply it with a different
+        // version directly because it's already on the classpath.
+        // FIXME - if we publish this plugin it would fix a lot of things
         classpath("aws.sdk.kotlin:build-plugins") {
             version {
-                require("0.3.1")
+                // require("0.3.1")
+                branch = "smithy-build-plugin"
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,7 @@ buildscript {
         // FIXME - if we publish this plugin it would fix a lot of things
         classpath("aws.sdk.kotlin:build-plugins") {
             version {
-                // require("0.3.1")
-                branch = "smithy-build-plugin"
+                require("0.3.2")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ crt-kotlin-version = "0.8.2"
 
 # codegen
 smithy-version = "1.42.0"
-smithy-gradle-version = "0.7.0"
+smithy-gradle-version = "0.9.0"
 
 # testing
 junit-version = "5.10.1"
@@ -58,6 +58,7 @@ crt-kotlin = { module = "aws.sdk.kotlin.crt:aws-crt-kotlin", version.ref = "crt-
 
 smithy-codegen-core = { module = "software.amazon.smithy:smithy-codegen-core", version.ref = "smithy-version" }
 smithy-cli = { module = "software.amazon.smithy:smithy-cli", version.ref = "smithy-version" }
+smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy-version" }
 smithy-waiters = { module = "software.amazon.smithy:smithy-waiters", version.ref = "smithy-version" }
 smithy-rules-engine = { module = "software.amazon.smithy:smithy-rules-engine", version.ref = "smithy-version" }
 smithy-aws-traits = { module = "software.amazon.smithy:smithy-aws-traits", version.ref = "smithy-version" }
@@ -92,4 +93,4 @@ kotlin-multiplatform = {id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark-version" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin-version"}
-smithy-gradle = { id = "software.amazon.smithy", version.ref = "smithy-gradle-version" }
+smithy-gradle-base = { id = "software.amazon.smithy.gradle.smithy-base", version.ref = "smithy-gradle-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,4 +93,3 @@ kotlin-multiplatform = {id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinx-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinx-benchmark-version" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin-version"}
-smithy-gradle-base = { id = "software.amazon.smithy.gradle.smithy-base", version.ref = "smithy-gradle-version" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,6 @@ pluginManagement {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven("https://plugins.gradle.org/m2/")
-        google()
         gradlePluginPortal()
     }
 }

--- a/tests/benchmarks/serde-benchmarks/smithy-build.json
+++ b/tests/benchmarks/serde-benchmarks/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["model"],
   "projections": {
     "twitter": {
       "transforms": [

--- a/tests/codegen/nullability-tests/build.gradle.kts
+++ b/tests/codegen/nullability-tests/build.gradle.kts
@@ -3,58 +3,53 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import software.amazon.smithy.gradle.tasks.SmithyBuild
-import software.amazon.smithy.gradle.tasks.Validate as SmithyValidate
+import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 
 plugins {
-    kotlin("jvm")
-    alias(libs.plugins.smithy.gradle)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.smithy.gradle.base)
 }
 
 skipPublishing()
+
+smithy {
+    format.set(false)
+}
+
+val codegen by configurations.creating
+dependencies {
+    codegen(project(":codegen:smithy-kotlin-codegen"))
+    codegen(libs.smithy.cli)
+    codegen(libs.smithy.model)
+}
+
+val generateSdk = tasks.named<SmithyBuildTask>("smithyBuild")
+generateSdk.configure {
+    resolvedCliClasspath.set(codegen)
+    runtimeClasspath.set(codegen)
+    buildClasspath.set(codegen)
+}
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")
 kotlin.sourceSets.all {
     optinAnnotations.forEach { languageSettings.optIn(it) }
 }
 
-val projectionDirs = listOf(
-    "smithyprojections/nullability-tests/client-mode/kotlin-codegen",
-    "smithyprojections/nullability-tests/client-careful-mode/kotlin-codegen",
+val projections = listOf(
+    "client-mode",
+    "client-careful-mode",
 )
 
 kotlin.sourceSets.getByName("main") {
-    projectionDirs.forEach {
-        kotlin.srcDir(layout.buildDirectory.dir(it))
+    projections.forEach { projectionName ->
+        kotlin.srcDir(smithy.getPluginProjectionPath(projectionName, "kotlin-codegen").map { it.resolve("src/main/kotlin") })
     }
-}
-tasks.withType<KotlinCompile> {
-    // generated code has warnings unfortunately
-    kotlinOptions.allWarningsAsErrors = false
-}
-
-tasks["smithyBuildJar"].enabled = false
-
-val codegen by configurations.creating
-dependencies {
-    codegen(project(":codegen:smithy-kotlin-codegen"))
-    codegen(libs.smithy.cli)
-}
-
-val generateSdk = tasks.register<SmithyBuild>("generateSdk") {
-    group = "codegen"
-    classpath = codegen
-    inputs.file(projectDir.resolve("smithy-build.json"))
-    inputs.files(codegen)
-}
-
-tasks.named<SmithyValidate>("smithyValidate") {
-    classpath = codegen
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     dependsOn(generateSdk)
+    // generated code has warnings unfortunately
+    kotlinOptions.allWarningsAsErrors = false
 }
 
 tasks.test {
@@ -66,12 +61,14 @@ tasks.test {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.core)
     compileOnly(project(":codegen:smithy-kotlin-codegen"))
+
+    implementation(libs.kotlinx.coroutines.core)
     implementation(project(":runtime:runtime-core"))
     implementation(project(":runtime:smithy-client"))
     implementation(project(":runtime:protocol:http-client"))
     implementation(project(":runtime:observability:telemetry-api"))
     implementation(project(":runtime:observability:telemetry-defaults"))
+
     testImplementation(libs.kotlin.test.junit5)
 }

--- a/tests/codegen/nullability-tests/build.gradle.kts
+++ b/tests/codegen/nullability-tests/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin.sourceSets.getByName("main") {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     dependsOn(tasks.generateSmithyProjections)
-    // generated code has warnings unfortunately
+    // FIXME - generated code has warnings unfortunately, see https://github.com/awslabs/aws-sdk-kotlin/issues/1169
     kotlinOptions.allWarningsAsErrors = false
 }
 

--- a/tests/codegen/nullability-tests/smithy-build.json
+++ b/tests/codegen/nullability-tests/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["model/nullability.smithy"],
   "projections": {
     "client-mode": {
       "transforms": [

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -2,32 +2,25 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
-import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.smithy.gradle.base)
+    id("aws.sdk.kotlin.gradle.smithybuild")
 }
 
 skipPublishing()
 
-smithy {
-    format.set(false)
-}
-
-val codegen by configurations.creating
+val codegen by configurations.getting
 dependencies {
     codegen(project(":codegen:smithy-kotlin-codegen"))
     codegen(libs.smithy.cli)
     codegen(libs.smithy.model)
 }
 
-val generateSdk = tasks.named<SmithyBuildTask>("smithyBuild")
-generateSdk.configure {
-    resolvedCliClasspath.set(codegen)
-    runtimeClasspath.set(codegen)
-    buildClasspath.set(codegen)
+tasks.generateSmithyProjections {
+    smithyBuildConfigs.set(files("smithy-build.json"))
 }
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")
@@ -36,11 +29,11 @@ kotlin.sourceSets.all {
 }
 
 kotlin.sourceSets.getByName("main") {
-    kotlin.srcDir(smithy.getPluginProjectionPath("paginator-tests", "kotlin-codegen").map { it.resolve("src/main/kotlin") })
+    kotlin.srcDir(smithyBuild.smithyKotlinProjectionSrcDir("paginator-tests"))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    dependsOn(generateSdk)
+    dependsOn(tasks.generateSmithyProjections)
 }
 
 tasks.test {

--- a/tests/codegen/paginator-tests/smithy-build.json
+++ b/tests/codegen/paginator-tests/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["model/paginated-operations.smithy"],
   "projections": {
     "paginator-tests": {
       "transforms": [

--- a/tests/codegen/waiter-tests/build.gradle.kts
+++ b/tests/codegen/waiter-tests/build.gradle.kts
@@ -3,15 +3,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
-import software.amazon.smithy.gradle.tasks.SmithyBuild
-import software.amazon.smithy.gradle.tasks.Validate as SmithyValidate
+import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 
 plugins {
-    kotlin("jvm")
-    alias(libs.plugins.smithy.gradle)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.smithy.gradle.base)
 }
 
 skipPublishing()
+
+smithy {
+    format.set(false)
+}
+
+val codegen by configurations.creating
+dependencies {
+    codegen(project(":codegen:smithy-kotlin-codegen"))
+    codegen(libs.smithy.cli)
+    codegen(libs.smithy.model)
+}
+
+val generateSdk = tasks.named<SmithyBuildTask>("smithyBuild")
+generateSdk.configure {
+    resolvedCliClasspath.set(codegen)
+    runtimeClasspath.set(codegen)
+    buildClasspath.set(codegen)
+}
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")
 kotlin.sourceSets.all {
@@ -19,32 +36,14 @@ kotlin.sourceSets.all {
 }
 
 kotlin.sourceSets.getByName("main") {
-    kotlin.srcDir(layout.buildDirectory.dir("smithyprojections/waiter-tests/waiter-tests/kotlin-codegen/src/main/kotlin"))
-}
-
-tasks["smithyBuildJar"].enabled = false
-
-val codegen by configurations.creating
-dependencies {
-    codegen(project(":codegen:smithy-kotlin-codegen"))
-    codegen(libs.smithy.cli)
-}
-
-val generateSdk = tasks.register<SmithyBuild>("generateSdk") {
-    group = "codegen"
-    classpath = codegen
-    inputs.file(projectDir.resolve("smithy-build.json"))
-    inputs.files(codegen)
-}
-
-tasks.named<SmithyValidate>("smithyValidate") {
-    classpath = codegen
+    kotlin.srcDir(smithy.getPluginProjectionPath("waiter-tests", "kotlin-codegen").map { it.resolve("src/main/kotlin") })
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     dependsOn(generateSdk)
     kotlinOptions {
-        allWarningsAsErrors = false // FIXME Generated waiters code contains lots of warnings
+        // generated code has warnings unfortunately
+        allWarningsAsErrors = false
     }
 }
 
@@ -57,10 +56,9 @@ tasks.test {
 }
 
 dependencies {
+    compileOnly(project(":codegen:smithy-kotlin-codegen"))
 
     implementation(libs.kotlinx.coroutines.core)
-
-    compileOnly(project(":codegen:smithy-kotlin-codegen"))
     implementation(project(":runtime:runtime-core"))
     implementation(project(":runtime:smithy-client"))
     implementation(project(":runtime:protocol:http-client"))

--- a/tests/codegen/waiter-tests/build.gradle.kts
+++ b/tests/codegen/waiter-tests/build.gradle.kts
@@ -2,32 +2,25 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
-import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.smithy.gradle.base)
+    id("aws.sdk.kotlin.gradle.smithybuild")
 }
 
 skipPublishing()
 
-smithy {
-    format.set(false)
-}
-
-val codegen by configurations.creating
+val codegen by configurations.getting
 dependencies {
     codegen(project(":codegen:smithy-kotlin-codegen"))
     codegen(libs.smithy.cli)
     codegen(libs.smithy.model)
 }
 
-val generateSdk = tasks.named<SmithyBuildTask>("smithyBuild")
-generateSdk.configure {
-    resolvedCliClasspath.set(codegen)
-    runtimeClasspath.set(codegen)
-    buildClasspath.set(codegen)
+tasks.generateSmithyProjections {
+    smithyBuildConfigs.set(files("smithy-build.json"))
 }
 
 val optinAnnotations = listOf("kotlin.RequiresOptIn", "aws.smithy.kotlin.runtime.InternalApi")
@@ -36,11 +29,11 @@ kotlin.sourceSets.all {
 }
 
 kotlin.sourceSets.getByName("main") {
-    kotlin.srcDir(smithy.getPluginProjectionPath("waiter-tests", "kotlin-codegen").map { it.resolve("src/main/kotlin") })
+    kotlin.srcDir(smithyBuild.smithyKotlinProjectionSrcDir("waiter-tests"))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    dependsOn(generateSdk)
+    dependsOn(tasks.generateSmithyProjections)
     kotlinOptions {
         // generated code has warnings unfortunately
         allWarningsAsErrors = false

--- a/tests/codegen/waiter-tests/smithy-build.json
+++ b/tests/codegen/waiter-tests/smithy-build.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
+  "sources": ["model"],
   "projections": {
     "waiter-tests": {
       "transforms": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Refactors the build to use our [new codegen plugin](https://github.com/awslabs/aws-kotlin-repo-tools/pull/29) based on the newer smithy gradle base plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
