### PR TITLE
fix: correctly include custom ports in signing/presigning

### DIFF
--- a/.changes/8127023a-192a-4cf7-a979-62987a2f40dd.json
+++ b/.changes/8127023a-192a-4cf7-a979-62987a2f40dd.json
@@ -1,0 +1,8 @@
+{
+    "id": "8127023a-192a-4cf7-a979-62987a2f40dd",
+    "type": "bugfix",
+    "description": "Correctly include custom ports in signing/presigning",
+    "issues": [
+        "awslabs/aws-sdk-kotlin#1177"
+    ]
+}

--- a/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
+++ b/runtime/auth/aws-signing-default/common/src/aws/smithy/kotlin/runtime/auth/awssigning/Canonicalizer.kt
@@ -112,7 +112,7 @@ internal class DefaultCanonicalizer(private val sha256Supplier: HashSupplier = :
             }
         }
 
-        param("Host", builder.url.host.toString(), !signViaQueryParams, overwrite = false)
+        param("Host", builder.url.hostAndPort, !signViaQueryParams, overwrite = false)
         param("X-Amz-Algorithm", ALGORITHM_NAME, signViaQueryParams)
         param("X-Amz-Credential", credentialValue(config), signViaQueryParams)
         param("X-Amz-Content-Sha256", hash, addHashHeader)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationEndpoint.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/OperationEndpoint.kt
@@ -77,6 +77,6 @@ public fun setResolvedEndpoint(req: HttpRequestBuilder, ctx: ExecutionContext, e
         encodedFragment = endpoint.uri.fragment?.encoded
     }
 
-    req.headers["Host"] = hostname
+    req.headers["Host"] = req.url.hostAndPort
     endpoint.headers?.let { req.headers.appendAll(it) }
 }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/OperationEndpointTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/operation/OperationEndpointTest.kt
@@ -25,6 +25,7 @@ class OperationEndpointTest {
 
         assertEquals(Host.Domain("api.test.com"), actual.url.host)
         assertEquals(Scheme.HTTPS, actual.url.scheme)
+        assertEquals(443, actual.url.port)
         assertEquals("api.test.com", actual.headers["Host"])
     }
 
@@ -38,6 +39,7 @@ class OperationEndpointTest {
         assertEquals(Host.Domain("api.test.com"), actual.url.host)
         assertEquals(Scheme.HTTPS, actual.url.scheme)
         assertEquals(8080, actual.url.port)
+        assertEquals("api.test.com:8080", actual.headers["Host"])
     }
 
     @Test

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -906,6 +906,7 @@ public final class aws/smithy/kotlin/runtime/net/url/Url {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFragment ()Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 	public final fun getHost ()Laws/smithy/kotlin/runtime/net/Host;
+	public final fun getHostAndPort ()Ljava/lang/String;
 	public final fun getParameters ()Laws/smithy/kotlin/runtime/net/url/QueryParameters;
 	public final fun getPath ()Laws/smithy/kotlin/runtime/net/url/UrlPath;
 	public final fun getPort ()I
@@ -926,6 +927,7 @@ public final class aws/smithy/kotlin/runtime/net/url/Url$Builder : aws/smithy/ko
 	public final fun getDecodedFragment ()Ljava/lang/String;
 	public final fun getEncodedFragment ()Ljava/lang/String;
 	public final fun getHost ()Laws/smithy/kotlin/runtime/net/Host;
+	public final fun getHostAndPort ()Ljava/lang/String;
 	public final fun getParameters ()Laws/smithy/kotlin/runtime/net/url/QueryParameters$Builder;
 	public final fun getPath ()Laws/smithy/kotlin/runtime/net/url/UrlPath$Builder;
 	public final fun getPort ()Ljava/lang/Integer;

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/url/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/url/Url.kt
@@ -122,6 +122,17 @@ public class Url private constructor(
     private val encoded: String
 
     /**
+     * Gets the host and port for the URL. The port is omitted if it's the default for the scheme.
+     */
+    public val hostAndPort: String = buildString {
+        append(host)
+        if (port != scheme.defaultPort) {
+            append(':')
+            append(port)
+        }
+    }
+
+    /**
      * Gets a request-relative path string for this URL which is suitable for use in an HTTP request line. The given
      * path will include query parameters and the fragment and will be prepended with a `/` (even for empty paths
      * without a trailing slash configured). It will not include the protocol, host, port, or user info.
@@ -212,6 +223,18 @@ public class Url private constructor(
          * The remote port number for the URL (e.g., TCP port)
          */
         public var port: Int? = url?.port
+
+        /**
+         * Gets the host and port for the URL. The port is omitted if it's the default for the scheme.
+         */
+        public val hostAndPort: String
+            get() = buildString {
+                append(host)
+                if (port != null && port != scheme.defaultPort) {
+                    append(':')
+                    append(port)
+                }
+            }
 
         // Path
 


### PR DESCRIPTION
## Issue \#

https://github.com/awslabs/aws-sdk-kotlin/issues/1177

## Description of changes

This change adds handling of non-standard ports during signing and presigning by including them in the `Host` header and also the canonical string used in signature calculation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
