### PR TITLE
fix: correctly parse URLs with '@' symbol

### DIFF
--- a/.changes/ed8a74dd-01a4-46c3-96eb-8ac9356bead6.json
+++ b/.changes/ed8a74dd-01a4-46c3-96eb-8ac9356bead6.json
@@ -1,0 +1,8 @@
+{
+    "id": "ed8a74dd-01a4-46c3-96eb-8ac9356bead6",
+    "type": "bugfix",
+    "description": "Correctly parse URLs which contain the `@` symbol in the path and/or fragment (but not in the userinfo)",
+    "issues": [
+        "awslabs/smithy-kotlin#1031"
+    ]
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/url/Url.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/net/url/Url.kt
@@ -50,14 +50,18 @@ public class Url private constructor(
                 val scanner = Scanner(value)
                 scanner.requireAndSkip("://") { scheme = Scheme.parse(it) }
 
-                scanner.optionalAndSkip("@") {
-                    userInfo.parseEncoded(it)
-                }
-
                 scanner.upToOrEnd("/", "?", "#") { authority ->
-                    val (h, p) = authority.parseHostPort()
-                    host = h
-                    p?.let { port = it }
+                    val innerScanner = Scanner(authority)
+
+                    innerScanner.optionalAndSkip("@") {
+                        userInfo.parseEncoded(it)
+                    }
+
+                    innerScanner.upToOrEnd { hostport ->
+                        val (h, p) = hostport.parseHostPort()
+                        host = h
+                        p?.let { port = it }
+                    }
                 }
 
                 scanner.ifStartsWith("/") {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/Scanner.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/text/Scanner.kt
@@ -169,7 +169,7 @@ public class Scanner(public val text: String) {
      * ```
      *
      * @param literals One or more strings to search for at/after the current position
-     * @param handler The handler to invoke on the substring *up to but not including nearest found element of
+     * @param handler The handler to invoke on the substring *up to but not including* nearest found element of
      * [literals] or, if none of [literals] are found,
      */
     public fun upToOrEnd(vararg literals: String, handler: (String) -> Unit) {

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/UrlParsingTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/net/url/UrlParsingTest.kt
@@ -277,6 +277,22 @@ class UrlParsingTest {
     }
 
     @Test
+    fun testAtSymbolsOutsideOfUserInfo() {
+        data class Test(val url: String, val userInfo: String, val path: String, val fragment: String?)
+        listOf(
+            Test("https://host/foo/bar@baz/blah", "", "/foo/bar@baz/blah", null),
+            Test("https://host/foo/bar/baz/blah#qux@quux", "", "/foo/bar/baz/blah", "qux@quux"),
+            Test("https://user:pass@host/foo/bar@baz/blah", "user:pass", "/foo/bar@baz/blah", null),
+            Test("https://user:pass@host/foo/bar@baz/blah#qux@quux", "user:pass", "/foo/bar@baz/blah", "qux@quux"),
+        ).forEach { (urlString, expectedUserInfo, expectedPath, expectedFragment) ->
+            val url = Url.parse(urlString)
+            assertEquals(expectedUserInfo, url.userInfo.toString(), "Error parsing $urlString")
+            assertEquals(expectedPath, url.path.encoded, "Error parsing $urlString")
+            assertEquals(expectedFragment, url.fragment?.encoded, "Error parsing $urlString")
+        }
+    }
+
+    @Test
     fun testComplete() {
         val expected = Url {
             scheme = Scheme.HTTPS


### PR DESCRIPTION
## Issue \#

Resolves #1031 

## Description of changes

Fixes parsing logic to correctly handle the `@` symbol outside of the userinfo segment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
