### PR TITLE
Revert "chore(deps): bump com.fasterxml.jackson:jackson-bom from 2.153 to 2.19.2 (#1363)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
         https://github.com/Kotlin/dokka/issues/3472#issuecomment-1929712374
         https://github.com/Kotlin/dokka/issues/3194#issuecomment-1929382630
          */
-        classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.19.2"))
+        classpath(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.15.3"))
     }
 }
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Reverts 5af711e7b6242491c3d46e1a27e99982c2ed91ba. Keeping Jackson version 2.15.3 is important because Dokka lacks support for later versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
