### PR TITLE
fix: revert to Dokka1 module paths

### DIFF
--- a/runtime/auth/aws-credentials/build.gradle.kts
+++ b/runtime/auth/aws-credentials/build.gradle.kts
@@ -30,3 +30,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-credentials"
+}

--- a/runtime/auth/aws-signing-common/build.gradle.kts
+++ b/runtime/auth/aws-signing-common/build.gradle.kts
@@ -34,3 +34,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-signing-common"
+}

--- a/runtime/auth/aws-signing-crt/build.gradle.kts
+++ b/runtime/auth/aws-signing-crt/build.gradle.kts
@@ -26,3 +26,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-signing-crt"
+}

--- a/runtime/auth/aws-signing-default/build.gradle.kts
+++ b/runtime/auth/aws-signing-default/build.gradle.kts
@@ -27,3 +27,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-signing-default"
+}

--- a/runtime/auth/aws-signing-tests/build.gradle.kts
+++ b/runtime/auth/aws-signing-tests/build.gradle.kts
@@ -39,3 +39,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-signing-tests"
+}

--- a/runtime/auth/http-auth-api/build.gradle.kts
+++ b/runtime/auth/http-auth-api/build.gradle.kts
@@ -16,3 +16,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-auth-api"
+}

--- a/runtime/auth/http-auth-aws/build.gradle.kts
+++ b/runtime/auth/http-auth-aws/build.gradle.kts
@@ -37,3 +37,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-auth-aws"
+}

--- a/runtime/auth/http-auth/build.gradle.kts
+++ b/runtime/auth/http-auth/build.gradle.kts
@@ -27,3 +27,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-auth"
+}

--- a/runtime/auth/identity-api/build.gradle.kts
+++ b/runtime/auth/identity-api/build.gradle.kts
@@ -28,3 +28,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "identity-api"
+}

--- a/runtime/crt-util/build.gradle.kts
+++ b/runtime/crt-util/build.gradle.kts
@@ -29,3 +29,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "crt-util"
+}

--- a/runtime/observability/logging-slf4j2/build.gradle.kts
+++ b/runtime/observability/logging-slf4j2/build.gradle.kts
@@ -25,3 +25,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "logging-slf4j2"
+}

--- a/runtime/observability/telemetry-api/build.gradle.kts
+++ b/runtime/observability/telemetry-api/build.gradle.kts
@@ -28,3 +28,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "telemetry-api"
+}

--- a/runtime/observability/telemetry-defaults/build.gradle.kts
+++ b/runtime/observability/telemetry-defaults/build.gradle.kts
@@ -29,3 +29,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "telemetry-defaults"
+}

--- a/runtime/observability/telemetry-provider-micrometer/build.gradle.kts
+++ b/runtime/observability/telemetry-provider-micrometer/build.gradle.kts
@@ -25,3 +25,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "telemetry-provider-micrometer"
+}

--- a/runtime/observability/telemetry-provider-otel/build.gradle.kts
+++ b/runtime/observability/telemetry-provider-otel/build.gradle.kts
@@ -26,3 +26,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "telemetry-provider-otel"
+}

--- a/runtime/protocol/aws-event-stream/build.gradle.kts
+++ b/runtime/protocol/aws-event-stream/build.gradle.kts
@@ -34,3 +34,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-event-stream"
+}

--- a/runtime/protocol/aws-json-protocols/build.gradle.kts
+++ b/runtime/protocol/aws-json-protocols/build.gradle.kts
@@ -33,3 +33,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-json-protocols"
+}

--- a/runtime/protocol/aws-protocol-core/build.gradle.kts
+++ b/runtime/protocol/aws-protocol-core/build.gradle.kts
@@ -32,3 +32,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-protocol-core"
+}

--- a/runtime/protocol/aws-xml-protocols/build.gradle.kts
+++ b/runtime/protocol/aws-xml-protocols/build.gradle.kts
@@ -31,3 +31,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "aws-xml-protocols"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-crt/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-crt/build.gradle.kts
@@ -35,3 +35,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-client-engine-crt"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-default/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/build.gradle.kts
@@ -32,3 +32,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-client-engine-default"
+}

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/build.gradle.kts
@@ -39,3 +39,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-client-engine-okhttp"
+}

--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -136,3 +136,7 @@ tasks.jvmTest {
 gradle.buildFinished {
     startTestServers.stop()
 }
+
+dokka {
+    modulePath = "test-suite"
+}

--- a/runtime/protocol/http-client/build.gradle.kts
+++ b/runtime/protocol/http-client/build.gradle.kts
@@ -36,3 +36,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-client"
+}

--- a/runtime/protocol/http-test/build.gradle.kts
+++ b/runtime/protocol/http-test/build.gradle.kts
@@ -33,3 +33,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http-test"
+}

--- a/runtime/protocol/http/build.gradle.kts
+++ b/runtime/protocol/http/build.gradle.kts
@@ -29,3 +29,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "http"
+}

--- a/runtime/protocol/smithy-rpcv2-protocols/build.gradle.kts
+++ b/runtime/protocol/smithy-rpcv2-protocols/build.gradle.kts
@@ -33,3 +33,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "smithy-rpcv2-protocols"
+}

--- a/runtime/runtime-core/build.gradle.kts
+++ b/runtime/runtime-core/build.gradle.kts
@@ -42,3 +42,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "runtime-core"
+}

--- a/runtime/serde/serde-cbor/build.gradle.kts
+++ b/runtime/serde/serde-cbor/build.gradle.kts
@@ -21,3 +21,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "serde-cbor"
+}

--- a/runtime/serde/serde-form-url/build.gradle.kts
+++ b/runtime/serde/serde-form-url/build.gradle.kts
@@ -20,3 +20,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "serde-form-url"
+}

--- a/runtime/serde/serde-json/build.gradle.kts
+++ b/runtime/serde/serde-json/build.gradle.kts
@@ -22,3 +22,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "serde-json"
+}

--- a/runtime/serde/serde-xml/build.gradle.kts
+++ b/runtime/serde/serde-xml/build.gradle.kts
@@ -22,3 +22,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "serde-xml"
+}

--- a/runtime/smithy-client/build.gradle.kts
+++ b/runtime/smithy-client/build.gradle.kts
@@ -28,3 +28,7 @@ kotlin {
         }
     }
 }
+
+dokka {
+    modulePath = "smithy-client"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Preserve Dokka v1's paths, which are just the module name, rather than the full path to the module. 
 
https://kotlinlang.org/docs/dokka-migration.html#revert-to-the-dgp-v1-directory-behavior

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
