### PR TITLE
fix: correctly serialize maps which use the Document type as a value

### DIFF
--- a/.changes/581b0e21-e59b-427c-a959-276f09276b88.json
+++ b/.changes/581b0e21-e59b-427c-a959-276f09276b88.json
@@ -1,0 +1,5 @@
+{
+    "id": "581b0e21-e59b-427c-a959-276f09276b88",
+    "type": "bugfix",
+    "description": "Correctly serialize maps which use the `Document` type as a value"
+}

--- a/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
+++ b/runtime/serde/common/src/aws/smithy/kotlin/runtime/serde/Serializer.kt
@@ -329,6 +329,15 @@ public interface MapSerializer : PrimitiveSerializer {
     public fun entry(key: String, value: SdkSerializable?)
 
     /**
+     * Writes the key given in the descriptor, and then
+     * serializes value.
+     *
+     * @param key
+     * @param value
+     */
+    public fun entry(key: String, value: Document?)
+
+    /**
      * Writes the field name given in the descriptor, and then
      * serializes the list field using the given block.
      *

--- a/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
+++ b/runtime/serde/serde-form-url/common/src/aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializer.kt
@@ -333,6 +333,9 @@ private class FormUrlMapSerializer(
         value.serialize(FormUrlSerializer(buffer, nestedPrefix))
     }
 
+    override fun entry(key: String, value: Document?) =
+        throw SerializationException("document values not supported by form-url serializer")
+
     override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
         writeKey(key)
 

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
@@ -199,7 +199,7 @@ public class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructS
 
     override fun entry(key: String, value: Document?) {
         jsonWriter.writeName(key)
-        if (value != null) serializeDocument(value) else jsonWriter.writeNull()
+        serializeDocument(value)
     }
 
     override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {

--- a/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
+++ b/runtime/serde/serde-json/common/src/aws/smithy/kotlin/runtime/serde/json/JsonSerializer.kt
@@ -197,6 +197,11 @@ public class JsonSerializer : Serializer, ListSerializer, MapSerializer, StructS
         if (value != null) serializeInstant(value, format) else jsonWriter.writeNull()
     }
 
+    override fun entry(key: String, value: Document?) {
+        jsonWriter.writeName(key)
+        if (value != null) serializeDocument(value) else jsonWriter.writeNull()
+    }
+
     override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
         jsonWriter.writeName(key)
         beginList(listDescriptor)

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonDeserializerTest.kt
@@ -227,6 +227,49 @@ class JsonDeserializerTest {
     }
 
     @Test
+    fun itHandlesMapsOfDocuments() {
+        val payload = """
+            {
+                "key1": {
+                    "number": 12,
+                    "string": "foo",
+                    "bool": true,
+                    "null": null
+                },
+                "key2": {
+                    "number": 4.5,
+                    "string": "bar",
+                    "bool": false,
+                    "null": null
+                }
+            }
+        """.trimIndent().encodeToByteArray()
+        val deserializer: Deserializer = JsonDeserializer(payload)
+        val actual = deserializer.deserializeMap(SdkFieldDescriptor(SerialKind.Map)) {
+            val map = mutableMapOf<String, Document>()
+            while (hasNextEntry()) {
+                map[key()] = deserializeDocument()
+            }
+            return@deserializeMap map
+        }
+        val expected = mapOf(
+            "key1" to buildDocument {
+                "number" to 12L
+                "string" to "foo"
+                "bool" to true
+                "null" to null
+            },
+            "key2" to buildDocument {
+                "number" to 4.5
+                "string" to "bar"
+                "bool" to false
+                "null" to null
+            },
+        )
+        actual.shouldContainExactly(expected)
+    }
+
+    @Test
     fun itChecksNullValuesOfNonSparseMaps() {
         val payload = """
             {

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
@@ -110,7 +110,7 @@ class JsonSerializerTest {
                 "string" to "bar"
                 "bool" to false
                 "null" to null
-            }
+            },
         )
         val json = JsonSerializer()
         json.serializeMap(testAnonObjDescriptor) {

--- a/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
+++ b/runtime/serde/serde-json/common/test/aws/smithy/kotlin/runtime/serde/json/JsonSerializerTest.kt
@@ -97,6 +97,31 @@ class JsonSerializerTest {
     }
 
     @Test
+    fun canSerializeMapOfDocuments() {
+        val objs = mapOf(
+            "A1" to buildDocument {
+                "number" to 12L
+                "string" to "foo"
+                "bool" to true
+                "null" to null
+            },
+            "B2" to buildDocument {
+                "number" to 4.5
+                "string" to "bar"
+                "bool" to false
+                "null" to null
+            }
+        )
+        val json = JsonSerializer()
+        json.serializeMap(testAnonObjDescriptor) {
+            for (obj in objs) {
+                entry(obj.key, obj.value)
+            }
+        }
+        assertEquals("""{"A1":{"number":12,"string":"foo","bool":true,"null":null},"B2":{"number":4.5,"string":"bar","bool":false,"null":null}}""", json.toByteArray().decodeToString())
+    }
+
+    @Test
     fun canSerializeMapOfLists() {
         val objs = mapOf(
             "A1" to listOf("a", "b", "c"),

--- a/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
+++ b/runtime/serde/serde-xml/common/src/aws/smithy/kotlin/runtime/serde/xml/XmlSerializer.kt
@@ -259,6 +259,9 @@ private class XmlMapSerializer(
 
     override fun entry(key: String, value: Instant?, format: TimestampFormat): Unit = entry(key, value?.format(format))
 
+    override fun entry(key: String, value: Document?) =
+        throw SerializationException("document values not supported by xml serializer")
+
     override fun listEntry(key: String, listDescriptor: SdkFieldDescriptor, block: ListSerializer.() -> Unit) {
         writeEntry(key) {
             val ls = xmlSerializer.beginList(listDescriptor)


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This adds a missed overload in the JSON serializer which handles serializing map values which are `Document` instances.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
