### PR TITLE
fix: make disk space for linux CI builds 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -184,7 +184,7 @@ jobs:
         uses: ./smithy-kotlin/.github/actions/setup-build
 
       - name: Configure CRT Docker Images
-        run: |          
+        run: |
           ./aws-crt-kotlin/docker-images/build-all.sh
 
       - name: Build and Test on Linux with Cross-Compile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
No GH issue.

Our linux CI builds are exhausting the disk space in GH runners:
```
e: /home/runner/.konan/dependencies/llvm-19-x86_64-linux-essentials-100/bin/ld.lld invocation reported errors

The /home/runner/.konan/dependencies/llvm-19-x86_64-linux-essentials-100/bin/ld.lld command returned non-zero exit code: 135.
output:

> Task :runtime:protocol:aws-event-stream:linkDebugTestLinuxX64 FAILED
e: Compilation failed: /tmp/included6654424596819046813: No space left on device
```

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
There are some unnecessary tools installed in GH runners we can get rid of so linux builds don't exhaust disk space. More research could still be done to figure out how to optimize our linux builds, so we don't need to do this to begin with.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
