### PR TITLE
fix: correctly apply resolved endpoint to presigned requests

### DIFF
--- a/.changes/80e3c346-9a4a-4d47-84f1-1655742f9711.json
+++ b/.changes/80e3c346-9a4a-4d47-84f1-1655742f9711.json
@@ -1,0 +1,8 @@
+{
+    "id": "80e3c346-9a4a-4d47-84f1-1655742f9711",
+    "type": "bugfix",
+    "description": "Correctly apply resolved endpoint to presigned requests",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1173"
+    ]
+}

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.kotlinx.coroutines.test)
+
+                // Needed for an actual signer implementation in tests
+                implementation(project(":runtime:auth:aws-signing-default"))
             }
         }
 

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Presigner.kt
@@ -15,7 +15,6 @@ import aws.smithy.kotlin.runtime.http.operation.ResolveEndpointRequest
 import aws.smithy.kotlin.runtime.http.operation.setResolvedEndpoint
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
-import aws.smithy.kotlin.runtime.http.request.header
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 
@@ -36,8 +35,6 @@ public suspend fun presignRequest(
     setResolvedEndpoint(unsignedRequestBuilder, ctx, endpoint)
 
     val signingContext = endpoint.authOptions.firstOrNull { it.schemeId == AuthSchemeId.AwsSigV4 }?.attributes ?: emptyAttributes()
-
-    // val unsignedRequest = unsignedRequestBuilder.apply { header("host", endpoint.uri.host.toString()) }.build()
 
     val config = AwsSigningConfig {
         region = signingContext.getOrNull(AwsSigningAttributes.SigningRegion)

--- a/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
+++ b/runtime/auth/aws-signing-common/common/test/aws/smithy/kotlin/runtime/auth/awssigning/PresignerTest.kt
@@ -19,8 +19,7 @@ import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
-private const val NON_HTTPS_URL = "http://localhost:8080/path/to/resource?foo=bar"
+import kotlin.test.assertTrue
 
 class PresignerTest {
     // Verify that custom endpoint URL schemes aren't changed.
@@ -40,7 +39,7 @@ class PresignerTest {
         val ctx = ExecutionContext()
         val credentialsProvider = TestCredentialsProvider(Credentials("foo", "bar"))
         val endpointResolver = TestEndpointResolver(Endpoint(expectedUrl))
-        val signer = TestSigner(HttpRequest { url(expectedUrl) })
+        val signer = DefaultAwsSigner
         val signingConfig: AwsSigningConfig.Builder.() -> Unit = {
             service = "launch-service"
             region = "the-moon"
@@ -61,7 +60,10 @@ class PresignerTest {
         assertEquals(expectedUrl.host, actualUrl.host)
         assertEquals(expectedUrl.port, actualUrl.port)
         assertEquals(expectedUrl.path, actualUrl.path)
-        assertEquals(expectedUrl.parameters, actualUrl.parameters)
+
+        expectedUrl.parameters.encodedParameters.entryValues.forEach { (key, value) ->
+            assertTrue(actualUrl.parameters.encodedParameters.contains(key, value))
+        }
     }
 }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationEndpoint.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationEndpoint.kt
@@ -8,6 +8,7 @@ package aws.smithy.kotlin.runtime.http.operation
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.client.endpoints.Endpoint
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
 import aws.smithy.kotlin.runtime.http.request.url
 import aws.smithy.kotlin.runtime.identity.Identity
 import aws.smithy.kotlin.runtime.net.Host
@@ -48,10 +49,21 @@ public data class ResolveEndpointRequest(
  */
 @InternalApi
 public fun setResolvedEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
-    val hostPrefix = req.context.getOrNull(HttpOperationContext.HostPrefix) ?: ""
+    setResolvedEndpoint(req.subject, req.context, endpoint)
+}
+
+/**
+ * Update an existing request with a resolved endpoint.
+ *
+ * Any values serialized to the HTTP path or query string are preserved (in the case of path, the existing serialized one
+ * is appended to what was resolved).
+ */
+@InternalApi
+public fun setResolvedEndpoint(req: HttpRequestBuilder, ctx: ExecutionContext, endpoint: Endpoint) {
+    val hostPrefix = ctx.getOrNull(HttpOperationContext.HostPrefix) ?: ""
     val hostname = "$hostPrefix${endpoint.uri.host}"
 
-    req.subject.url {
+    req.url {
         // Can't use Url.Builder.copyFrom because we need to keep existing path/parameters and merge in new ones
         scheme = endpoint.uri.scheme
         userInfo.copyFrom(endpoint.uri.userInfo)
@@ -65,6 +77,6 @@ public fun setResolvedEndpoint(req: SdkHttpRequest, endpoint: Endpoint) {
         encodedFragment = endpoint.uri.fragment?.encoded
     }
 
-    req.subject.headers["Host"] = hostname
-    endpoint.headers?.let { req.subject.headers.appendAll(it) }
+    req.headers["Host"] = hostname
+    endpoint.headers?.let { req.headers.appendAll(it) }
 }


### PR DESCRIPTION
## Issue \#

https://github.com/awslabs/aws-sdk-kotlin/issues/1173

## Description of changes

This change ensures that the resolved endpoint is fully applied to an unsigned request before presigning, ensuring that any non-standard rules are applied (e.g., S3's `forcePathStyle`).

**Companion PR**: https://github.com/awslabs/aws-sdk-kotlin/pull/1174

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
