### PR TITLE
refactor: delegate exception error messages to exception base class logic

### DIFF
--- a/.changes/f274caeb-9450-45b1-935c-5f61905de53b.json
+++ b/.changes/f274caeb-9450-45b1-935c-5f61905de53b.json
@@ -1,0 +1,5 @@
+{
+    "id": "f274caeb-9450-45b1-935c-5f61905de53b",
+    "type": "misc",
+    "description": "Refactor exception codegen to delegate message field to exception base class"
+}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -58,6 +58,7 @@ public class aws/smithy/kotlin/runtime/ServiceException : aws/smithy/kotlin/runt
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun <init> (Ljava/lang/Throwable;)V
+	public fun getMessage ()Ljava/lang/String;
 	public synthetic fun getSdkErrorMetadata ()Laws/smithy/kotlin/runtime/ErrorMetadata;
 	public fun getSdkErrorMetadata ()Laws/smithy/kotlin/runtime/ServiceErrorMetadata;
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/Exceptions.kt
@@ -149,5 +149,8 @@ public open class ServiceException : SdkBaseException {
 
     public constructor(cause: Throwable?) : super(cause)
 
+    override val message: String?
+        get() = super.message ?: sdkErrorMetadata.errorMessage
+
     override val sdkErrorMetadata: ServiceErrorMetadata = ServiceErrorMetadata()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
n/a


## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Refactor exception codegen to pass the `message` field to the exception base class constructor rather than overriding it wholesale. This will allow the base class to augment the message (or fill it in from other sources like `sdkErrorMetadata` which may have more information from protocol parsing logic).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
