### PR TITLE
chore: add @InternalApi to binary compatibility checks; introduce new PR check to verify no API-breaking changes

### DIFF
--- a/.github/workflows/api-compat-verification.yml
+++ b/.github/workflows/api-compat-verification.yml
@@ -1,0 +1,33 @@
+name: API compatibility verification
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    branches: [ main ]
+
+jobs:
+  api-compat-verification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for API compatibility
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'acknowledge-api-break') }}
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --numstat "*.api" | awk '
+            BEGIN { s = 0 }
+            
+            # git diff numstat shows lines deleted in field 2, hence sum up field 2 across all items 
+            { s += $2 }
+            
+            # exit with the number of lines deleted as the result code so that `if ${{ failure() }}` works below
+            END { exit s }
+          '
+      - name: Error message
+        if: ${{ failure() }}
+        run: |
+          echo "::error ::This change modifies the public API in a way that may be backwards-incompatible. Carefully"
+          echo "::error ::review this pull request and either:
+          echo "::error ::* Revert the changes which caused the API incompatibility –or–"
+          echo "::error ::* Add the 'acknowledge-api-break' label to this PR (in rare cases warranting an API breakage)"
+          exit 1

--- a/.github/workflows/api-compat-verification.yml
+++ b/.github/workflows/api-compat-verification.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           echo "::error ::This change modifies the public API in a way that may be backwards-incompatible. Carefully"
-          echo "::error ::review this pull request and either:
+          echo "::error ::review this pull request and either:"
           echo "::error ::* Revert the changes which caused the API incompatibility –or–"
           echo "::error ::* Add the 'acknowledge-api-break' label to this PR (in rare cases warranting an API breakage)"
           exit 1

--- a/.github/workflows/api-compat-verification.yml
+++ b/.github/workflows/api-compat-verification.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Error message
         if: ${{ failure() }}
         run: |
-          echo "::error ::This change modifies the public API in a way that may be backwards-incompatible. Carefully"
-          echo "::error ::review this pull request and either:"
+          echo "::error ::This change modifies the public API in a way that may be backwards-incompatible. Carefully review this pull request and either:"
           echo "::error ::* Revert the changes which caused the API incompatibility –or–"
           echo "::error ::* Add the 'acknowledge-api-break' label to this PR (in rare cases warranting an API breakage)"
           exit 1

--- a/.github/workflows/api-compat-verification.yml
+++ b/.github/workflows/api-compat-verification.yml
@@ -20,7 +20,7 @@ jobs:
             # git diff numstat shows lines deleted in field 2, hence sum up field 2 across all items 
             { s += $2 }
             
