### PR TITLE
chore: migrate repo from awslabs to aws

### DIFF
--- a/.github/workflows/artifact-size-metrics.yml
+++ b/.github/workflows/artifact-size-metrics.yml
@@ -32,7 +32,7 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Generate Artifact Size Metrics
         run: ./gradlew artifactSizeMetrics
       - name: Save Artifact Size Metrics
@@ -56,14 +56,14 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Generate Artifact Size Metrics
         run: ./gradlew artifactSizeMetrics
       - name: Analyze Artifact Size Metrics
         run: ./gradlew analyzeArtifactSizeMetrics
 
       - name: Show Results
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/artifact-size-metrics/show-results@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/artifact-size-metrics/show-results@main
 
       - name: Evaluate
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'acknowledge-artifact-size-increase') }}

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -22,4 +22,4 @@ jobs:
           aws-region: us-west-2
 
       - name: Verify changelog
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/changelog-verification@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/changelog-verification@main

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: 17
           cache: 'gradle'
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Test
         shell: bash
         run: |
@@ -62,7 +62,7 @@ jobs:
           java-version: 17
           cache: 'gradle'
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Test
         shell: bash
         run: |
@@ -88,7 +88,7 @@ jobs:
           java-version: 17
           cache: 'gradle'
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Test
         shell: bash
         run: |
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: 'aws-kotlin-repo-tools'
-        repository: 'awslabs/aws-kotlin-repo-tools'
+        repository: 'aws/aws-kotlin-repo-tools'
         ref: '0.2.3'
         sparse-checkout: |
           .github
@@ -115,13 +115,13 @@ jobs:
       with:
         # smithy-kotlin is checked out as a sibling dir which will automatically make it an included build
         path: 'aws-sdk-kotlin'
-        repository: 'awslabs/aws-sdk-kotlin'
+        repository: 'aws/aws-sdk-kotlin'
     - name: Configure Gradle - smithy-kotlin
-      uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+      uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       with:
         working-directory: ./smithy-kotlin
     - name: Configure Gradle - aws-sdk-kotlin
-      uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+      uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       with:
         working-directory: ./aws-sdk-kotlin
     - name: Configure JDK

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -36,12 +36,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
         with:
           working-directory: ./smithy-kotlin
 
       - name: Setup kat
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/setup-kat@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/setup-kat@main
 
       - name: Configure JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Configure Gradle
-      uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+      uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
     - name: Lint ${{ env.PACKAGE_NAME }}
       run: |
         ./gradlew ktlint

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge main
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/merge-main@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/merge-main@main
         with:
           ci-user-pat: ${{ secrets.CI_USER_PAT }}
           exempt-branches: # Add any if required

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
 
       - name: Build smithy-kotlin
         run: ./gradlew test jvmTest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ operating system, run `./gradlew build`.
 
 #### CI downstream
 
-This repo is a core dependency of [**aws-sdk-kotlin**](https://github.com/awslabs/aws-sdk-kotlin) and many changes made
+This repo is a core dependency of [**aws-sdk-kotlin**](https://github.com/aws/aws-sdk-kotlin) and many changes made
 here could impact that repo as well. To ensure that **aws-sdk-kotlin** continues to function correctly, we run a
 downstream CI check that builds both code bases in a shared workspace. To run this check locally, check out both
 repositories into subdirectories of the same parent, build/publish **smithy-kotlin** followed by
@@ -178,7 +178,7 @@ repositories into subdirectories of the same parent, build/publish **smithy-kotl
 mkdir path/to/workspace # create a new directory to hold both repositories
 cd path/to/workspace
 git clone -b branch-name https://github.com/smithy-lang/smithy-kotlin.git  # replace branch-name as appropriate
-git clone -b branch-name https://github.com/awslabs/aws-sdk-kotlin.git # replace branch-name as appropriate
+git clone -b branch-name https://github.com/aws/aws-sdk-kotlin.git # replace branch-name as appropriate
 cd smithy-kotlin
 ./gradlew build publishToMavenLocal
 cd ../aws-sdk-kotlin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Migrate repository references from awslabs to aws organization following GitHub repository transfer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
