### PR TITLE
chore: relocate brazil transform

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -1,0 +1,64 @@
+{
+  "dependencies": {
+    "com.squareup.okhttp3:okhttp-coroutines-jvm:5.*": "OkHttp3CoroutinesJvm-5.x",
+    "com.squareup.okhttp3:okhttp-coroutines:5.*": "OkHttp3Coroutines-5.x",
+    "com.squareup.okhttp3:okhttp-jvm:5.*": "OkHttp3Jvm-5.x",
+    "com.squareup.okhttp3:okhttp:5.*": "OkHttp3-5.x",
+    "com.squareup.okio:okio-jvm:3.*": "OkioJvm-3.x",
+    "com.squareup.okio:okio:3.*": "Okio-3.x",
+    "io.opentelemetry:opentelemetry-api:1.*": "Maven-io-opentelemetry_opentelemetry-api-1.x",
+    "org.jetbrains.kotlin:kotlin-stdlib-common:1.9.*": "KotlinStdlibCommon-1.9.x",
+    "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.*": "KotlinStdlibJdk8-1.9.x",
+    "org.jetbrains.kotlin:kotlin-stdlib:1.9.*": "KotlinStdlib-1.9.x",
+    "org.jetbrains.kotlinx:atomicfu-jvm:0.23.1": "AtomicfuJvm-0.23.1",
+    "org.jetbrains.kotlinx:atomicfu:0.23.1": "Atomicfu-0.23.1",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.*": "KotlinxCoroutinesCoreJvm-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.*": "KotlinxCoroutinesCore-1.7.x",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.*": "KotlinxCoroutinesJdk8-1.7.x",
+    "org.slf4j:slf4j-api:2.*": "Maven-org-slf4j_slf4j-api-2.x",
+    "software.amazon.awssdk.crt:aws-crt:0.*": "Aws-crt-java-1.0.x",
+    "aws.sdk.kotlin.crt:aws-crt-kotlin:0.8.*": "AwsCrtKotlin-0.8.x"
+  },
+  "packageHandlingRules": {
+    "versioning": {
+      "defaultVersionLayout": "{MAJOR}.0.x",
+      "overrides": {
+        "software.amazon.smithy.kotlin:smithy-kotlin-codegen": "{MAJOR}.{MINOR}.x",
+        "software.amazon.smithy.kotlin:smithy-kotlin-codegen-testutils": "{MAJOR}.{MINOR}.x"
+      }
+    },
+    "rename": {
+        "software.amazon.smithy.kotlin:smithy-kotlin-codegen": "SmithyKotlinCodegen",
+        "software.amazon.smithy.kotlin:smithy-kotlin-codegen-testutils": "SmithyKotlinCodegenTestUtils"
+    },
+    "ignore": [
+      "aws.smithy.kotlin:http-test",
+      "aws.smithy.kotlin:smithy-test",
+      "aws.smithy.kotlin:testing",
+      "aws.smithy.kotlin:bom",
+      "aws.smithy.kotlin:version-catalog"
+    ],
+    "resolvesConflictDependencies": {
+      "com.squareup.okhttp3:okhttp-coroutines-jvm:5.*": [
+        "KotlinStdlibCommon-1.9.x",
+        "KotlinStdlib-1.9.x",
+        "KotlinxCoroutinesCoreJvm-1.7.x"
+      ],
+      "com.squareup.okhttp3:okhttp-jvm:5.*": [
+        "KotlinStdlibCommon-1.9.x",
+        "KotlinStdlib-1.9.x"
+      ],
+      "com.squareup.okio:okio-jvm:3.*": [
+        "KotlinStdlibCommon-1.9.x",
+        "KotlinStdlibJdk8-1.9.x"
+      ],
+      "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.*": [
+        "KotlinStdlibCommon-1.9.x",
+        "KotlinStdlibJdk8-1.9.x"
+      ],
+      "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.*": [
+        "KotlinStdlibJdk8-1.9.x"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

**refactor**: Add a new `.brazil.json` file with the transform logic for just `aws-sdk-kotlin`. **NOTE**: This will not take effect until we release a new version of `kat` and update the release pipeline to use it. Until then the "global" transform config from repo tools is still the one being used. I tested this locally already the runtime and diffed the transform output using the one from repo tools and this new localized copy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