-            # exit with the number of lines deleted as the result code so that `if ${{ failure() }}` works below
+            # exit with the number of lines deleted as the result code so that `if failure()` works below
             END { exit s }
           '
       - name: Error message

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,8 +116,6 @@ configureLinting(lintPaths)
 
 // Binary compatibility
 apiValidation {
-    nonPublicMarkers.add("aws.smithy.kotlin.runtime.InternalApi")
-
     ignoredProjects.addAll(
         setOf(
             "dokka-smithy",

--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -1,3 +1,21 @@
+public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedByteReadChannel : aws/smithy/kotlin/runtime/io/SdkByteReadChannel {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;[BLaws/smithy/kotlin/runtime/http/DeferredHeaders;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;[BLaws/smithy/kotlin/runtime/http/DeferredHeaders;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun cancel (Ljava/lang/Throwable;)Z
+	public fun getAvailableForRead ()I
+	public fun getClosedCause ()Ljava/lang/Throwable;
+	public fun isClosedForRead ()Z
+	public fun isClosedForWrite ()Z
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsChunkedSource : aws/smithy/kotlin/runtime/io/SdkSource {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkSource;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;[BLaws/smithy/kotlin/runtime/http/DeferredHeaders;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/io/SdkSource;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;[BLaws/smithy/kotlin/runtime/http/DeferredHeaders;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+}
+
 public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSignatureType : java/lang/Enum {
 	public static final field HTTP_REQUEST_CHUNK Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignatureType;
 	public static final field HTTP_REQUEST_EVENT Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignatureType;
@@ -103,6 +121,19 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig$Co
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;
 }
 
+public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult {
+	public fun <init> (Ljava/lang/Object;[B)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()[B
+	public final fun copy (Ljava/lang/Object;[B)Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult;Ljava/lang/Object;[BILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOutput ()Ljava/lang/Object;
+	public final fun getSignature ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification {
 }
 
@@ -151,10 +182,20 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/HashSpecification$U
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awssigning/PresignerKt {
+	public static final fun presignRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/auth/awscredentials/CredentialsProvider;Laws/smithy/kotlin/runtime/http/operation/EndpointResolver;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/auth/awssigning/UnsupportedSigningAlgorithmException : aws/smithy/kotlin/runtime/ClientException {
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm;)V
+	public final fun getSigningAlgorithm ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm;
 }
 
 public final class aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtilKt {
 	public static final field AWS_CHUNKED_THRESHOLD I
 	public static final field CHUNK_SIZE_BYTES I
+	public static final fun getUseAwsChunkedEncoding (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;)Z
+	public static final fun isEligibleForAwsChunkedStreaming (Laws/smithy/kotlin/runtime/http/HttpBody;)Z
+	public static final fun setAwsChunkedBody (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningConfig;[BLaws/smithy/kotlin/runtime/http/DeferredHeaders;)V
+	public static final fun setAwsChunkedHeaders (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;)V
 }
 

--- a/runtime/auth/http-auth-aws/api/http-auth-aws.api
+++ b/runtime/auth/http-auth-aws/api/http-auth-aws.api
@@ -1,4 +1,41 @@
+public final class aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner : aws/smithy/kotlin/runtime/http/auth/HttpSigner {
+	public static final field Companion Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Config;)V
+	public fun sign (Laws/smithy/kotlin/runtime/http/auth/SignHttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/http/auth/AwsHttpSigner;
+}
+
+public final class aws/smithy/kotlin/runtime/http/auth/AwsHttpSigner$Config {
+	public fun <init> ()V
+	public final fun getAlgorithm ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm;
+	public final fun getExpiresAfter-FghU774 ()Lkotlin/time/Duration;
+	public final fun getNormalizeUriPath ()Z
+	public final fun getOmitSessionToken ()Z
+	public final fun getService ()Ljava/lang/String;
+	public final fun getShouldSignHeader ()Lkotlin/jvm/functions/Function1;
+	public final fun getSignatureType ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignatureType;
+	public final fun getSignedBodyHeader ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignedBodyHeader;
+	public final fun getSigner ()Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;
+	public final fun getUseDoubleUriEncode ()Z
+	public final fun isUnsignedPayload ()Z
+	public final fun setAlgorithm (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm;)V
+	public final fun setExpiresAfter-BwNAW2A (Lkotlin/time/Duration;)V
+	public final fun setNormalizeUriPath (Z)V
+	public final fun setOmitSessionToken (Z)V
+	public final fun setService (Ljava/lang/String;)V
+	public final fun setShouldSignHeader (Lkotlin/jvm/functions/Function1;)V
+	public final fun setSignatureType (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignatureType;)V
+	public final fun setSignedBodyHeader (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSignedBodyHeader;)V
+	public final fun setSigner (Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigner;)V
+	public final fun setUnsignedPayload (Z)V
+	public final fun setUseDoubleUriEncode (Z)V
+}
+
 public final class aws/smithy/kotlin/runtime/http/auth/EndpointAuthKt {
+	public static final fun mergeAuthOptions (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
@@ -12,6 +49,8 @@ public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthScheme
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AsymmetricAuthSchemeKt {
+	public static final fun sigV4A (ZLjava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)Laws/smithy/kotlin/runtime/auth/AuthOption;
+	public static synthetic fun sigV4A$default (ZLjava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/AuthOption;
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme : aws/smithy/kotlin/runtime/http/auth/AuthScheme {
@@ -25,5 +64,7 @@ public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthScheme : aws/smi
 }
 
 public final class aws/smithy/kotlin/runtime/http/auth/SigV4AuthSchemeKt {
+	public static final fun sigV4 (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;)Laws/smithy/kotlin/runtime/auth/AuthOption;
+	public static synthetic fun sigV4$default (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/auth/AuthOption;
 }
 

--- a/runtime/auth/identity-api/api/identity-api.api
+++ b/runtime/auth/identity-api/api/identity-api.api
@@ -62,11 +62,20 @@ public final class aws/smithy/kotlin/runtime/identity/IdentityProvider$DefaultIm
 	public static synthetic fun resolve$default (Laws/smithy/kotlin/runtime/identity/IdentityProvider;Laws/smithy/kotlin/runtime/collections/Attributes;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public abstract class aws/smithy/kotlin/runtime/identity/IdentityProviderChain : aws/smithy/kotlin/runtime/identity/CloseableIdentityProvider {
+	public fun <init> ([Laws/smithy/kotlin/runtime/identity/IdentityProvider;)V
+	public fun close ()V
+	protected final fun getProviders ()[Laws/smithy/kotlin/runtime/identity/IdentityProvider;
+	public fun resolve (Laws/smithy/kotlin/runtime/collections/Attributes;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/identity/IdentityProviderConfig {
 	public abstract fun identityProviderForScheme-kHcdgsI (Ljava/lang/String;)Laws/smithy/kotlin/runtime/identity/IdentityProvider;
 }
 
 public final class aws/smithy/kotlin/runtime/identity/IdentityProviderConfigKt {
+	public static final fun asIdentityProviderConfig (Laws/smithy/kotlin/runtime/identity/IdentityProvider;)Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;
 }
 
 public final class aws/smithy/kotlin/runtime/identity/IdentityProviderException : aws/smithy/kotlin/runtime/ClientException {

--- a/runtime/crt-util/api/crt-util.api
+++ b/runtime/crt-util/api/crt-util.api
@@ -1,3 +1,31 @@
 public final class aws/smithy/kotlin/runtime/crt/HttpKt {
+	public static final fun path (Laws/sdk/kotlin/crt/http/HttpRequest;)Ljava/lang/String;
+	public static final fun queryParameters (Laws/sdk/kotlin/crt/http/HttpRequest;)Laws/smithy/kotlin/runtime/net/url/QueryParameters;
+	public static final fun toCrtHeaders (Laws/smithy/kotlin/runtime/http/Headers;)Laws/sdk/kotlin/crt/http/Headers;
+	public static final fun toSdkHeaders (Laws/sdk/kotlin/crt/http/Headers;)Laws/smithy/kotlin/runtime/http/Headers;
+	public static final fun toSignableCrtRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequest;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun toSignableCrtRequest$default (Laws/smithy/kotlin/runtime/http/request/HttpRequest;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun update (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/sdk/kotlin/crt/http/HttpRequest;)V
+}
+
+public final class aws/smithy/kotlin/runtime/crt/ReadChannelBodyStream : aws/sdk/kotlin/crt/http/HttpRequestBodyStream, kotlinx/coroutines/CoroutineScope {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Lkotlin/coroutines/CoroutineContext;)V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun resetPosition ()Z
+	public fun sendRequestBody (Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
+}
+
+public final class aws/smithy/kotlin/runtime/crt/SdkDefaultIO {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/crt/SdkDefaultIO;
+	public final fun getClientBootstrap ()Laws/sdk/kotlin/crt/io/ClientBootstrap;
+	public final fun getEventLoop ()Laws/sdk/kotlin/crt/io/EventLoopGroup;
+	public final fun getHostResolver ()Laws/sdk/kotlin/crt/io/HostResolver;
+	public final fun getTlsContext ()Laws/sdk/kotlin/crt/io/TlsContext;
+}
+
+public final class aws/smithy/kotlin/runtime/crt/SdkSourceBodyStream : aws/sdk/kotlin/crt/http/HttpRequestBodyStream {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkSource;)V
+	public fun resetPosition ()Z
+	public fun sendRequestBody (Laws/sdk/kotlin/crt/io/MutableBuffer;)Z
 }
 

--- a/runtime/observability/telemetry-api/api/telemetry-api.api
+++ b/runtime/observability/telemetry-api/api/telemetry-api.api
@@ -19,10 +19,23 @@ public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProvider$Compani
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Laws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext$Key;
+	public fun <init> (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public final fun copy (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)Laws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext;Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContext$Key : kotlin/coroutines/CoroutineContext$Key {
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/TelemetryProviderContextKt {
+	public static final fun getTelemetryProvider (Lkotlin/coroutines/CoroutineContext;)Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/context/Context {
@@ -46,13 +59,39 @@ public final class aws/smithy/kotlin/runtime/telemetry/context/ContextManager$Co
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/context/Scope : java/io/Closeable {
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement : kotlin/coroutines/AbstractCoroutineContextElement, kotlin/coroutines/CoroutineContext$Element, kotlinx/coroutines/ThreadContextElement {
+	public static final field Key Laws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement$Key;
+	public fun <init> (Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
+	public final fun getContext ()Laws/smithy/kotlin/runtime/telemetry/context/Context;
+	public fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Laws/smithy/kotlin/runtime/telemetry/context/Scope;)V
+	public synthetic fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Object;)V
+	public fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Laws/smithy/kotlin/runtime/telemetry/context/Scope;
+	public synthetic fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElement$Key : kotlin/coroutines/CoroutineContext$Key {
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/context/TelemetryContextElementKt {
+	public static final fun getTelemetryContext (Lkotlin/coroutines/CoroutineContext;)Laws/smithy/kotlin/runtime/telemetry/context/Context;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/logging/CoroutineContextLogExtKt {
+	public static final fun debug (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun debug$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun error (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun error$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun getLoggingContext (Lkotlin/coroutines/CoroutineContext;)Ljava/util/Map;
+	public static final fun info (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun info$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun log (Lkotlin/coroutines/CoroutineContext;Laws/smithy/kotlin/runtime/telemetry/logging/LogLevel;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun log$default (Lkotlin/coroutines/CoroutineContext;Laws/smithy/kotlin/runtime/telemetry/logging/LogLevel;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun logger (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;)Laws/smithy/kotlin/runtime/telemetry/logging/Logger;
+	public static final fun trace (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun trace$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun warn (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun warn$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun withLogCtx ([Lkotlin/Pair;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/logging/LogLevel : java/lang/Enum {
@@ -114,6 +153,19 @@ public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider$Co
 	public final fun getNone ()Laws/smithy/kotlin/runtime/telemetry/logging/LoggerProvider;
 }
 
+public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Laws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement$Key;
+	public fun <init> (Ljava/util/Map;)V
+	public fun <init> ([Lkotlin/Pair;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Laws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement;Ljava/util/Map;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKvPairs ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/telemetry/logging/LoggingContextElement$Key : kotlin/coroutines/CoroutineContext$Key {
 }
 
@@ -140,6 +192,8 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/Histogram$Default
 public final class aws/smithy/kotlin/runtime/telemetry/metrics/HistogramKt {
 	public static final fun measureSeconds (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static synthetic fun measureSeconds$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun recordSeconds-dWUq8MI (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;JLaws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;)V
+	public static synthetic fun recordSeconds-dWUq8MI$default (Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;JLaws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/context/Context;ILjava/lang/Object;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/metrics/Meter {
@@ -188,6 +242,13 @@ public final class aws/smithy/kotlin/runtime/telemetry/metrics/UpDownCounter$Def
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/trace/CoroutineContextTraceExtKt {
+	public static final fun getTraceSpan (Lkotlin/coroutines/CoroutineContext;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
+	public static final fun withSpan (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withSpan (Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withSpan (Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withSpan$default (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun withSpan$default (Laws/smithy/kotlin/runtime/telemetry/trace/Tracer;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun withSpan$default (Ljava/lang/String;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/SpanContext {
@@ -231,6 +292,18 @@ public abstract interface class aws/smithy/kotlin/runtime/telemetry/trace/TraceS
 
 public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpan$DefaultImpls {
 	public static synthetic fun emitEvent$default (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;Ljava/lang/String;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)V
+}
+
+public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext : kotlin/coroutines/AbstractCoroutineContextElement {
+	public static final field Key Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext$Key;
+	public fun <init> (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
+	public final fun copy (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext;Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTraceSpan ()Laws/smithy/kotlin/runtime/telemetry/trace/TraceSpan;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/telemetry/trace/TraceSpanContext$Key : kotlin/coroutines/CoroutineContext$Key {

--- a/runtime/protocol/aws-event-stream/api/aws-event-stream.api
+++ b/runtime/protocol/aws-event-stream/api/aws-event-stream.api
@@ -4,20 +4,267 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStream
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/EventStreamSigningKt {
+	public static final fun sign (Lkotlinx/coroutines/flow/Flow;Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameDecoderKt {
+	public static final fun decodeFrames (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/FrameEncoderKt {
+	public static final fun asEventStreamHttpBody (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun encode (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Header {
+	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header$Companion;
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;
+	public final fun copy (Ljava/lang/String;Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header;Ljava/lang/String;Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header;
+	public final fun encode (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Header$Companion {
+	public final fun decode (Laws/smithy/kotlin/runtime/io/SdkBufferedSource;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header;
+}
+
+public abstract class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Companion;
+	public final fun encode (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;)V
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Bool : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Bool;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Bool;ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Bool;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Byte : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public synthetic fun <init> (BLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-w2LRezQ ()B
+	public final fun copy-7apg3OU (B)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Byte;
+	public static synthetic fun copy-7apg3OU$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Byte;BILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Byte;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue-w2LRezQ ()B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$ByteArray : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$ByteArray;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$ByteArray;[BILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$ByteArray;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Companion {
+	public final fun decode (Laws/smithy/kotlin/runtime/io/SdkBufferedSource;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int16 : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (S)V
+	public final fun component1 ()S
+	public final fun copy (S)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int16;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int16;SILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int16;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()S
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int32 : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int32;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int32;IILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int32;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int64 : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int64;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int64;JILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Int64;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$String : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$String;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Timestamp : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (Laws/smithy/kotlin/runtime/time/Instant;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/time/Instant;
+	public final fun copy (Laws/smithy/kotlin/runtime/time/Instant;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Timestamp;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Timestamp;Laws/smithy/kotlin/runtime/time/Instant;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Timestamp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Laws/smithy/kotlin/runtime/time/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid : aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue {
+	public fun <init> (Laws/smithy/kotlin/runtime/util/Uuid;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/util/Uuid;
+	public final fun copy (Laws/smithy/kotlin/runtime/util/Uuid;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid;Laws/smithy/kotlin/runtime/util/Uuid;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue$Uuid;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Laws/smithy/kotlin/runtime/util/Uuid;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValueKt {
+	public static final fun expectBool (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Z
+	public static final fun expectByte (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)B
+	public static final fun expectByteArray (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)[B
+	public static final fun expectInt16 (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)S
+	public static final fun expectInt32 (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)I
+	public static final fun expectInt64 (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)J
+	public static final fun expectString (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Ljava/lang/String;
+	public static final fun expectTimestamp (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Laws/smithy/kotlin/runtime/time/Instant;
+	public static final fun expectUuid (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)Laws/smithy/kotlin/runtime/util/Uuid;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Message {
+	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message$Companion;
+	public fun <init> (Ljava/util/List;[B)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()[B
+	public final fun copy (Ljava/util/List;[B)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;Ljava/util/List;[BILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;
+	public final fun encode (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/List;
+	public final fun getPayload ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Message$Companion {
+	public final fun decode (Laws/smithy/kotlin/runtime/io/SdkBufferedSource;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageBuilder {
+	public fun <init> ()V
+	public final fun addHeader (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Header;)V
+	public final fun addHeader (Ljava/lang/String;Laws/smithy/kotlin/runtime/awsprotocol/eventstream/HeaderValue;)V
+	public final fun build ()Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;
+	public final fun getHeaders ()Ljava/util/List;
+	public final fun getPayload ()[B
+	public final fun setPayload ([B)V
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageKt {
+	public static final fun buildMessage (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;
+}
+
+public abstract class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType {
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Error : aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Error;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Error;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Event : aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Event;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Event;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Event;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentType ()Ljava/lang/String;
+	public final fun getShapeType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Exception : aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Exception;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Exception;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$Exception;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentType ()Ljava/lang/String;
+	public final fun getShapeType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$SdkUnknown : aws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$SdkUnknown;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$SdkUnknown;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType$SdkUnknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude {
+	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude;IIILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude;
+	public final fun encode (Laws/smithy/kotlin/runtime/io/SdkBufferedSink;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeadersLength ()I
+	public final fun getPayloadLen ()I
+	public final fun getTotalLen ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude$Companion {
+	public final fun decode (Laws/smithy/kotlin/runtime/io/SdkBufferedSource;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Prelude;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/eventstream/ResponseHeadersKt {
+	public static final fun type (Laws/smithy/kotlin/runtime/awsprotocol/eventstream/Message;)Laws/smithy/kotlin/runtime/awsprotocol/eventstream/MessageType;
 }
 

--- a/runtime/protocol/aws-json-protocols/api/aws-json-protocols.api
+++ b/runtime/protocol/aws-json-protocols/api/aws-json-protocols.api
@@ -1,3 +1,15 @@
+public final class aws/smithy/kotlin/runtime/awsprotocol/json/AwsJsonProtocol : aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+	public fun modifyRequest (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun modifyRequest (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializer {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializer;
+	public final fun deserialize (Laws/smithy/kotlin/runtime/http/Headers;[B)Laws/smithy/kotlin/runtime/awsprotocol/ErrorDetails;
+}
+
 public final class aws/smithy/kotlin/runtime/awsprotocol/json/RestJsonErrorDeserializerKt {
 	public static final field X_AMZN_ERROR_MESSAGE_HEADER_NAME Ljava/lang/String;
 	public static final field X_AMZN_ERROR_TYPE_HEADER_NAME Ljava/lang/String;

--- a/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
+++ b/runtime/protocol/aws-protocol-core/api/aws-protocol-core.api
@@ -4,11 +4,27 @@ public abstract interface class aws/smithy/kotlin/runtime/awsprotocol/AwsErrorDe
 	public abstract fun getRequestId ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails {
+	public static final field Companion Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails$Companion;
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/ServiceException$ErrorType;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Laws/smithy/kotlin/runtime/ServiceException$ErrorType;
+	public final fun copy (Ljava/lang/String;Laws/smithy/kotlin/runtime/ServiceException$ErrorType;)Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;Ljava/lang/String;Laws/smithy/kotlin/runtime/ServiceException$ErrorType;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getType ()Laws/smithy/kotlin/runtime/ServiceException$ErrorType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails$Companion {
 	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetailsKt {
+	public static final field X_AMZN_QUERY_ERROR_HEADER Ljava/lang/String;
+	public static final fun setAwsQueryCompatibleErrorMetadata (Ljava/lang/Object;Laws/smithy/kotlin/runtime/awsprotocol/AwsQueryCompatibleErrorDetails;)V
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
@@ -39,10 +55,28 @@ public final class aws/smithy/kotlin/runtime/awsprotocol/ClockSkewInterceptor$Co
 	public final fun getCLOCK_SKEW_THRESHOLD-UwyO8pc ()J
 }
 
+public final class aws/smithy/kotlin/runtime/awsprotocol/ErrorDetails : aws/smithy/kotlin/runtime/awsprotocol/AwsErrorDetails {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/awsprotocol/ErrorDetails;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/awsprotocol/ErrorDetails;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/awsprotocol/ErrorDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCode ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getRequestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/awsprotocol/ProtocolErrorsKt {
+	public static final fun setAseErrorMetadata (Ljava/lang/Object;Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/awsprotocol/AwsErrorDetails;)V
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/ResponseUtilsKt {
 	public static final field X_AMZN_REQUEST_ID_HEADER Ljava/lang/String;
+	public static final fun matches (Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/HttpStatusCode;)Z
+	public static final fun withPayload (Laws/smithy/kotlin/runtime/http/response/HttpResponse;[B)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 }
 

--- a/runtime/protocol/aws-xml-protocols/api/aws-xml-protocols.api
+++ b/runtime/protocol/aws-xml-protocols/api/aws-xml-protocols.api
@@ -1,6 +1,8 @@
 public final class aws/smithy/kotlin/runtime/awsprotocol/xml/Ec2QueryErrorDeserializerKt {
+	public static final fun parseEc2QueryErrorResponse ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/awsprotocol/xml/RestXmlErrorDeserializerKt {
+	public static final fun parseRestXmlErrorResponse ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/runtime/protocol/http-client-engines/http-client-engine-default/api/http-client-engine-default.api
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/api/http-client-engine-default.api
@@ -8,3 +8,17 @@ public final class aws/smithy/kotlin/runtime/http/engine/DefaultHttpEngineKt {
 	public static synthetic fun DefaultHttpEngine$default (Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/engine/CloseableHttpClientEngine;
 }
 
+public final class aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImpl : aws/smithy/kotlin/runtime/http/config/HttpEngineConfig {
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getHttpClient ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;
+}
+
+public final class aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImpl$BuilderImpl : aws/smithy/kotlin/runtime/http/config/HttpEngineConfig$Builder {
+	public fun <init> ()V
+	public fun buildHttpEngineConfig ()Laws/smithy/kotlin/runtime/http/config/HttpEngineConfig;
+	public fun getHttpClient ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;
+	public fun httpClient (Laws/smithy/kotlin/runtime/http/config/EngineFactory;Lkotlin/jvm/functions/Function1;)V
+	public fun httpClient (Lkotlin/jvm/functions/Function1;)V
+	public fun setHttpClient (Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;)V
+}
+

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -25,6 +25,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/config/HttpEngine
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/config/HttpEngineConfig$Builder {
+	public abstract fun buildHttpEngineConfig ()Laws/smithy/kotlin/runtime/http/config/HttpEngineConfig;
 	public abstract fun getHttpClient ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;
 	public abstract fun httpClient (Laws/smithy/kotlin/runtime/http/config/EngineFactory;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun httpClient (Lkotlin/jvm/functions/Function1;)V
@@ -54,11 +55,24 @@ public abstract interface class aws/smithy/kotlin/runtime/http/engine/CloseableH
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/CoroutineUtilsKt {
+	public static final fun callContext (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/engine/EngineAttributes {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/engine/EngineAttributes;
+	public final fun getTimeToFirstByte ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClientEngine : kotlinx/coroutines/CoroutineScope {
 	public abstract fun getConfig ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig;
 	public abstract fun roundTrip (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineBase : aws/smithy/kotlin/runtime/http/engine/CloseableHttpClientEngine {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun close ()V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	protected fun shutdown ()V
 }
 
 public final class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineClosedException : aws/smithy/kotlin/runtime/ClientException {
@@ -80,6 +94,7 @@ public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClient
 	public abstract fun getSocketWriteTimeout-UwyO8pc ()J
 	public abstract fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
 	public abstract fun getTlsContext ()Laws/smithy/kotlin/runtime/http/engine/TlsContext;
+	public abstract fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig$Builder {
@@ -114,6 +129,47 @@ public final class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig$
 public final class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig$Companion {
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig;
+}
+
+public class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfigImpl : aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig {
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig$Builder;)V
+	public fun getConnectTimeout-UwyO8pc ()J
+	public fun getConnectionAcquireTimeout-UwyO8pc ()J
+	public fun getConnectionIdleTimeout-UwyO8pc ()J
+	public fun getHostResolver ()Laws/smithy/kotlin/runtime/net/HostResolver;
+	public fun getMaxConcurrency-pVg5ArA ()I
+	public fun getProxySelector ()Laws/smithy/kotlin/runtime/http/engine/ProxySelector;
+	public fun getSocketReadTimeout-UwyO8pc ()J
+	public fun getSocketWriteTimeout-UwyO8pc ()J
+	public fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public fun getTlsContext ()Laws/smithy/kotlin/runtime/http/engine/TlsContext;
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public class aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfigImpl$BuilderImpl : aws/smithy/kotlin/runtime/http/engine/HttpClientEngineConfig$Builder {
+	public fun <init> ()V
+	public fun getConnectTimeout-UwyO8pc ()J
+	public fun getConnectionAcquireTimeout-UwyO8pc ()J
+	public fun getConnectionIdleTimeout-UwyO8pc ()J
+	public fun getHostResolver ()Laws/smithy/kotlin/runtime/net/HostResolver;
+	public fun getMaxConcurrency-pVg5ArA ()I
+	public fun getProxySelector ()Laws/smithy/kotlin/runtime/http/engine/ProxySelector;
+	public fun getSocketReadTimeout-UwyO8pc ()J
+	public fun getSocketWriteTimeout-UwyO8pc ()J
+	public fun getTelemetryProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public fun getTlsContext ()Laws/smithy/kotlin/runtime/http/engine/TlsContext;
+	public fun setConnectTimeout-LRDsOJo (J)V
+	public fun setConnectionAcquireTimeout-LRDsOJo (J)V
+	public fun setConnectionIdleTimeout-LRDsOJo (J)V
+	public fun setHostResolver (Laws/smithy/kotlin/runtime/net/HostResolver;)V
+	public fun setMaxConcurrency-WZ4Q5Ns (I)V
+	public fun setProxySelector (Laws/smithy/kotlin/runtime/http/engine/ProxySelector;)V
+	public fun setSocketReadTimeout-LRDsOJo (J)V
+	public fun setSocketWriteTimeout-LRDsOJo (J)V
+	public fun setTelemetryProvider (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
+	public fun setTlsContext (Laws/smithy/kotlin/runtime/http/engine/TlsContext;)V
+	public fun tlsContext (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract class aws/smithy/kotlin/runtime/http/engine/ProxyConfig {
@@ -163,11 +219,220 @@ public final class aws/smithy/kotlin/runtime/http/engine/TlsContext$Companion {
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/http/engine/TlsContext;
 }
 
+public final class aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetricAttributes {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetricAttributes;
+	public final fun getAcquiredConnection ()Laws/smithy/kotlin/runtime/collections/Attributes;
+	public final fun getIdleConnection ()Laws/smithy/kotlin/runtime/collections/Attributes;
+	public final fun getInFlightRequest ()Laws/smithy/kotlin/runtime/collections/Attributes;
+	public final fun getQueuedRequest ()Laws/smithy/kotlin/runtime/collections/Attributes;
+}
+
+public final class aws/smithy/kotlin/runtime/http/engine/internal/HttpClientMetrics : java/io/Closeable {
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
+	public fun close ()V
+	public final fun getAcquiredConnections ()J
+	public final fun getBytesReceived ()Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
+	public final fun getBytesSent ()Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
+	public final fun getConnectionAcquireDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getConnectionUptime ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getConnectionsLimit ()J
+	public final fun getIdleConnections ()J
+	public final fun getInFlightRequests ()J
+	public final fun getProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public final fun getQueuedRequests ()J
+	public final fun getRequestConcurrencyLimit ()J
+	public final fun getRequestsQueuedDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getTimeToFirstByteDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun setAcquiredConnections (J)V
+	public final fun setConnectionsLimit (J)V
+	public final fun setIdleConnections (J)V
+	public final fun setInFlightRequests (J)V
+	public final fun setQueuedRequests (J)V
+	public final fun setRequestConcurrencyLimit (J)V
+}
+
 public final class aws/smithy/kotlin/runtime/http/engine/internal/ManagedHttpClientEngineKt {
+	public static final fun manage (Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;)Laws/smithy/kotlin/runtime/http/engine/HttpClientEngine;
 }
 
 public final class aws/smithy/kotlin/runtime/http/interceptors/ChecksumMismatchException : aws/smithy/kotlin/runtime/ClientException {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/ContinueInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> (J)V
+	public final fun getThresholdLengthBytes ()J
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/DiscoveredEndpointErrorInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsRequestInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public static final field Companion Laws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/FlexibleChecksumsResponseInterceptor$Companion {
+	public final fun getChecksumHeaderValidated ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/Md5ChecksumInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/RequestCompressionInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> (JLjava/util/List;Ljava/util/List;)V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/interceptors/ResponseLengthValidationInterceptor : aws/smithy/kotlin/runtime/client/Interceptor {
+	public fun <init> ()V
+	public fun modifyBeforeAttemptCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeCompletion-gIAlu-s (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeRetryLoop (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun modifyBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readAfterAttempt (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterDeserialization (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterExecution (Laws/smithy/kotlin/runtime/client/ResponseInterceptorContext;)V
+	public fun readAfterSerialization (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readAfterTransmit (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeAttempt (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeDeserialization (Laws/smithy/kotlin/runtime/client/ProtocolResponseInterceptorContext;)V
+	public fun readBeforeExecution (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSerialization (Laws/smithy/kotlin/runtime/client/RequestInterceptorContext;)V
+	public fun readBeforeSigning (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+	public fun readBeforeTransmit (Laws/smithy/kotlin/runtime/client/ProtocolRequestInterceptorContext;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/middleware/DefaultValidateResponse : aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware {
+	public fun <init> ()V
+	public fun handle (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun handle (Ljava/lang/Object;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseException : aws/smithy/kotlin/runtime/SdkBaseException {
@@ -185,24 +450,241 @@ public final class aws/smithy/kotlin/runtime/http/middleware/HttpResponseExcepti
 	public final fun setStatusCode (Laws/smithy/kotlin/runtime/http/HttpStatusCode;)V
 }
 
+public final class aws/smithy/kotlin/runtime/http/middleware/MutateHeaders : aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun append (Ljava/lang/String;Ljava/lang/String;)V
+	public fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+	public fun modifyRequest (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun modifyRequest (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun set (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun setIfMissing (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver {
+	public abstract fun resolve (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/EndpointResolver {
+	public abstract fun resolve (Laws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {
+	public abstract fun deserialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/HttpCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/operation/HttpOperationContext;
+	public final fun getClockSkew ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getClockSkewApproximateSigningTime ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getHostPrefix ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getHttpCallList ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getOperationAttributes ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getOperationInput ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getOperationMetrics ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getSdkInvocationId ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/HttpSerialize {
+	public abstract fun serialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/IdentityDeserializer : aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/operation/IdentityDeserializer;
+	public fun deserialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/HttpCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/InitializeMiddleware : aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
 public final class aws/smithy/kotlin/runtime/http/operation/InitializeMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/InitializeMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/InlineMiddleware {
+	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware : aws/smithy/kotlin/runtime/io/middleware/ModifyRequest {
+	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/MutateMiddleware : aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/MutateMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/MutateMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/OperationAuthConfig {
+	public static final field Companion Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver;Ljava/util/Map;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;
+	public final fun copy (Laws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver;Ljava/util/Map;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;)Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;Laws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver;Ljava/util/Map;Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthSchemeResolver ()Laws/smithy/kotlin/runtime/http/operation/AuthSchemeResolver;
+	public final fun getConfiguredAuthSchemes ()Ljava/util/Map;
+	public final fun getIdentityProviderConfig ()Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/OperationAuthConfig$Companion {
+	public final fun from (Laws/smithy/kotlin/runtime/identity/IdentityProviderConfig;[Laws/smithy/kotlin/runtime/http/auth/AuthScheme;)Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;
+	public final fun getAnonymous ()Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/OperationEndpointKt {
+	public static final fun setResolvedEndpoint (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;)V
+	public static final fun setResolvedEndpoint (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/OperationMetrics {
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
+	public final fun getDeserializationDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public final fun getResolveEndpointDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getResolveIdentityDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getRpcAttemptDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getRpcAttemptOverheadDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getRpcAttempts ()Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
+	public final fun getRpcCallDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getRpcErrors ()Laws/smithy/kotlin/runtime/telemetry/metrics/MonotonicCounter;
+	public final fun getSerializationDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+	public final fun getSigningDuration ()Laws/smithy/kotlin/runtime/telemetry/metrics/Histogram;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/OperationRequest {
+	public fun <init> (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Ljava/lang/Object;)Laws/smithy/kotlin/runtime/http/operation/OperationRequest;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/operation/OperationRequest;Laws/smithy/kotlin/runtime/operation/ExecutionContext;Ljava/lang/Object;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/operation/OperationRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun getSubject ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/OperationTelemetryKt {
+	public static final fun telemetry (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperationBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware : aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public abstract fun install (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware$DefaultImpls {
+	public static fun install (Laws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware;Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest {
+	public fun <init> (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/identity/Identity;)V
+	public final fun component1 ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun component2 ()Laws/smithy/kotlin/runtime/http/request/HttpRequest;
+	public final fun component3 ()Laws/smithy/kotlin/runtime/identity/Identity;
+	public final fun copy (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/identity/Identity;)Laws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest;Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/identity/Identity;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/operation/ResolveEndpointRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun getHttpRequest ()Laws/smithy/kotlin/runtime/http/request/HttpRequest;
+	public final fun getIdentity ()Laws/smithy/kotlin/runtime/identity/Identity;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation {
+	public static final field Companion Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation$Companion;
+	public final fun getContext ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun getExecution ()Laws/smithy/kotlin/runtime/http/operation/SdkOperationExecution;
+	public final fun getInterceptors ()Ljava/util/List;
+	public final fun install (Laws/smithy/kotlin/runtime/http/operation/InitializeMiddleware;)V
+	public final fun install (Laws/smithy/kotlin/runtime/http/operation/InlineMiddleware;)V
+	public final fun install (Laws/smithy/kotlin/runtime/http/operation/ModifyRequestMiddleware;)V
+	public final fun install (Laws/smithy/kotlin/runtime/http/operation/MutateMiddleware;)V
+	public final fun install (Laws/smithy/kotlin/runtime/http/operation/ReceiveMiddleware;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperation$Companion {
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperationBuilder {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public final fun build ()Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;
+	public final fun getContext ()Laws/smithy/kotlin/runtime/operation/ExecutionContext;
+	public final fun getDeserializer ()Laws/smithy/kotlin/runtime/http/operation/HttpDeserialize;
+	public final fun getExecution ()Laws/smithy/kotlin/runtime/http/operation/SdkOperationExecution;
+	public final fun getHostPrefix ()Ljava/lang/String;
+	public final fun getOperationName ()Ljava/lang/String;
+	public final fun getSerializer ()Laws/smithy/kotlin/runtime/http/operation/HttpSerialize;
+	public final fun getServiceName ()Ljava/lang/String;
+	public final fun getTelemetry ()Laws/smithy/kotlin/runtime/http/operation/SdkOperationTelemetry;
+	public final fun setDeserializer (Laws/smithy/kotlin/runtime/http/operation/HttpDeserialize;)V
+	public final fun setHostPrefix (Ljava/lang/String;)V
+	public final fun setOperationName (Ljava/lang/String;)V
+	public final fun setSerializer (Laws/smithy/kotlin/runtime/http/operation/HttpSerialize;)V
+	public final fun setServiceName (Ljava/lang/String;)V
 }
 
 public final class aws/smithy/kotlin/runtime/http/operation/SdkHttpOperationKt {
+	public static final fun context (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperationBuilder;Lkotlin/jvm/functions/Function1;)V
+	public static final fun execute (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;Laws/smithy/kotlin/runtime/io/Handler;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getSdkInvocationId (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
+	public static final fun roundTrip (Laws/smithy/kotlin/runtime/http/operation/SdkHttpOperation;Laws/smithy/kotlin/runtime/io/Handler;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/SdkOperationExecution {
+	public fun <init> ()V
+	public final fun getAuth ()Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;
+	public final fun getEndpointResolver ()Laws/smithy/kotlin/runtime/http/operation/EndpointResolver;
+	public final fun getInitialize ()Laws/smithy/kotlin/runtime/io/middleware/Phase;
+	public final fun getMutate ()Laws/smithy/kotlin/runtime/io/middleware/Phase;
+	public final fun getOnEachAttempt ()Laws/smithy/kotlin/runtime/io/middleware/Phase;
+	public final fun getReceive ()Laws/smithy/kotlin/runtime/io/middleware/Phase;
+	public final fun getRetryPolicy ()Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;
+	public final fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+	public final fun setAuth (Laws/smithy/kotlin/runtime/http/operation/OperationAuthConfig;)V
+	public final fun setEndpointResolver (Laws/smithy/kotlin/runtime/http/operation/EndpointResolver;)V
+	public final fun setRetryPolicy (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;)V
+	public final fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/SdkOperationTelemetry {
+	public fun <init> ()V
+	public final fun getAttributes ()Laws/smithy/kotlin/runtime/collections/Attributes;
+	public final fun getMetrics ()Laws/smithy/kotlin/runtime/http/operation/OperationMetrics;
+	public final fun getProvider ()Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;
+	public final fun getScope ()Ljava/lang/String;
+	public final fun getSpanKind ()Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;
+	public final fun getSpanName ()Ljava/lang/String;
+	public final fun setAttributes (Laws/smithy/kotlin/runtime/collections/Attributes;)V
+	public final fun setMetrics (Laws/smithy/kotlin/runtime/http/operation/OperationMetrics;)V
+	public final fun setProvider (Laws/smithy/kotlin/runtime/telemetry/TelemetryProvider;)V
+	public final fun setScope (Ljava/lang/String;)V
+	public final fun setSpanKind (Laws/smithy/kotlin/runtime/telemetry/trace/SpanKind;)V
+	public final fun setSpanName (Ljava/lang/String;)V
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/UnitDeserializer : aws/smithy/kotlin/runtime/http/operation/HttpDeserialize {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/operation/UnitDeserializer;
+	public fun deserialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Laws/smithy/kotlin/runtime/http/HttpCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/http/operation/UnitSerializer : aws/smithy/kotlin/runtime/http/operation/HttpSerialize {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/http/operation/UnitSerializer;
+	public synthetic fun serialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun serialize (Laws/smithy/kotlin/runtime/operation/ExecutionContext;Lkotlin/Unit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/runtime/protocol/http/api/http.api
+++ b/runtime/protocol/http/api/http.api
@@ -23,6 +23,7 @@ public final class aws/smithy/kotlin/runtime/http/DeferredHeadersBuilder : aws/s
 }
 
 public final class aws/smithy/kotlin/runtime/http/DeferredHeadersKt {
+	public static final fun toHeaders (Laws/smithy/kotlin/runtime/http/DeferredHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/http/Headers : aws/smithy/kotlin/runtime/collections/ValuesMap {
@@ -85,13 +86,24 @@ public abstract class aws/smithy/kotlin/runtime/http/HttpBody$SourceContent : aw
 public final class aws/smithy/kotlin/runtime/http/HttpBodyKt {
 	public static final fun readAll (Laws/smithy/kotlin/runtime/http/HttpBody;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun toByteStream (Laws/smithy/kotlin/runtime/http/HttpBody;)Laws/smithy/kotlin/runtime/content/ByteStream;
+	public static final fun toHashingBody (Laws/smithy/kotlin/runtime/http/HttpBody;Laws/smithy/kotlin/runtime/hashing/HashFunction;Ljava/lang/Long;)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static final fun toHttpBody (Laws/smithy/kotlin/runtime/content/ByteStream;)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static final fun toHttpBody (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Ljava/lang/Long;)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static final fun toHttpBody (Laws/smithy/kotlin/runtime/io/SdkSource;Ljava/lang/Long;)Laws/smithy/kotlin/runtime/http/HttpBody;
 	public static final fun toHttpBody (Ljava/lang/String;)Laws/smithy/kotlin/runtime/http/HttpBody;
 	public static final fun toHttpBody ([B)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static synthetic fun toHttpBody$default (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;Ljava/lang/Long;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static synthetic fun toHttpBody$default (Laws/smithy/kotlin/runtime/io/SdkSource;Ljava/lang/Long;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/HttpBody;
+	public static final fun toSdkByteReadChannel (Laws/smithy/kotlin/runtime/http/HttpBody;Lkotlinx/coroutines/CoroutineScope;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
+	public static synthetic fun toSdkByteReadChannel$default (Laws/smithy/kotlin/runtime/http/HttpBody;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
 }
 
 public class aws/smithy/kotlin/runtime/http/HttpCall : kotlinx/coroutines/CoroutineScope {
 	public fun <init> (Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun <init> (Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun cancelInFlight ()V
+	public fun copy (Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/http/response/HttpResponse;)Laws/smithy/kotlin/runtime/http/HttpCall;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/HttpCall;Laws/smithy/kotlin/runtime/http/request/HttpRequest;Laws/smithy/kotlin/runtime/http/response/HttpResponse;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/HttpCall;
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getRequest ()Laws/smithy/kotlin/runtime/http/request/HttpRequest;
 	public final fun getRequestTime ()Laws/smithy/kotlin/runtime/time/Instant;
@@ -100,6 +112,7 @@ public class aws/smithy/kotlin/runtime/http/HttpCall : kotlinx/coroutines/Corout
 }
 
 public final class aws/smithy/kotlin/runtime/http/HttpCallKt {
+	public static final fun complete (Laws/smithy/kotlin/runtime/http/HttpCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/http/HttpErrorCode : java/lang/Enum {
@@ -282,8 +295,11 @@ public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilder : a
 }
 
 public final class aws/smithy/kotlin/runtime/http/request/HttpRequestBuilderKt {
+	public static final fun dumpRequest (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun header (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun headers (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
+	public static final fun immutableView (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Z)Laws/smithy/kotlin/runtime/http/request/HttpRequest;
+	public static synthetic fun immutableView$default (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/request/HttpRequest;
 	public static final fun url (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Laws/smithy/kotlin/runtime/net/url/Url;)V
 	public static final fun url (Laws/smithy/kotlin/runtime/http/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 }
@@ -305,11 +321,15 @@ public final class aws/smithy/kotlin/runtime/http/response/HttpResponseKt {
 	public static synthetic fun HttpResponse$default (Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static final fun copy (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/http/response/HttpResponse;Laws/smithy/kotlin/runtime/http/HttpStatusCode;Laws/smithy/kotlin/runtime/http/Headers;Laws/smithy/kotlin/runtime/http/HttpBody;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/http/response/HttpResponse;
+	public static final fun dumpResponse (Laws/smithy/kotlin/runtime/http/response/HttpResponse;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAllHeaders (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/util/List;
 	public static final fun header (Laws/smithy/kotlin/runtime/ProtocolResponse;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun statusCode (Laws/smithy/kotlin/runtime/ProtocolResponse;)Laws/smithy/kotlin/runtime/http/HttpStatusCode;
 }
 
 public final class aws/smithy/kotlin/runtime/http/util/HeaderListsKt {
+	public static final fun quoteHeaderValue (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun splitHeaderListValues (Ljava/lang/String;)Ljava/util/List;
+	public static final fun splitHttpDateHeaderListValues (Ljava/lang/String;)Ljava/util/List;
 }
 

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2,7 +2,6 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun <init> (Ljava/lang/Throwable;)V
 }
 
 public class aws/smithy/kotlin/runtime/ErrorMetadata {

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -8,6 +8,7 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 public class aws/smithy/kotlin/runtime/ErrorMetadata {
 	public static final field Companion Laws/smithy/kotlin/runtime/ErrorMetadata$Companion;
 	public fun <init> ()V
+	public final fun getAttributes ()Laws/smithy/kotlin/runtime/collections/MutableAttributes;
 	public final fun isRetryable ()Z
 	public final fun isThrottling ()Z
 }
@@ -159,7 +160,21 @@ public final class aws/smithy/kotlin/runtime/collections/MutableMultiMapKt {
 	public static final fun mutableMultiMapOf ([Lkotlin/Pair;)Laws/smithy/kotlin/runtime/collections/MutableMultiMap;
 }
 
+public final class aws/smithy/kotlin/runtime/collections/ReadThroughCache {
+	public synthetic fun <init> (JLaws/smithy/kotlin/runtime/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLaws/smithy/kotlin/runtime/time/Clock;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun get (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSize ()I
+	public final fun invalidate (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class aws/smithy/kotlin/runtime/collections/StackKt {
+	public static final fun pop (Ljava/util/List;)Ljava/lang/Object;
+	public static final fun popOrNull (Ljava/util/List;)Ljava/lang/Object;
+	public static final fun push (Ljava/util/List;Ljava/lang/Object;)Z
+	public static final fun replaceTop (Ljava/util/List;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun top (Ljava/util/List;)Ljava/lang/Object;
+	public static final fun topOrNull (Ljava/util/List;)Ljava/lang/Object;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/collections/ValuesMap {
@@ -180,7 +195,52 @@ public final class aws/smithy/kotlin/runtime/collections/ValuesMap$DefaultImpls 
 	public static fun get (Laws/smithy/kotlin/runtime/collections/ValuesMap;Ljava/lang/String;)Ljava/lang/Object;
 }
 
+public class aws/smithy/kotlin/runtime/collections/ValuesMapBuilder {
+	public fun <init> ()V
+	public fun <init> (ZI)V
+	public synthetic fun <init> (ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun append (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun appendAll (Laws/smithy/kotlin/runtime/collections/ValuesMap;)V
+	public final fun appendAll (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public final fun appendMissing (Laws/smithy/kotlin/runtime/collections/ValuesMap;)V
+	public final fun appendMissing (Ljava/lang/String;Ljava/lang/Iterable;)V
+	public fun build ()Laws/smithy/kotlin/runtime/collections/ValuesMap;
+	public final fun clear ()V
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun contains (Ljava/lang/String;Ljava/lang/Object;)Z
+	public final fun entries ()Ljava/util/Set;
+	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public final fun getCaseInsensitiveName ()Z
+	protected final fun getValues ()Ljava/util/Map;
+	public final fun isEmpty ()Z
+	public final fun names ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;)Ljava/util/List;
+	public final fun remove (Ljava/lang/String;Ljava/lang/Object;)Z
+	public final fun removeKeysWithNoEntries ()V
+	public final fun set (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun setMissing (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public class aws/smithy/kotlin/runtime/collections/ValuesMapImpl : aws/smithy/kotlin/runtime/collections/ValuesMap {
+	public fun <init> ()V
+	public fun <init> (ZLjava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contains (Ljava/lang/String;)Z
+	public fun contains (Ljava/lang/String;Ljava/lang/Object;)Z
+	public fun entries ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun forEach (Lkotlin/jvm/functions/Function2;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/String;)Ljava/util/List;
+	public fun getCaseInsensitiveName ()Z
+	protected final fun getValues ()Ljava/util/Map;
+	public fun isEmpty ()Z
+	public fun names ()Ljava/util/Set;
+}
+
 public final class aws/smithy/kotlin/runtime/collections/ValuesMapKt {
+	public static final fun deepCopy (Ljava/util/Map;)Ljava/util/Map;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/compression/CompressionAlgorithm {
@@ -196,7 +256,37 @@ public final class aws/smithy/kotlin/runtime/compression/Gzip : aws/smithy/kotli
 	public fun getId ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/config/EnvironmentSetting {
+	public static final field Companion Laws/smithy/kotlin/runtime/config/EnvironmentSetting$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/config/EnvironmentSetting;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getEnvVar ()Ljava/lang/String;
+	public final fun getParse ()Lkotlin/jvm/functions/Function1;
+	public final fun getSysProp ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun orElse (Ljava/lang/Object;)Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/config/EnvironmentSetting$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function2;
+}
+
 public final class aws/smithy/kotlin/runtime/config/EnvironmentSettingKt {
+	public static final fun getBoolEnvSetting ()Lkotlin/jvm/functions/Function2;
+	public static final fun getIntEnvSetting ()Lkotlin/jvm/functions/Function2;
+	public static final fun getLongEnvSetting ()Lkotlin/jvm/functions/Function2;
+	public static final fun getStrEnvSetting ()Lkotlin/jvm/functions/Function2;
+	public static final fun resolve (Laws/smithy/kotlin/runtime/config/EnvironmentSetting;Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;)Ljava/lang/Object;
+	public static synthetic fun resolve$default (Laws/smithy/kotlin/runtime/config/EnvironmentSetting;Laws/smithy/kotlin/runtime/util/PlatformEnvironProvider;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class aws/smithy/kotlin/runtime/content/ByteStream {
@@ -445,7 +535,23 @@ public final class aws/smithy/kotlin/runtime/content/FileContent : aws/smithy/ko
 	public fun readFrom ()Laws/smithy/kotlin/runtime/io/SdkSource;
 }
 
+public final class aws/smithy/kotlin/runtime/hashing/Crc32 : aws/smithy/kotlin/runtime/hashing/Crc32Base {
+	public fun <init> ()V
+	public fun digestValue-pVg5ArA ()I
+	public fun reset ()V
+	public fun update ([BII)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/hashing/Crc32Base : aws/smithy/kotlin/runtime/hashing/HashFunction {
+	public fun <init> ()V
+	public fun digest ()[B
+	public abstract fun digestValue-pVg5ArA ()I
+	public fun getBlockSizeBytes ()I
+	public fun getDigestSizeBytes ()I
+}
+
 public final class aws/smithy/kotlin/runtime/hashing/Crc32Kt {
+	public static final fun crc32 ([B)I
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Crc32c : aws/smithy/kotlin/runtime/hashing/Crc32Base {
@@ -456,6 +562,15 @@ public final class aws/smithy/kotlin/runtime/hashing/Crc32c : aws/smithy/kotlin/
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Crc32cKt {
+	public static final fun crc32c ([B)I
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/hashing/HashFunction {
+	public abstract fun digest ()[B
+	public abstract fun getBlockSizeBytes ()I
+	public abstract fun getDigestSizeBytes ()I
+	public abstract fun reset ()V
+	public abstract fun update ([BII)V
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/HashFunction$DefaultImpls {
@@ -463,21 +578,69 @@ public final class aws/smithy/kotlin/runtime/hashing/HashFunction$DefaultImpls {
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/HashFunctionKt {
+	public static final fun hash ([BLaws/smithy/kotlin/runtime/hashing/HashFunction;)[B
+	public static final fun hash ([BLkotlin/jvm/functions/Function0;)[B
+	public static final fun toHashFunction (Ljava/lang/String;)Laws/smithy/kotlin/runtime/hashing/HashFunction;
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/HmacKt {
+	public static final fun hmac ([B[BLaws/smithy/kotlin/runtime/hashing/HashFunction;)[B
+	public static final fun hmac ([B[BLkotlin/jvm/functions/Function0;)[B
+}
+
+public final class aws/smithy/kotlin/runtime/hashing/Md5 : aws/smithy/kotlin/runtime/hashing/Md5Base {
+	public fun <init> ()V
+	public fun digest ()[B
+	public fun reset ()V
+	public fun update ([BII)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/hashing/Md5Base : aws/smithy/kotlin/runtime/hashing/HashFunction {
+	public fun <init> ()V
+	public fun getBlockSizeBytes ()I
+	public fun getDigestSizeBytes ()I
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Md5Kt {
+	public static final fun md5 ([B)[B
+}
+
+public final class aws/smithy/kotlin/runtime/hashing/Sha1 : aws/smithy/kotlin/runtime/hashing/Sha1Base {
+	public fun <init> ()V
+	public fun digest ()[B
+	public fun reset ()V
+	public fun update ([BII)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/hashing/Sha1Base : aws/smithy/kotlin/runtime/hashing/HashFunction {
+	public fun <init> ()V
+	public fun getBlockSizeBytes ()I
+	public fun getDigestSizeBytes ()I
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Sha1Kt {
+	public static final fun sha1 ([B)[B
+}
+
+public final class aws/smithy/kotlin/runtime/hashing/Sha256 : aws/smithy/kotlin/runtime/hashing/Sha256Base {
+	public fun <init> ()V
+	public fun digest ()[B
+	public fun reset ()V
+	public fun update ([BII)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/hashing/Sha256Base : aws/smithy/kotlin/runtime/hashing/HashFunction {
+	public fun <init> ()V
+	public fun getBlockSizeBytes ()I
+	public fun getDigestSizeBytes ()I
 }
 
 public final class aws/smithy/kotlin/runtime/hashing/Sha256Kt {
+	public static final fun sha256 ([B)[B
 }
 
 public final class aws/smithy/kotlin/runtime/io/CloseableKt {
+	public static final fun closeIfCloseable (Ljava/lang/Object;)V
 	public static final fun use (Ljava/io/Closeable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
@@ -487,8 +650,48 @@ public final class aws/smithy/kotlin/runtime/io/ClosedWriteChannelException : ja
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class aws/smithy/kotlin/runtime/io/GzipByteReadChannel : aws/smithy/kotlin/runtime/io/SdkByteReadChannel {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;)V
+	public fun cancel (Ljava/lang/Throwable;)Z
+	public fun getAvailableForRead ()I
+	public fun getClosedCause ()Ljava/lang/Throwable;
+	public fun isClosedForRead ()Z
+	public fun isClosedForWrite ()Z
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/GzipSdkSource : aws/smithy/kotlin/runtime/io/SdkSource {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkSource;)V
+	public fun close ()V
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/io/Handler {
 	public abstract fun call (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/HashingByteReadChannel : aws/smithy/kotlin/runtime/io/SdkByteReadChannel {
+	public fun <init> (Laws/smithy/kotlin/runtime/hashing/HashFunction;Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;)V
+	public fun cancel (Ljava/lang/Throwable;)Z
+	public final fun digest ()[B
+	public fun getAvailableForRead ()I
+	public fun getClosedCause ()Ljava/lang/Throwable;
+	public fun isClosedForRead ()Z
+	public fun isClosedForWrite ()Z
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/HashingSink : aws/smithy/kotlin/runtime/io/internal/SdkSinkObserver {
+	public fun <init> (Laws/smithy/kotlin/runtime/hashing/HashFunction;Laws/smithy/kotlin/runtime/io/SdkSink;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/hashing/HashFunction;Laws/smithy/kotlin/runtime/io/SdkSink;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun digest ()[B
+	public fun observe ([BII)V
+}
+
+public final class aws/smithy/kotlin/runtime/io/HashingSource : aws/smithy/kotlin/runtime/io/internal/SdkSourceObserver {
+	public fun <init> (Laws/smithy/kotlin/runtime/hashing/HashFunction;Laws/smithy/kotlin/runtime/io/SdkSource;)V
+	public final fun digest ()[B
+	public fun observe ([BII)V
 }
 
 public final class aws/smithy/kotlin/runtime/io/JavaIOKt {
@@ -612,6 +815,10 @@ public final class aws/smithy/kotlin/runtime/io/SdkByteChannel$DefaultImpls {
 
 public final class aws/smithy/kotlin/runtime/io/SdkByteChannelKt {
 	public static final field DEFAULT_BYTE_CHANNEL_MAX_BUFFER_SIZE I
+	public static final fun SdkByteChannel (ZI)Laws/smithy/kotlin/runtime/io/SdkByteChannel;
+	public static synthetic fun SdkByteChannel$default (ZIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteChannel;
+	public static final fun SdkByteReadChannel ([BII)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
+	public static synthetic fun SdkByteReadChannel$default ([BIIILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkByteReadChannel {
@@ -662,7 +869,32 @@ public final class aws/smithy/kotlin/runtime/io/SdkIoKt {
 	public static final fun source ([B)Laws/smithy/kotlin/runtime/io/SdkSource;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/io/SdkManaged {
+	public abstract fun share ()V
+	public abstract fun unshare ()Z
+}
+
+public abstract class aws/smithy/kotlin/runtime/io/SdkManagedBase : aws/smithy/kotlin/runtime/io/SdkManaged {
+	public fun <init> ()V
+	public fun share ()V
+	public fun unshare ()Z
+}
+
+public class aws/smithy/kotlin/runtime/io/SdkManagedCloseable : aws/smithy/kotlin/runtime/io/SdkManagedBase {
+	public fun <init> (Ljava/io/Closeable;)V
+	public fun unshare ()Z
+}
+
+public final class aws/smithy/kotlin/runtime/io/SdkManagedGroup {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Laws/smithy/kotlin/runtime/io/SdkManaged;)V
+	public final fun unshareAll ()V
+}
+
 public final class aws/smithy/kotlin/runtime/io/SdkManagedGroupKt {
+	public static final fun addIfManaged (Laws/smithy/kotlin/runtime/io/SdkManagedGroup;Ljava/lang/Object;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/io/SdkSink : java/io/Closeable {
@@ -682,6 +914,9 @@ public abstract interface class aws/smithy/kotlin/runtime/io/SdkSource : java/io
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkSourceJVMKt {
+	public static final fun readToByteArray (Laws/smithy/kotlin/runtime/io/SdkSource;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toSdkByteReadChannel (Laws/smithy/kotlin/runtime/io/SdkSource;Lkotlinx/coroutines/CoroutineScope;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
+	public static synthetic fun toSdkByteReadChannel$default (Laws/smithy/kotlin/runtime/io/SdkSource;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/SdkByteReadChannel;
 }
 
 public final class aws/smithy/kotlin/runtime/io/SdkSourceKt {
@@ -689,12 +924,104 @@ public final class aws/smithy/kotlin/runtime/io/SdkSourceKt {
 }
 
 public final class aws/smithy/kotlin/runtime/io/internal/ConvertKt {
+	public static final fun toOkio (Laws/smithy/kotlin/runtime/io/SdkBuffer;)Lokio/Buffer;
+	public static final fun toOkio (Laws/smithy/kotlin/runtime/io/SdkSink;)Lokio/Sink;
+	public static final fun toOkio (Laws/smithy/kotlin/runtime/io/SdkSource;)Lokio/Source;
+	public static final fun toSdk (Lokio/Buffer;)Laws/smithy/kotlin/runtime/io/SdkBuffer;
+	public static final fun toSdk (Lokio/Sink;)Laws/smithy/kotlin/runtime/io/SdkSink;
+	public static final fun toSdk (Lokio/Source;)Laws/smithy/kotlin/runtime/io/SdkSource;
+}
+
+public final class aws/smithy/kotlin/runtime/io/internal/JobChannel : aws/smithy/kotlin/runtime/io/SdkByteChannel {
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteChannel;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/io/SdkByteChannel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun attachJob (Lkotlinx/coroutines/Job;)V
+	public fun cancel (Ljava/lang/Throwable;)Z
+	public fun close ()V
+	public fun close (Ljava/lang/Throwable;)Z
+	public fun flush ()V
+	public fun getAutoFlush ()Z
+	public fun getAvailableForRead ()I
+	public fun getAvailableForWrite ()I
+	public fun getClosedCause ()Ljava/lang/Throwable;
+	public fun getTotalBytesWritten ()J
+	public fun isClosedForRead ()Z
+	public fun isClosedForWrite ()Z
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun write (Laws/smithy/kotlin/runtime/io/SdkBuffer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/internal/SdkDispatchers {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/io/internal/SdkDispatchers;
+	public final fun getIO ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public abstract class aws/smithy/kotlin/runtime/io/internal/SdkSinkObserver : aws/smithy/kotlin/runtime/io/SdkSink {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkSink;)V
+	public fun close ()V
+	public fun flush ()V
+	public abstract fun observe ([BII)V
+	public fun write (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/io/internal/SdkSourceObserver : aws/smithy/kotlin/runtime/io/SdkSource {
+	public fun <init> (Laws/smithy/kotlin/runtime/io/SdkSource;)V
+	public fun close ()V
+	public abstract fun observe ([BII)V
+	public fun read (Laws/smithy/kotlin/runtime/io/SdkBuffer;J)J
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public abstract fun handle (Ljava/lang/Object;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/io/middleware/MiddlewareKt {
+	public static final fun decorate (Laws/smithy/kotlin/runtime/io/Handler;[Laws/smithy/kotlin/runtime/io/middleware/Middleware;)Laws/smithy/kotlin/runtime/io/Handler;
+}
+
+public final class aws/smithy/kotlin/runtime/io/middleware/MiddlewareLambda : aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public fun <init> (Lkotlin/jvm/functions/Function3;)V
+	public final fun copy (Lkotlin/jvm/functions/Function3;)Laws/smithy/kotlin/runtime/io/middleware/MiddlewareLambda;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/io/middleware/MiddlewareLambda;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/io/middleware/MiddlewareLambda;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun handle (Ljava/lang/Object;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/io/middleware/ModifyRequest {
+	public abstract fun modifyRequest (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/io/middleware/ModifyResponse {
+	public abstract fun modifyResponse (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/io/middleware/Phase : aws/smithy/kotlin/runtime/io/middleware/Middleware {
+	public fun <init> ()V
+	public fun handle (Ljava/lang/Object;Laws/smithy/kotlin/runtime/io/Handler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun intercept (Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun intercept$default (Laws/smithy/kotlin/runtime/io/middleware/Phase;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public final fun register (Laws/smithy/kotlin/runtime/io/middleware/Middleware;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;)V
+	public final fun register (Laws/smithy/kotlin/runtime/io/middleware/ModifyRequest;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;)V
+	public final fun register (Laws/smithy/kotlin/runtime/io/middleware/ModifyResponse;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;)V
+	public static synthetic fun register$default (Laws/smithy/kotlin/runtime/io/middleware/Phase;Laws/smithy/kotlin/runtime/io/middleware/Middleware;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;ILjava/lang/Object;)V
+	public static synthetic fun register$default (Laws/smithy/kotlin/runtime/io/middleware/Phase;Laws/smithy/kotlin/runtime/io/middleware/ModifyRequest;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;ILjava/lang/Object;)V
+	public static synthetic fun register$default (Laws/smithy/kotlin/runtime/io/middleware/Phase;Laws/smithy/kotlin/runtime/io/middleware/ModifyResponse;Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;ILjava/lang/Object;)V
+}
+
+public final class aws/smithy/kotlin/runtime/io/middleware/Phase$Order : java/lang/Enum {
+	public static final field After Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;
+	public static final field Before Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;
+	public static fun values ()[Laws/smithy/kotlin/runtime/io/middleware/Phase$Order;
 }
 
 public final class aws/smithy/kotlin/runtime/net/DefaultHostResolverJVMKt {
+	public static final fun toHostAddress (Ljava/net/InetAddress;)Laws/smithy/kotlin/runtime/net/HostAddress;
+	public static final fun toInetAddress (Laws/smithy/kotlin/runtime/net/HostAddress;)Ljava/net/InetAddress;
 }
 
 public abstract class aws/smithy/kotlin/runtime/net/Host {
@@ -727,12 +1054,99 @@ public final class aws/smithy/kotlin/runtime/net/Host$IpAddress : aws/smithy/kot
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/net/HostAddress {
+	public fun <init> (Ljava/lang/String;Laws/smithy/kotlin/runtime/net/IpAddr;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Laws/smithy/kotlin/runtime/net/IpAddr;
+	public final fun copy (Ljava/lang/String;Laws/smithy/kotlin/runtime/net/IpAddr;)Laws/smithy/kotlin/runtime/net/HostAddress;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/net/HostAddress;Ljava/lang/String;Laws/smithy/kotlin/runtime/net/IpAddr;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/net/HostAddress;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Laws/smithy/kotlin/runtime/net/IpAddr;
+	public final fun getHostname ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/net/HostKt {
 	public static final fun toUrlString (Laws/smithy/kotlin/runtime/net/Host;)Ljava/lang/String;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/net/HostResolver {
+	public static final field Companion Laws/smithy/kotlin/runtime/net/HostResolver$Companion;
+	public abstract fun purgeCache (Laws/smithy/kotlin/runtime/net/HostAddress;)V
+	public abstract fun reportFailure (Laws/smithy/kotlin/runtime/net/HostAddress;)V
+	public abstract fun resolve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/net/HostResolver$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/net/HostResolver;
+}
+
 public final class aws/smithy/kotlin/runtime/net/HostResolver$DefaultImpls {
 	public static synthetic fun purgeCache$default (Laws/smithy/kotlin/runtime/net/HostResolver;Laws/smithy/kotlin/runtime/net/HostAddress;ILjava/lang/Object;)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/net/IpAddr {
+	public static final field Companion Laws/smithy/kotlin/runtime/net/IpAddr$Companion;
+	public abstract fun getAddress ()Ljava/lang/String;
+	public abstract fun getOctets ()[B
+	public abstract fun isLoopBack ()Z
+	public abstract fun isUnspecified ()Z
+}
+
+public final class aws/smithy/kotlin/runtime/net/IpAddr$Companion {
+	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/IpAddr;
+}
+
+public final class aws/smithy/kotlin/runtime/net/IpV4Addr : aws/smithy/kotlin/runtime/net/IpAddr {
+	public static final field Companion Laws/smithy/kotlin/runtime/net/IpV4Addr$Companion;
+	public synthetic fun <init> (BBBBLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([B)V
+	public final fun component1 ()[B
+	public final fun copy ([B)Laws/smithy/kotlin/runtime/net/IpV4Addr;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/net/IpV4Addr;[BILjava/lang/Object;)Laws/smithy/kotlin/runtime/net/IpV4Addr;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAddress ()Ljava/lang/String;
+	public fun getOctets ()[B
+	public fun hashCode ()I
+	public fun isLoopBack ()Z
+	public fun isUnspecified ()Z
+	public final fun toMappedIpv6 ()Laws/smithy/kotlin/runtime/net/IpV6Addr;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/IpV4Addr$Companion {
+	public final fun getLOCALHOST ()Laws/smithy/kotlin/runtime/net/IpV4Addr;
+	public final fun getUNSPECIFIED ()Laws/smithy/kotlin/runtime/net/IpV4Addr;
+	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/IpV4Addr;
+}
+
+public final class aws/smithy/kotlin/runtime/net/IpV6Addr : aws/smithy/kotlin/runtime/net/IpAddr {
+	public static final field Companion Laws/smithy/kotlin/runtime/net/IpV6Addr$Companion;
+	public synthetic fun <init> (SSSSSSSSLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (SSSSSSSSLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BLjava/lang/String;)V
+	public synthetic fun <init> ([BLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy ([BLjava/lang/String;)Laws/smithy/kotlin/runtime/net/IpV6Addr;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/net/IpV6Addr;[BLjava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/net/IpV6Addr;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAddress ()Ljava/lang/String;
+	public fun getOctets ()[B
+	public final fun getSegments-amswpOA ()[S
+	public final fun getZoneId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isLoopBack ()Z
+	public fun isUnspecified ()Z
+	public final fun toIpv4Mapped ()Laws/smithy/kotlin/runtime/net/IpV4Addr;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/net/IpV6Addr$Companion {
+	public final fun getLOCALHOST ()Laws/smithy/kotlin/runtime/net/IpV6Addr;
+	public final fun getUNSPECIFIED ()Laws/smithy/kotlin/runtime/net/IpV6Addr;
+	public final fun parse (Ljava/lang/String;)Laws/smithy/kotlin/runtime/net/IpV6Addr;
 }
 
 public final class aws/smithy/kotlin/runtime/net/Scheme {
@@ -759,9 +1173,13 @@ public final class aws/smithy/kotlin/runtime/net/Scheme$Companion {
 }
 
 public final class aws/smithy/kotlin/runtime/net/SchemeKt {
+	public static final fun isSecure (Laws/smithy/kotlin/runtime/net/Scheme;)Z
 }
 
 public final class aws/smithy/kotlin/runtime/net/TextKt {
+	public static final fun isIpv4 (Ljava/lang/String;)Z
+	public static final fun isIpv6 (Ljava/lang/String;)Z
+	public static final fun isValidHostname (Ljava/lang/String;)Z
 }
 
 public final class aws/smithy/kotlin/runtime/net/TlsVersion : java/lang/Enum {
@@ -849,6 +1267,7 @@ public final class aws/smithy/kotlin/runtime/net/url/QueryParameters$Builder : a
 	public fun containsValue (Ljava/util/List;)Z
 	public final fun copyFrom (Laws/smithy/kotlin/runtime/net/url/QueryParameters$Builder;)V
 	public final fun copyFrom (Laws/smithy/kotlin/runtime/net/url/QueryParameters;)V
+	public final fun decodedParameters (Laws/smithy/kotlin/runtime/text/encoding/Encoding;Lkotlin/jvm/functions/Function1;)V
 	public final fun decodedParameters (Lkotlin/jvm/functions/Function1;)V
 	public final fun encodedParameters (Lkotlin/jvm/functions/Function1;)V
 	public final fun entrySet ()Ljava/util/Set;
@@ -1172,6 +1591,7 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy 
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
 	public abstract fun getMaxAttempts ()I
+	public abstract fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
@@ -1289,6 +1709,7 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayPro
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+	public abstract fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
@@ -1316,6 +1737,7 @@ public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWit
 	public final fun getJitter ()D
 	public final fun getMaxBackoff-UwyO8pc ()J
 	public final fun getScaleFactor ()D
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/ExponentialBackoffWithJitter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
@@ -1348,6 +1770,7 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimi
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config {
+	public abstract fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config$Builder {
@@ -1369,6 +1792,7 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTok
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config {
+	public abstract fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
@@ -1398,6 +1822,7 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 	public final fun getRetryCost ()I
 	public final fun getTimeoutRetryCost ()I
 	public final fun getUseCircuitBreakerMode ()Z
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
@@ -1421,6 +1846,46 @@ public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBuc
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config$Companion {
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket$Config;
+}
+
+public abstract class aws/smithy/kotlin/runtime/retries/policy/Acceptor {
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;)V
+	public final fun evaluate (Ljava/lang/Object;Ljava/lang/Object;)Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;
+	public final fun getState ()Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;
+	protected abstract fun matches (Ljava/lang/Object;Ljava/lang/Object;)Z
+}
+
+public final class aws/smithy/kotlin/runtime/retries/policy/AcceptorRetryPolicy : aws/smithy/kotlin/runtime/retries/policy/RetryPolicy {
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public fun evaluate (Ljava/lang/Object;)Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/policy/ErrorTypeAcceptor : aws/smithy/kotlin/runtime/retries/policy/Acceptor {
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Ljava/lang/String;)V
+	public final fun getErrorType ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/policy/InputOutputAcceptor : aws/smithy/kotlin/runtime/retries/policy/Acceptor {
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Lkotlin/jvm/functions/Function1;)V
+	public final fun getMatcher ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/policy/InputOutputAcceptor$InputOutput {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;)Laws/smithy/kotlin/runtime/retries/policy/InputOutputAcceptor$InputOutput;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/retries/policy/InputOutputAcceptor$InputOutput;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/retries/policy/InputOutputAcceptor$InputOutput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInput ()Ljava/lang/Object;
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/policy/OutputAcceptor : aws/smithy/kotlin/runtime/retries/policy/Acceptor {
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Lkotlin/jvm/functions/Function1;)V
+	public final fun getMatcher ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract class aws/smithy/kotlin/runtime/retries/policy/RetryDirective {
@@ -1470,10 +1935,32 @@ public final class aws/smithy/kotlin/runtime/retries/policy/StandardRetryPolicy$
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/policy/StandardRetryPolicy;
 }
 
+public final class aws/smithy/kotlin/runtime/retries/policy/SuccessAcceptor : aws/smithy/kotlin/runtime/retries/policy/Acceptor {
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Z)V
+	public final fun getSuccess ()Z
+}
+
+public final class aws/smithy/kotlin/runtime/text/Scanner {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getText ()Ljava/lang/String;
+	public final fun ifStartsWith (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun ifStartsWithSkip (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun optionalAndSkip ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun requireAndSkip ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun startsWith (Ljava/lang/String;)Z
+	public fun toString ()Ljava/lang/String;
+	public final fun upToOrEnd ([Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class aws/smithy/kotlin/runtime/text/TextKt {
+	public static final fun ensurePrefix (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun ensureSuffix (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class aws/smithy/kotlin/runtime/text/Utf8Kt {
+	public static final fun byteCountUtf8 (B)I
+	public static final fun codePointToChars (Lkotlin/jvm/internal/CharCompanionObject;I)[C
+	public static final fun isSupplementaryCodePoint (Lkotlin/jvm/internal/CharCompanionObject;I)Z
 }
 
 public final class aws/smithy/kotlin/runtime/text/encoding/Base64Kt {
@@ -1503,12 +1990,52 @@ public final class aws/smithy/kotlin/runtime/text/encoding/Encodable$Companion {
 	public final fun getEmpty ()Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/text/encoding/Encoding {
+	public static final field Companion Laws/smithy/kotlin/runtime/text/encoding/Encoding$Companion;
+	public abstract fun decode (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun encodableFromDecoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public abstract fun encodableFromEncoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public abstract fun encode (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/text/encoding/Encoding$Companion {
+}
+
 public final class aws/smithy/kotlin/runtime/text/encoding/Encoding$DefaultImpls {
 	public static fun encodableFromDecoded (Laws/smithy/kotlin/runtime/text/encoding/Encoding;Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 	public static fun encodableFromEncoded (Laws/smithy/kotlin/runtime/text/encoding/Encoding;Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
 }
 
 public final class aws/smithy/kotlin/runtime/text/encoding/HexKt {
+	public static final fun decodeHex (Ljava/lang/String;)[B
+	public static final fun decodeHexBytes (Ljava/lang/String;)[B
+	public static final fun encodeHex ([B)Ljava/lang/String;
+	public static final fun encodeToHex ([B)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/text/encoding/PercentEncoding : aws/smithy/kotlin/runtime/text/encoding/Encoding {
+	public static final field Companion Laws/smithy/kotlin/runtime/text/encoding/PercentEncoding$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decode (Ljava/lang/String;)Ljava/lang/String;
+	public fun encodableFromDecoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public fun encodableFromEncoded (Ljava/lang/String;)Laws/smithy/kotlin/runtime/text/encoding/Encodable;
+	public fun encode (Ljava/lang/String;)Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getSpecialMapping ()Ljava/util/Map;
+	public final fun getValidChars ()Ljava/util/Set;
+}
+
+public final class aws/smithy/kotlin/runtime/text/encoding/PercentEncoding$Companion {
+	public final fun getFormUrl ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getFragment ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getHost ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getPath ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getQuery ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getSigV4 ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getSmithyLabel ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
+	public final fun getUserInfo ()Laws/smithy/kotlin/runtime/text/encoding/Encoding;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/time/Clock {
@@ -1562,6 +2089,14 @@ public final class aws/smithy/kotlin/runtime/time/InstantKt {
 	public static final fun until (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/Instant;)J
 }
 
+public final class aws/smithy/kotlin/runtime/time/ManualClock : aws/smithy/kotlin/runtime/time/Clock {
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/time/Instant;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/time/Instant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun advance-LRDsOJo (J)V
+	public fun now ()Laws/smithy/kotlin/runtime/time/Instant;
+}
+
 public class aws/smithy/kotlin/runtime/time/ParseException : aws/smithy/kotlin/runtime/SdkBaseException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;I)V
 }
@@ -1581,11 +2116,32 @@ public abstract interface class aws/smithy/kotlin/runtime/util/Buildable {
 	public abstract fun build ()Ljava/lang/Object;
 }
 
+public final class aws/smithy/kotlin/runtime/util/CachedValue : java/io/Closeable {
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/ExpiringValue;JLaws/smithy/kotlin/runtime/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/ExpiringValue;JLaws/smithy/kotlin/runtime/time/Clock;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Object;Laws/smithy/kotlin/runtime/time/Instant;JLaws/smithy/kotlin/runtime/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Object;Laws/smithy/kotlin/runtime/time/Instant;JLaws/smithy/kotlin/runtime/time/Clock;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun get ()Ljava/lang/Object;
+	public final fun getOrLoad (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun isExpired ()Z
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/util/CanDeepCopy {
 	public abstract fun deepCopy ()Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/util/CoroutineUtilsKt {
+	public static final fun derivedName (Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;)Lkotlinx/coroutines/CoroutineName;
+}
+
+public final class aws/smithy/kotlin/runtime/util/DslBuilderProperty {
+	public fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun dsl (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun getInstance ()Ljava/lang/Object;
+	public final fun getSupply ()Lkotlin/jvm/functions/Function0;
+	public final fun setInstance (Ljava/lang/Object;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/util/DslFactory {
@@ -1595,6 +2151,19 @@ public abstract interface class aws/smithy/kotlin/runtime/util/DslFactory {
 public abstract interface class aws/smithy/kotlin/runtime/util/EnvironmentProvider {
 	public abstract fun getAllEnvVars ()Ljava/util/Map;
 	public abstract fun getenv (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/util/ExpiringValue {
+	public fun <init> (Ljava/lang/Object;Laws/smithy/kotlin/runtime/time/Instant;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Laws/smithy/kotlin/runtime/time/Instant;
+	public final fun copy (Ljava/lang/Object;Laws/smithy/kotlin/runtime/time/Instant;)Laws/smithy/kotlin/runtime/util/ExpiringValue;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/util/ExpiringValue;Ljava/lang/Object;Laws/smithy/kotlin/runtime/time/Instant;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/util/ExpiringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpiresAt ()Laws/smithy/kotlin/runtime/time/Instant;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/util/Filesystem {
@@ -1611,12 +2180,28 @@ public final class aws/smithy/kotlin/runtime/util/Filesystem$Companion {
 }
 
 public final class aws/smithy/kotlin/runtime/util/FlowUtilKt {
+	public static final fun mergeSequential ([Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class aws/smithy/kotlin/runtime/util/JMESPathKt {
+	public static final fun getLength (Ljava/util/Collection;)I
+	public static final fun toNumber (D)D
+	public static final fun toNumber (F)F
+	public static final fun toNumber (I)I
+	public static final fun toNumber (J)J
+	public static final fun toNumber (Ljava/lang/Object;)Ljava/lang/Void;
+	public static final fun toNumber (Ljava/lang/String;)Ljava/lang/Double;
+	public static final fun toNumber (S)S
+	public static final fun truthiness (Ljava/lang/Object;)Z
+	public static final fun type (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/util/LazyAsyncValue {
+	public abstract fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/util/LazyAsyncValueKt {
+	public static final fun asyncLazy (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/util/LazyAsyncValue;
 }
 
 public final class aws/smithy/kotlin/runtime/util/OperatingSystem {
@@ -1659,6 +2244,7 @@ public abstract interface class aws/smithy/kotlin/runtime/util/PlatformProvider 
 }
 
 public final class aws/smithy/kotlin/runtime/util/PlatformProvider$Companion {
+	public final fun getSystem ()Laws/smithy/kotlin/runtime/util/PlatformProvider;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/util/PropertyProvider {
@@ -1666,6 +2252,50 @@ public abstract interface class aws/smithy/kotlin/runtime/util/PropertyProvider 
 	public abstract fun getProperty (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class aws/smithy/kotlin/runtime/util/SingleFlightGroup {
+	public fun <init> ()V
+	public final fun singleFlight (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider : aws/smithy/kotlin/runtime/util/Filesystem, aws/smithy/kotlin/runtime/util/PlatformProvider {
+	public static final field Companion Laws/smithy/kotlin/runtime/util/TestPlatformProvider$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun fileExists (Ljava/lang/String;)Z
+	public fun getAllEnvVars ()Ljava/util/Map;
+	public fun getAllProperties ()Ljava/util/Map;
+	public fun getFilePathSeparator ()Ljava/lang/String;
+	public fun getProperty (Ljava/lang/String;)Ljava/lang/String;
+	public fun getenv (Ljava/lang/String;)Ljava/lang/String;
+	public fun isAndroid ()Z
+	public fun isBrowser ()Z
+	public fun isJvm ()Z
+	public fun isNative ()Z
+	public fun isNode ()Z
+	public fun osInfo ()Laws/smithy/kotlin/runtime/util/OperatingSystem;
+	public fun readFileOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun writeFile (Ljava/lang/String;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider$Companion {
+}
+
+public final class aws/smithy/kotlin/runtime/util/Uuid {
+	public static final field Companion Laws/smithy/kotlin/runtime/util/Uuid$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Laws/smithy/kotlin/runtime/util/Uuid;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/util/Uuid;JJILjava/lang/Object;)Laws/smithy/kotlin/runtime/util/Uuid;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHigh ()J
+	public final fun getLow ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/util/Uuid$Companion {
+	public final fun random ()Laws/smithy/kotlin/runtime/util/Uuid;
 }
 

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2,6 +2,7 @@ public class aws/smithy/kotlin/runtime/ClientException : aws/smithy/kotlin/runti
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
 }
 
 public class aws/smithy/kotlin/runtime/ErrorMetadata {

--- a/runtime/serde/api/serde.api
+++ b/runtime/serde/api/serde.api
@@ -5,10 +5,218 @@ public final class aws/smithy/kotlin/runtime/serde/DeserializationException : aw
 	public fun <init> (Ljava/lang/Throwable;)V
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer {
+	public abstract fun deserializeList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$ElementIterator;
+	public abstract fun deserializeMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$EntryIterator;
+	public abstract fun deserializeStruct (Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer$ElementIterator : aws/smithy/kotlin/runtime/serde/PrimitiveDeserializer {
+	public abstract fun hasNextElement ()Z
+	public abstract fun nextHasValue ()Z
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer$EntryIterator : aws/smithy/kotlin/runtime/serde/PrimitiveDeserializer {
+	public abstract fun hasNextEntry ()Z
+	public abstract fun key ()Ljava/lang/String;
+	public abstract fun nextHasValue ()Z
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator : aws/smithy/kotlin/runtime/serde/PrimitiveDeserializer {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator$Companion;
+	public static final field UNKNOWN_FIELD I
+	public abstract fun findNextFieldIndex ()Ljava/lang/Integer;
+	public abstract fun skipValue ()V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator$Companion {
+	public static final field UNKNOWN_FIELD I
+}
+
 public final class aws/smithy/kotlin/runtime/serde/DeserializerKt {
+	public static final fun deserializeList (Laws/smithy/kotlin/runtime/serde/Deserializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun deserializeMap (Laws/smithy/kotlin/runtime/serde/Deserializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun deserializeStruct (Laws/smithy/kotlin/runtime/serde/Deserializer;Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/FieldTrait {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/ListSerializer : aws/smithy/kotlin/runtime/serde/PrimitiveSerializer {
+	public abstract fun endList ()V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/MapSerializer : aws/smithy/kotlin/runtime/serde/PrimitiveSerializer {
+	public abstract fun endMap ()V
+	public abstract fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/content/Document;)V
+	public abstract fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public abstract fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Byte;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Character;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Double;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Float;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Integer;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Long;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/Short;)V
+	public abstract fun entry (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun listEntry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun mapEntry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/PrimitiveDeserializer {
+	public abstract fun deserializeBigDecimal ()Ljava/math/BigDecimal;
+	public abstract fun deserializeBigInteger ()Ljava/math/BigInteger;
+	public abstract fun deserializeBoolean ()Z
+	public abstract fun deserializeByte ()B
+	public abstract fun deserializeDocument ()Laws/smithy/kotlin/runtime/content/Document;
+	public abstract fun deserializeDouble ()D
+	public abstract fun deserializeFloat ()F
+	public abstract fun deserializeInt ()I
+	public abstract fun deserializeLong ()J
+	public abstract fun deserializeNull ()Ljava/lang/Void;
+	public abstract fun deserializeShort ()S
+	public abstract fun deserializeString ()Ljava/lang/String;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/PrimitiveSerializer {
+	public abstract fun serializeBigDecimal (Ljava/math/BigDecimal;)V
+	public abstract fun serializeBigInteger (Ljava/math/BigInteger;)V
+	public abstract fun serializeBoolean (Z)V
+	public abstract fun serializeByte (B)V
+	public abstract fun serializeChar (C)V
+	public abstract fun serializeDocument (Laws/smithy/kotlin/runtime/content/Document;)V
+	public abstract fun serializeDouble (D)V
+	public abstract fun serializeFloat (F)V
+	public abstract fun serializeInstant (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public abstract fun serializeInt (I)V
+	public abstract fun serializeLong (J)V
+	public abstract fun serializeNull ()V
+	public abstract fun serializeSdkSerializable (Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public abstract fun serializeShort (S)V
+	public abstract fun serializeString (Ljava/lang/String;)V
+}
+
+public class aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/SerialKind;ILjava/util/Set;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/serde/SerialKind;ILjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/SerialKind;Ljava/util/Set;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/SerialKind;[Laws/smithy/kotlin/runtime/serde/FieldTrait;)V
+	public final fun getIndex ()I
+	public final fun getKind ()Laws/smithy/kotlin/runtime/serde/SerialKind;
+	public final fun getTraits ()Ljava/util/Set;
+	public final fun setIndex (I)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor$Companion {
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor : aws/smithy/kotlin/runtime/serde/SdkFieldDescriptor {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor$Companion;
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFields ()Ljava/util/List;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor$Builder {
+	public fun <init> ()V
+	public final fun build ()Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;
+	public final fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)V
+	public final fun trait (Laws/smithy/kotlin/runtime/serde/FieldTrait;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SdkObjectDescriptor$Companion {
+	public final fun build (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/SdkSerializable {
+	public abstract fun serialize (Laws/smithy/kotlin/runtime/serde/Serializer;)V
 }
 
 public final class aws/smithy/kotlin/runtime/serde/SdkSerializableKt {
+	public static final fun asSdkSerializable (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Laws/smithy/kotlin/runtime/serde/SdkSerializable;
+	public static final fun field (Laws/smithy/kotlin/runtime/serde/StructSerializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)V
+}
+
+public abstract class aws/smithy/kotlin/runtime/serde/SerialKind {
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$BigNumber : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$BigNumber;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Blob : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Blob;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Boolean : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Boolean;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Byte : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Byte;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Char : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Char;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Document : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Document;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Double : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Double;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Enum : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Enum;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Float : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Float;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$IntEnum : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$IntEnum;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Integer : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Integer;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$List : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$List;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Long : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Long;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Map : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Map;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Short : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Short;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$String : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Struct : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Struct;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Timestamp : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Timestamp;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SerialKind$Unit : aws/smithy/kotlin/runtime/serde/SerialKind {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SerialKind$Unit;
 }
 
 public final class aws/smithy/kotlin/runtime/serde/SerializationException : aws/smithy/kotlin/runtime/ClientException {
@@ -18,6 +226,42 @@ public final class aws/smithy/kotlin/runtime/serde/SerializationException : aws/
 	public fun <init> (Ljava/lang/Throwable;)V
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/serde/Serializer : aws/smithy/kotlin/runtime/serde/PrimitiveSerializer {
+	public abstract fun beginList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/ListSerializer;
+	public abstract fun beginMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/MapSerializer;
+	public abstract fun beginStruct (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/StructSerializer;
+	public abstract fun toByteArray ()[B
+}
+
 public final class aws/smithy/kotlin/runtime/serde/SerializerKt {
+	public static final fun serializeList (Laws/smithy/kotlin/runtime/serde/Serializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public static final fun serializeMap (Laws/smithy/kotlin/runtime/serde/Serializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public static final fun serializeStruct (Laws/smithy/kotlin/runtime/serde/Serializer;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/SparseValues : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/SparseValues;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/StructSerializer : aws/smithy/kotlin/runtime/serde/PrimitiveSerializer {
+	public abstract fun endStruct ()V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;B)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;C)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;D)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;F)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;I)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;J)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/content/Document;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/lang/String;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigDecimal;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigInteger;)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;S)V
+	public abstract fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Z)V
+	public abstract fun listField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun mapField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun nullField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)V
+	public abstract fun structField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/runtime/serde/serde-form-url/api/serde-form-url.api
+++ b/runtime/serde/serde-form-url/api/serde-form-url.api
@@ -1,3 +1,68 @@
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMember ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/serde/formurl/FormUrlCollectionName;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlFlattened : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/formurl/FormUrlFlattened;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/serde/formurl/FormUrlMapName;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerialName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlSerialName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/formurl/FormUrlSerialName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/formurl/FormUrlSerialName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class aws/smithy/kotlin/runtime/serde/formurl/FormUrlSerializerKt {
+	public static final fun FormUrlSerializer ()Laws/smithy/kotlin/runtime/serde/Serializer;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/formurl/QueryLiteral : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/formurl/QueryLiteral;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/formurl/QueryLiteral;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/formurl/QueryLiteral;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/runtime/serde/serde-json/api/serde-json.api
+++ b/runtime/serde/serde-json/api/serde-json.api
@@ -1,9 +1,224 @@
+public final class aws/smithy/kotlin/runtime/serde/json/IgnoreKey : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/json/IgnoreKey;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/IgnoreKey;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/IgnoreKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonDeserializer : aws/smithy/kotlin/runtime/serde/Deserializer, aws/smithy/kotlin/runtime/serde/Deserializer$ElementIterator, aws/smithy/kotlin/runtime/serde/Deserializer$EntryIterator, aws/smithy/kotlin/runtime/serde/PrimitiveDeserializer {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/json/JsonDeserializer$Companion;
+	public fun <init> ([B)V
+	public fun deserializeBigDecimal ()Ljava/math/BigDecimal;
+	public fun deserializeBigInteger ()Ljava/math/BigInteger;
+	public fun deserializeBoolean ()Z
+	public fun deserializeByte ()B
+	public fun deserializeDocument ()Laws/smithy/kotlin/runtime/content/Document;
+	public fun deserializeDouble ()D
+	public fun deserializeFloat ()F
+	public fun deserializeInt ()I
+	public fun deserializeList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$ElementIterator;
+	public fun deserializeLong ()J
+	public fun deserializeMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$EntryIterator;
+	public fun deserializeNull ()Ljava/lang/Void;
+	public fun deserializeShort ()S
+	public fun deserializeString ()Ljava/lang/String;
+	public fun deserializeStruct (Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator;
+	public fun hasNextElement ()Z
+	public fun hasNextEntry ()Z
+	public fun key ()Ljava/lang/String;
+	public fun nextHasValue ()Z
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonDeserializer$Companion {
+}
+
 public final class aws/smithy/kotlin/runtime/serde/json/JsonFieldTraitsKt {
+	public static final fun getSerialName (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonSerialName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/json/JsonSerialName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/JsonSerialName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonSerialName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonSerializer : aws/smithy/kotlin/runtime/serde/ListSerializer, aws/smithy/kotlin/runtime/serde/MapSerializer, aws/smithy/kotlin/runtime/serde/Serializer, aws/smithy/kotlin/runtime/serde/StructSerializer {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/json/JsonSerializer$Companion;
+	public fun <init> ()V
+	public fun beginList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/ListSerializer;
+	public fun beginMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/MapSerializer;
+	public fun beginStruct (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/StructSerializer;
+	public fun endList ()V
+	public fun endMap ()V
+	public fun endStruct ()V
+	public fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/content/Document;)V
+	public fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public fun entry (Ljava/lang/String;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Byte;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Character;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Double;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Float;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Integer;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Long;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/Short;)V
+	public fun entry (Ljava/lang/String;Ljava/lang/String;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;B)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;C)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;D)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;F)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;I)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;J)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/content/Document;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/lang/String;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigDecimal;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigInteger;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;S)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Z)V
+	public fun listEntry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun listField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun mapEntry (Ljava/lang/String;Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun mapField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun nullField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)V
+	public fun serializeBigDecimal (Ljava/math/BigDecimal;)V
+	public fun serializeBigInteger (Ljava/math/BigInteger;)V
+	public fun serializeBoolean (Z)V
+	public fun serializeByte (B)V
+	public fun serializeChar (C)V
+	public fun serializeDocument (Laws/smithy/kotlin/runtime/content/Document;)V
+	public fun serializeDouble (D)V
+	public fun serializeFloat (F)V
+	public fun serializeInstant (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public fun serializeInt (I)V
+	public fun serializeLong (J)V
+	public fun serializeNull ()V
+	public fun serializeSdkSerializable (Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public fun serializeShort (S)V
+	public fun serializeString (Ljava/lang/String;)V
+	public fun structField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun toByteArray ()[B
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonSerializer$Companion {
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/json/JsonStreamReader {
+	public abstract fun nextToken ()Laws/smithy/kotlin/runtime/serde/json/JsonToken;
+	public abstract fun peek ()Laws/smithy/kotlin/runtime/serde/json/JsonToken;
+	public abstract fun skipNext ()V
 }
 
 public final class aws/smithy/kotlin/runtime/serde/json/JsonStreamReaderKt {
+	public static final fun jsonStreamReader ([B)Laws/smithy/kotlin/runtime/serde/json/JsonStreamReader;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/json/JsonStreamWriter {
+	public abstract fun beginArray ()V
+	public abstract fun beginObject ()V
+	public abstract fun endArray ()V
+	public abstract fun endObject ()V
+	public abstract fun getBytes ()[B
+	public abstract fun writeName (Ljava/lang/String;)V
+	public abstract fun writeNull ()V
+	public abstract fun writeRawValue (Ljava/lang/String;)V
+	public abstract fun writeValue (B)V
+	public abstract fun writeValue (D)V
+	public abstract fun writeValue (F)V
+	public abstract fun writeValue (I)V
+	public abstract fun writeValue (J)V
+	public abstract fun writeValue (Ljava/lang/Number;)V
+	public abstract fun writeValue (Ljava/lang/String;)V
+	public abstract fun writeValue (Ljava/math/BigDecimal;)V
+	public abstract fun writeValue (Ljava/math/BigInteger;)V
+	public abstract fun writeValue (S)V
+	public abstract fun writeValue (Z)V
 }
 
 public final class aws/smithy/kotlin/runtime/serde/json/JsonStreamWriterKt {
+	public static final fun jsonStreamWriter (Z)Laws/smithy/kotlin/runtime/serde/json/JsonStreamWriter;
+	public static synthetic fun jsonStreamWriter$default (ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonStreamWriter;
+}
+
+public abstract class aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$BeginArray : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$BeginArray;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$BeginObject : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$BeginObject;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$Bool : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Bool;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/JsonToken$Bool;ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Bool;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$EndArray : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$EndArray;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$EndDocument : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$EndDocument;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$EndObject : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$EndObject;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$Name : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Name;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/JsonToken$Name;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Name;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$Null : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/json/JsonToken$Null;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$Number : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Number;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/JsonToken$Number;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$Number;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/json/JsonToken$String : aws/smithy/kotlin/runtime/serde/json/JsonToken {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$String;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/json/JsonToken$String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/json/JsonToken$String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/runtime/serde/serde-xml/api/serde-xml.api
+++ b/runtime/serde/serde-xml/api/serde-xml.api
@@ -1,9 +1,189 @@
+public class aws/smithy/kotlin/runtime/serde/xml/AbstractXmlNamespaceTrait {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public final fun isDefault ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/Flattened : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/Flattened;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlAliasName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlAliasName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlAliasName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlAliasName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlAttribute : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/XmlAttribute;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlCollectionName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/xml/XmlCollectionName$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlCollectionName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlCollectionName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlCollectionName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElement ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlCollectionName$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/serde/xml/XmlCollectionName;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlCollectionValueNamespace : aws/smithy/kotlin/runtime/serde/xml/AbstractXmlNamespaceTrait, aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlDeserializer : aws/smithy/kotlin/runtime/serde/Deserializer {
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;Z)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BZ)V
+	public synthetic fun <init> ([BZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun deserializeList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$ElementIterator;
+	public fun deserializeMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$EntryIterator;
+	public fun deserializeStruct (Laws/smithy/kotlin/runtime/serde/SdkObjectDescriptor;)Laws/smithy/kotlin/runtime/serde/Deserializer$FieldIterator;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlError : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/XmlError;
+	public final fun getErrorTag ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlMapKeyNamespace : aws/smithy/kotlin/runtime/serde/xml/AbstractXmlNamespaceTrait, aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlMapName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/xml/XmlMapName$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlMapName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlMapName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlMapName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntry ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlMapName$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/serde/xml/XmlMapName;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlNamespace : aws/smithy/kotlin/runtime/serde/xml/AbstractXmlNamespaceTrait, aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlSerialName : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlSerialName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlSerialName;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlSerialName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlSerializer : aws/smithy/kotlin/runtime/serde/Serializer, aws/smithy/kotlin/runtime/serde/StructSerializer {
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun beginList (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/ListSerializer;
+	public fun beginMap (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/MapSerializer;
+	public fun beginStruct (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)Laws/smithy/kotlin/runtime/serde/StructSerializer;
+	public fun endStruct ()V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;B)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;C)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;D)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;F)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;I)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;J)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/content/Document;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/lang/String;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigDecimal;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Ljava/math/BigInteger;)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;S)V
+	public fun field (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Z)V
+	public fun listField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun mapField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun nullField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;)V
+	public fun serializeBigDecimal (Ljava/math/BigDecimal;)V
+	public fun serializeBigInteger (Ljava/math/BigInteger;)V
+	public fun serializeBoolean (Z)V
+	public fun serializeByte (B)V
+	public fun serializeChar (C)V
+	public fun serializeDocument (Laws/smithy/kotlin/runtime/content/Document;)V
+	public fun serializeDouble (D)V
+	public fun serializeFloat (F)V
+	public fun serializeInstant (Laws/smithy/kotlin/runtime/time/Instant;Laws/smithy/kotlin/runtime/time/TimestampFormat;)V
+	public fun serializeInt (I)V
+	public fun serializeLong (J)V
+	public fun serializeNull ()V
+	public fun serializeSdkSerializable (Laws/smithy/kotlin/runtime/serde/SdkSerializable;)V
+	public fun serializeShort (S)V
+	public fun serializeString (Ljava/lang/String;)V
+	public fun structField (Laws/smithy/kotlin/runtime/serde/SdkFieldDescriptor;Lkotlin/jvm/functions/Function1;)V
+	public fun toByteArray ()[B
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader {
+	public abstract fun getLastToken ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public abstract fun nextToken ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public abstract fun peek (I)Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public abstract fun skipNext ()V
+	public abstract fun subTreeReader (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
+}
+
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$DefaultImpls {
 	public static synthetic fun peek$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;IILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
 	public static synthetic fun subTreeReader$default (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
 }
 
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth : java/lang/Enum {
+	public static final field CHILD Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
+	public static final field CURRENT Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
+	public static fun values ()[Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;
+}
+
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamReaderKt {
+	public static final fun xmlStreamReader ([B)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
+}
+
+public abstract interface class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter {
+	public abstract fun attribute (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public abstract fun endDocument ()V
+	public abstract fun endTag (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public abstract fun getBytes ()[B
+	public abstract fun getText ()Ljava/lang/String;
+	public abstract fun namespacePrefix (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun startDocument ()V
+	public abstract fun startTag (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public abstract fun text (Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
 }
 
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter$DefaultImpls {
@@ -14,8 +194,158 @@ public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter$DefaultIm
 }
 
 public final class aws/smithy/kotlin/runtime/serde/xml/XmlStreamWriterKt {
+	public static final fun text (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;Ljava/lang/Number;)V
+	public static final fun xmlStreamWriter (Z)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+	public static synthetic fun xmlStreamWriter$default (ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamWriter;
+}
+
+public abstract class aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public abstract fun getDepth ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$BeginElement : aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public fun <init> (ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;Ljava/util/Map;Ljava/util/List;)V
+	public synthetic fun <init> (ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()I
+	public final fun component2 ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;Ljava/util/Map;Ljava/util/List;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$BeginElement;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$BeginElement;ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$BeginElement;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Ljava/util/Map;
+	public fun getDepth ()I
+	public final fun getName ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public final fun getNsDeclarations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$EndDocument : aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/XmlToken$EndDocument;
+	public fun getDepth ()I
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$EndElement : aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public fun <init> (ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;)V
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public final fun copy (ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$EndElement;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$EndElement;ILaws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$EndElement;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDepth ()I
+	public final fun getName ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$Namespace {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Namespace;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Namespace;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Namespace;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocal ()Ljava/lang/String;
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$StartDocument : aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/XmlToken$StartDocument;
+	public fun getDepth ()I
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlToken$Text : aws/smithy/kotlin/runtime/serde/xml/XmlToken {
+	public fun <init> (ILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Text;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Text;ILjava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/serde/xml/XmlToken$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDepth ()I
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/XmlUnwrappedOutput : aws/smithy/kotlin/runtime/serde/FieldTrait {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/serde/xml/XmlUnwrappedOutput;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/deserialization/LexingXmlStreamReader : aws/smithy/kotlin/runtime/serde/xml/XmlStreamReader {
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer;)V
+	public fun getLastToken ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public fun nextToken ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public fun peek (I)Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+	public fun skipNext ()V
+	public fun subTreeReader (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader$SubtreeStartDepth;)Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/deserialization/StringTextStream {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun advance (ILjava/lang/String;)V
+	public final fun advanceIf (Ljava/lang/String;)Z
+	public final fun advanceUntilSpace ()V
+	public final fun advanceWhileSpace ()V
+	public final fun peekMatches (Ljava/lang/String;)Z
+	public final fun readOrThrow (Ljava/lang/String;)C
+	public final fun readThrough (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun readUntil (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun readWhileXmlName ()Ljava/lang/String;
+	public final fun rewind (ILjava/lang/String;)V
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/deserialization/XmlLexer {
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/xml/deserialization/StringTextStream;)V
+	public final fun getEndOfDocument ()Z
+	public final fun parseNext ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode {
+	public static final field Companion Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun addChild (Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;)V
+	public final fun getAttributes ()Ljava/util/Map;
+	public final fun getChildren ()Ljava/util/Map;
+	public final fun getName ()Laws/smithy/kotlin/runtime/serde/xml/XmlToken$QualifiedName;
+	public final fun getNamespaces ()Ljava/util/List;
+	public final fun getParent ()Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;
+	public final fun getText ()Ljava/lang/String;
+	public final fun setParent (Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;)V
+	public final fun setText (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/serde/xml/dom/XmlNode$Companion {
+	public final fun parse ([B)Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;
 }
 
 public final class aws/smithy/kotlin/runtime/serde/xml/dom/XmlNodeKt {
+	public static final fun parseDom (Laws/smithy/kotlin/runtime/serde/xml/XmlStreamReader;)Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;
+	public static final fun toXmlString (Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;Z)Ljava/lang/String;
+	public static synthetic fun toXmlString$default (Laws/smithy/kotlin/runtime/serde/xml/dom/XmlNode;ZILjava/lang/Object;)Ljava/lang/String;
 }
 

--- a/runtime/smithy-client/api/smithy-client.api
+++ b/runtime/smithy-client/api/smithy-client.api
@@ -1,3 +1,10 @@
+public abstract class aws/smithy/kotlin/runtime/client/AbstractSdkClientBuilder : aws/smithy/kotlin/runtime/client/SdkClient$Builder {
+	public fun <init> ()V
+	public final fun build ()Laws/smithy/kotlin/runtime/client/SdkClient;
+	public synthetic fun build ()Ljava/lang/Object;
+	protected abstract fun newClient (Laws/smithy/kotlin/runtime/client/SdkClientConfig;)Laws/smithy/kotlin/runtime/client/SdkClient;
+}
+
 public abstract interface class aws/smithy/kotlin/runtime/client/IdempotencyTokenConfig {
 	public abstract fun getIdempotencyTokenProvider ()Laws/smithy/kotlin/runtime/client/IdempotencyTokenProvider;
 }
@@ -131,10 +138,25 @@ public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyCl
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig$Builder {
+	public abstract fun buildRetryStrategyClientConfig ()Laws/smithy/kotlin/runtime/client/RetryStrategyClientConfig;
 	public abstract fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
 	public abstract fun retryStrategy (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun retryStrategy (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
+}
+
+public final class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfigImpl : aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig {
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/RetryStrategy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+}
+
+public final class aws/smithy/kotlin/runtime/client/RetryStrategyClientConfigImpl$BuilderImpl : aws/smithy/kotlin/runtime/client/RetryStrategyClientConfig$Builder {
+	public fun <init> ()V
+	public fun buildRetryStrategyClientConfig ()Laws/smithy/kotlin/runtime/client/RetryStrategyClientConfig;
+	public fun getRetryStrategy ()Laws/smithy/kotlin/runtime/retries/RetryStrategy;
+	public fun retryStrategy (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public fun retryStrategy (Lkotlin/jvm/functions/Function1;)V
+	public fun setRetryStrategy (Laws/smithy/kotlin/runtime/retries/RetryStrategy;)V
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/SdkClient : java/io/Closeable {
@@ -177,6 +199,18 @@ public final class aws/smithy/kotlin/runtime/client/SdkClientOption {
 }
 
 public final class aws/smithy/kotlin/runtime/client/SdkClientOptionKt {
+	public static final fun getIdempotencyTokenProvider (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Laws/smithy/kotlin/runtime/client/IdempotencyTokenProvider;
+	public static final fun getLogMode (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Laws/smithy/kotlin/runtime/client/LogMode;
+	public static final fun getOperationName (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
+	public static final fun getServiceName (Laws/smithy/kotlin/runtime/operation/ExecutionContext;)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/client/config/ClientSettings {
+	public static final field INSTANCE Laws/smithy/kotlin/runtime/client/config/ClientSettings;
+	public final fun getLogMode ()Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public final fun getMaxAttempts ()Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public final fun getMinTlsVersion ()Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
+	public final fun getRetryMode ()Laws/smithy/kotlin/runtime/config/EnvironmentSetting;
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/client/config/CompressionClientConfig {
@@ -197,12 +231,15 @@ public abstract interface annotation class aws/smithy/kotlin/runtime/client/conf
 
 public final class aws/smithy/kotlin/runtime/client/config/RequestCompressionConfig {
 	public static final field Companion Laws/smithy/kotlin/runtime/client/config/RequestCompressionConfig$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/client/config/RequestCompressionConfig$Builder;)V
 	public final fun getCompressionAlgorithms ()Ljava/util/List;
 	public final fun getDisableRequestCompression ()Z
 	public final fun getRequestMinCompressionSizeBytes ()J
+	public final fun toBuilder ()Laws/smithy/kotlin/runtime/client/config/RequestCompressionConfig$Builder;
 }
 
 public final class aws/smithy/kotlin/runtime/client/config/RequestCompressionConfig$Builder {
+	public fun <init> ()V
 	public final fun getCompressionAlgorithms ()Ljava/util/List;
 	public final fun getDisableRequestCompression ()Ljava/lang/Boolean;
 	public final fun getRequestMinCompressionSizeBytes ()Ljava/lang/Long;
@@ -215,9 +252,20 @@ public final class aws/smithy/kotlin/runtime/client/config/RequestCompressionCon
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/client/config/RequestCompressionConfig;
 }
 
+public final class aws/smithy/kotlin/runtime/client/config/RetryMode : java/lang/Enum {
+	public static final field ADAPTIVE Laws/smithy/kotlin/runtime/client/config/RetryMode;
+	public static final field LEGACY Laws/smithy/kotlin/runtime/client/config/RetryMode;
+	public static final field STANDARD Laws/smithy/kotlin/runtime/client/config/RetryMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Laws/smithy/kotlin/runtime/client/config/RetryMode;
+	public static fun values ()[Laws/smithy/kotlin/runtime/client/config/RetryMode;
+}
+
 public final class aws/smithy/kotlin/runtime/client/endpoints/Endpoint {
 	public fun <init> (Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;)V
 	public synthetic fun <init> (Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;Laws/smithy/kotlin/runtime/collections/Attributes;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;Laws/smithy/kotlin/runtime/collections/Attributes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Laws/smithy/kotlin/runtime/net/url/Url;
 	public final fun component2 ()Laws/smithy/kotlin/runtime/collections/ValuesMap;
@@ -225,6 +273,7 @@ public final class aws/smithy/kotlin/runtime/client/endpoints/Endpoint {
 	public final fun copy (Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;
 	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;Laws/smithy/kotlin/runtime/net/url/Url;Laws/smithy/kotlin/runtime/collections/ValuesMap;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributes ()Laws/smithy/kotlin/runtime/collections/Attributes;
 	public final fun getHeaders ()Laws/smithy/kotlin/runtime/collections/ValuesMap;
 	public final fun getUri ()Laws/smithy/kotlin/runtime/net/url/Url;
 	public fun hashCode ()I
@@ -240,8 +289,33 @@ public final class aws/smithy/kotlin/runtime/client/endpoints/EndpointProviderEx
 }
 
 public final class aws/smithy/kotlin/runtime/client/endpoints/SigningContextKt {
+	public static final fun getAuthOptions (Laws/smithy/kotlin/runtime/client/endpoints/Endpoint;)Ljava/util/List;
+	public static final fun getSigningContextAttributeKey ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
 
 public final class aws/smithy/kotlin/runtime/client/endpoints/functions/FunctionsKt {
+	public static final fun isValidHostLabel (Ljava/lang/String;Z)Z
+	public static final fun parseUrl (Ljava/lang/String;)Laws/smithy/kotlin/runtime/client/endpoints/functions/Url;
+	public static final fun substring (Ljava/lang/String;IIZ)Ljava/lang/String;
+	public static final fun uriEncode (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/client/endpoints/functions/Url {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Laws/smithy/kotlin/runtime/client/endpoints/functions/Url;
+	public static synthetic fun copy$default (Laws/smithy/kotlin/runtime/client/endpoints/functions/Url;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Laws/smithy/kotlin/runtime/client/endpoints/functions/Url;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthority ()Ljava/lang/String;
+	public final fun getNormalizedPath ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getScheme ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isIp ()Z
+	public fun toString ()Ljava/lang/String;
 }
 


### PR DESCRIPTION
## Issue \#

https://github.com/awslabs/aws-sdk-kotlin/issues/1191

## Description of changes

This change tightens backwards compatibility guarantees by:
* Removing `@InternalApi` from the exemptions for the backwards compatibility verifier
  * Also updates the API dumps because a lot of previously-exempted APIs are now in scope
* Adds a PR check which verifies that either no API dump lines have been deleted _or_ the **acknowledge-api-break** label is applied to the PR
  * [Example run with no breaking changes](https://github.com/awslabs/smithy-kotlin/actions/runs/7791179880/job/21246672755) (succeeded)
  * [Example run with breaking changes, no label](https://github.com/awslabs/smithy-kotlin/actions/runs/7791240677/job/21246879734) (failed)
  * [Example run with breaking changes, **acknowledge-api-break** label](https://github.com/awslabs/smithy-kotlin/actions/runs/7791252823/job/21246921308?pr=1030) (succeeded)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
