### PR TITLE
feat: add `EnableAwsChunked` signing attribute

### DIFF
--- a/.changes/fb91506d-98b4-4344-bf8b-c1527afe002c.json
+++ b/.changes/fb91506d-98b4-4344-bf8b-c1527afe002c.json
@@ -1,0 +1,5 @@
+{
+    "id": "fb91506d-98b4-4344-bf8b-c1527afe002c",
+    "type": "feature",
+    "description": "Add `EnableAwsChunked` signing attribute"
+}

--- a/runtime/auth/aws-signing-common/api/aws-signing-common.api
+++ b/runtime/auth/aws-signing-common/api/aws-signing-common.api
@@ -52,6 +52,7 @@ public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAlgorithm
 public final class aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes {
 	public static final field INSTANCE Laws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes;
 	public final fun getCredentialsProvider ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getEnableAwsChunked ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getHashSpecification ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getNormalizeUriPath ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getRequestSignature ()Laws/smithy/kotlin/runtime/collections/AttributeKey;

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/AwsSigningAttributes.kt
@@ -78,4 +78,12 @@ public object AwsSigningAttributes {
      * Flag indicating whether to normalize the URI path. See [AwsSigningConfig.normalizeUriPath] for more details.
      */
     public val NormalizeUriPath: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#NormalizeUriPath")
+
+    /**
+     * Flag indicating whether to enable sending requests with `aws-chunked` content encoding. Defaults to `false`.
+     * Note: This flag does not solely control aws-chunked behavior. The size of the request body must also be above a
+     * defined threshold in order to be chunked.
+     * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html">SigV4 Streaming</a>
+     */
+    public val EnableAwsChunked: AttributeKey<Boolean> = AttributeKey("aws.smithy.kotlin.signing#EnableAwsChunked")
 }

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -77,6 +77,7 @@ public abstract class AwsHttpSignerTestBase(
                 set(AwsSigningAttributes.SigningRegion, "us-east-1")
                 set(AwsSigningAttributes.SigningDate, Instant.fromIso8601("2020-10-16T19:56:00Z"))
                 set(AwsSigningAttributes.SigningService, "demo")
+                set(AwsSigningAttributes.EnableAwsChunked, true)
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to downstream PR: https://github.com/awslabs/aws-sdk-kotlin/pull/1224

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR updates the logic enabling `aws-chunked` to also consider the new `EnableAwsChunked` signing attribute

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
