### PR TITLE
misc: remove "Content-Length" headers for `aws-chunked` requests

### DIFF
--- a/.changes/68f9a5ff-ff1e-4b7f-bf55-02ad98170cd9.json
+++ b/.changes/68f9a5ff-ff1e-4b7f-bf55-02ad98170cd9.json
@@ -1,0 +1,5 @@
+{
+    "id": "68f9a5ff-ff1e-4b7f-bf55-02ad98170cd9",
+    "type": "misc",
+    "description": "Remove \"Content-Length\" header for requests made with `aws-chunked` encoding"
+}

--- a/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
+++ b/runtime/auth/aws-signing-common/common/src/aws/smithy/kotlin/runtime/auth/awssigning/internal/AwsChunkedUtil.kt
@@ -66,7 +66,10 @@ public val AwsSigningConfig.useAwsChunkedEncoding: Boolean
 public fun HttpRequestBuilder.setAwsChunkedHeaders() {
     headers.append("Content-Encoding", "aws-chunked")
     headers["Transfer-Encoding"] = "chunked"
-    headers["X-Amz-Decoded-Content-Length"] = body.contentLength!!.toString()
+    headers["X-Amz-Decoded-Content-Length"] = checkNotNull(headers["Content-Length"] ?: body.contentLength?.toString()) {
+        "Expected \"Content-Length\" header or `body.contentLength` to be set for aws-chunked"
+    }
+    headers.remove("Content-Length") // Any precalculated Content-Length is no longer correct after we chunk the body up
 }
 
 /**

--- a/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
+++ b/runtime/auth/http-auth-aws/common/test/aws/smithy/kotlin/runtime/http/auth/AwsHttpSignerTestBase.kt
@@ -148,8 +148,8 @@ public abstract class AwsHttpSignerTestBase(
         val op = buildOperation(streaming = true, replayable = false, requestBody = "a".repeat(AWS_CHUNKED_THRESHOLD + 1))
         val expectedDate = "20201016T195600Z"
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
-            "SignedHeaders=content-encoding;content-length;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
-            "Signature=dec1a06b61f953afe430ce4a0f10ee8d5ad3d29696516c4ccda23a0aab6664d5"
+            "SignedHeaders=content-encoding;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
+            "Signature=ac341b9b248a0b23d2fcd9f7e805f4eb0b8a1b789bb23a8ec6adc6c48dd084ad"
 
         val signed = getSignedRequest(op)
         assertEquals(expectedDate, signed.headers["X-Amz-Date"])
@@ -161,8 +161,8 @@ public abstract class AwsHttpSignerTestBase(
         val op = buildOperation(streaming = true, replayable = true, requestBody = "a".repeat(AWS_CHUNKED_THRESHOLD + 1))
         val expectedDate = "20201016T195600Z"
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
-            "SignedHeaders=content-encoding;content-length;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
-            "Signature=dec1a06b61f953afe430ce4a0f10ee8d5ad3d29696516c4ccda23a0aab6664d5"
+            "SignedHeaders=content-encoding;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
+            "Signature=ac341b9b248a0b23d2fcd9f7e805f4eb0b8a1b789bb23a8ec6adc6c48dd084ad"
 
         val signed = getSignedRequest(op)
         assertEquals(expectedDate, signed.headers["X-Amz-Date"])
@@ -175,8 +175,8 @@ public abstract class AwsHttpSignerTestBase(
         val expectedDate = "20201016T195600Z"
         // should have same signature as testSignAwsChunkedStreamNonReplayable(), except for the hash, since the body is different
         val expectedSig = "AWS4-HMAC-SHA256 Credential=AKID/20201016/us-east-1/demo/aws4_request, " +
-            "SignedHeaders=content-encoding;content-length;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
-            "Signature=9600a7fbf17056d41557ec5d6abfe7b5db4a75222e563f5e16afde9c1c0014bb"
+            "SignedHeaders=content-encoding;host;transfer-encoding;x-amz-archive-description;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, " +
+            "Signature=3f0277123c9ed8a8858f793886a0ac0fcb457bc54401ffc22d470f373397cff0"
 
         val signed = getSignedRequest(op)
         assertEquals(expectedDate, signed.headers["X-Amz-Date"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
