### PR TITLE
chore: scope the stale_issue.yaml workflow to run only on this repository

### DIFF
--- a/.github/workflows/stale_issue.yaml
+++ b/.github/workflows/stale_issue.yaml
@@ -11,6 +11,7 @@ jobs:
   cleanup:
     name: Stale issue job
     runs-on: ubuntu-latest
+    if: github.repository == 'smithy-lang/smithy-kotlin'
     steps:
     - uses: aws-actions/stale-issue-cleanup@v4
       with:


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The stale issue cleanup workflow should be scoped to run only on this repository (and not other repos to which the workflow file may be copied).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
