### PR TITLE
chore: remove manual resolution of transitive Docker dependencies

### DIFF
--- a/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
+++ b/runtime/protocol/http-client-engines/test-suite/build.gradle.kts
@@ -45,12 +45,6 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(libs.docker.core)
-                // FIXME docker-java has a ton of dependencies with vulnerabilities, and they don't seem motivated to fix them.
-                // So we must override their dependencies with the latest patched versions. https://github.com/docker-java/docker-java/issues/1974
-                implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7.1") // https://github.com/docker-java/docker-java/issues/2177
-                implementation("org.apache.commons:commons-compress:1.26.0") // https://github.com/docker-java/docker-java/pull/2256
-                implementation("org.bouncycastle:bcpkix-jdk18on:1.78") // https://github.com/docker-java/docker-java/pull/2326
-
                 implementation(libs.docker.transport.zerodep)
 
                 implementation(project(":runtime:observability:telemetry-defaults"))


### PR DESCRIPTION
## Issue \#

https://github.com/docker-java/docker-java/issues/1974

## Description of changes

The manual dependency versions we configured for Docker transitive dependencies should no longer be necessary now that https://github.com/docker-java/docker-java/issues/1974 is resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
