### PR TITLE
Replace junit with kotlin test

### DIFF
--- a/codegen/aws-codegen/src/test/kotlin/aws/smithy/kotlin/codegen/aws/customization/RegionSupportTest.kt
+++ b/codegen/aws-codegen/src/test/kotlin/aws/smithy/kotlin/codegen/aws/customization/RegionSupportTest.kt
@@ -13,8 +13,8 @@ import aws.smithy.kotlin.codegen.test.newTestContext
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toRenderingContext
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.ServiceShape
+import kotlin.test.Test
 
 class RegionSupportTest {
     @Test

--- a/codegen/codegen/build.gradle.kts
+++ b/codegen/codegen/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(project(":codegen:codegen-testutils"))
+    testImplementation(project(":runtime:testing"))
 }
 
 val generateSdkRuntimeVersion by tasks.registering {

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/KotlinSettingsTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/KotlinSettingsTest.kt
@@ -8,19 +8,12 @@ package aws.smithy.kotlin.codegen
 import aws.smithy.kotlin.codegen.test.TestModelDefault
 import aws.smithy.kotlin.codegen.test.toSmithyModel
 import aws.smithy.kotlin.codegen.utils.dq
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import org.junit.jupiter.params.provider.CsvSource
-import org.junit.jupiter.params.support.ParameterDeclarations
+import aws.smithy.kotlin.runtime.testing.parameterized
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.knowledge.NullableIndex.CheckMode
 import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.ShapeId
-import java.util.stream.Stream
 import kotlin.test.*
 
 class KotlinSettingsTest {
@@ -297,15 +290,16 @@ class KotlinSettingsTest {
         }
     }
 
-    @ParameterizedTest(name = "{0} ==> {1}")
-    @CsvSource(
-        "client, CLIENT",
-        "clientCareful, CLIENT_CAREFUL",
-        "clientZeroValueV1, CLIENT_ZERO_VALUE_V1",
-        "clientZeroValueV1NoInput, CLIENT_ZERO_VALUE_V1_NO_INPUT",
-        "server, SERVER",
-    )
-    fun testNullabilityCheckMode(pluginSetting: String, expectedEnumString: String) {
+    @Test
+    fun testNullabilityCheckMode() = parameterized(
+        listOf(
+            "client" to "CLIENT",
+            "clientCareful" to "CLIENT_CAREFUL",
+            "clientZeroValueV1" to "CLIENT_ZERO_VALUE_V1",
+            "clientZeroValueV1NoInput" to "CLIENT_ZERO_VALUE_V1_NO_INPUT",
+            "server" to "SERVER",
+        ),
+    ) { (pluginSetting, expectedEnumString) ->
         val expected = CheckMode.valueOf(expectedEnumString)
         val contents = """
             {
@@ -317,12 +311,13 @@ class KotlinSettingsTest {
         assertEquals(expected, apiSettings.nullabilityCheckMode)
     }
 
-    @ParameterizedTest(name = "{0} ==> {1}")
-    @CsvSource(
-        "always, ALWAYS",
-        "whenDifferent, WHEN_DIFFERENT",
-    )
-    fun testDefaultValueSerializationMode(pluginSetting: String, expectedEnumString: String) {
+    @Test
+    fun testDefaultValueSerializationMode() = parameterized(
+        listOf(
+            "always" to "ALWAYS",
+            "whenDifferent" to "WHEN_DIFFERENT",
+        ),
+    ) { (pluginSetting, expectedEnumString) ->
         val expected = DefaultValueSerializationMode.valueOf(expectedEnumString)
         val contents = """
             {
@@ -334,13 +329,21 @@ class KotlinSettingsTest {
         assertEquals(expected, apiSettings.defaultValueSerializationMode)
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(TestProtocolSelectionArgumentProvider::class)
-    fun testProtocolSelection(
-        protocolPriorityCsv: String,
-        serviceProtocolsCsv: String,
-        expectedProtocolName: String?,
-    ) {
+    @Test
+    fun testProtocolSelection() = parameterized(
+        listOf(
+            Triple(ALL_PROTOCOLS, "rpcv2Cbor, awsJson1_0", "rpcv2Cbor"),
+            Triple(ALL_PROTOCOLS, "rpcv2Cbor", "rpcv2Cbor"),
+            Triple(ALL_PROTOCOLS, "rpcv2Cbor, awsJson1_0, awsQuery", "rpcv2Cbor"),
+            Triple(ALL_PROTOCOLS, "awsJson1_0, awsQuery", "awsJson1_0"),
+            Triple(ALL_PROTOCOLS, "awsQuery", "awsQuery"),
+            Triple(NO_CBOR, "rpcv2Cbor, awsJson1_0", "awsJson1_0"),
+            Triple(NO_CBOR, "rpcv2Cbor", null),
+            Triple(NO_CBOR, "rpcv2Cbor, awsJson1_0, awsQuery", "awsJson1_0"),
+            Triple(NO_CBOR, "awsJson1_0, awsQuery", "awsJson1_0"),
+            Triple(NO_CBOR, "awsQuery", "awsQuery"),
+        ),
+    ) { (protocolPriorityCsv, serviceProtocolsCsv, expectedProtocolName) ->
         val serviceProtocols = serviceProtocolsCsv.csvToProtocolList()
         val serviceProtocolImports = serviceProtocols.joinToString("\n") { "use $it" }
         val serviceProtocolTraits = serviceProtocols.joinToString("\n") { "@${it.name}" }
@@ -383,72 +386,8 @@ class KotlinSettingsTest {
     }
 }
 
-/**
- * A junit [ArgumentsProvider] which supplies protocol selection parameterized test values sourced from the Smithy RPCv2
- * CBOR Support SEP § Smithy protocol selection tests.
- */
-class TestProtocolSelectionArgumentProvider : ArgumentsProvider {
-    companion object {
-        private const val ALL_PROTOCOLS = "rpcv2Cbor, awsJson1_0, awsJson1_1, restJson1, restXml, awsQuery, ec2Query"
-        private const val NO_CBOR = "awsJson1_0, awsJson1_1, restJson1, restXml, awsQuery, ec2Query"
-    }
-
-    override fun provideArguments(
-        parameters: ParameterDeclarations?,
-        context: ExtensionContext?,
-    ): Stream<out Arguments> = Stream.of(
-        Arguments.of(
-            ALL_PROTOCOLS,
-            "rpcv2Cbor, awsJson1_0",
-            "rpcv2Cbor",
-        ),
-        Arguments.of(
-            ALL_PROTOCOLS,
-            "rpcv2Cbor",
-            "rpcv2Cbor",
-        ),
-        Arguments.of(
-            ALL_PROTOCOLS,
-            "rpcv2Cbor, awsJson1_0, awsQuery",
-            "rpcv2Cbor",
-        ),
-        Arguments.of(
-            ALL_PROTOCOLS,
-            "awsJson1_0, awsQuery",
-            "awsJson1_0",
-        ),
-        Arguments.of(
-            ALL_PROTOCOLS,
-            "awsQuery",
-            "awsQuery",
-        ),
-        Arguments.of(
-            NO_CBOR,
-            "rpcv2Cbor, awsJson1_0",
-            "awsJson1_0",
-        ),
-        Arguments.of(
-            NO_CBOR,
-            "rpcv2Cbor",
-            null,
-        ),
-        Arguments.of(
-            NO_CBOR,
-            "rpcv2Cbor, awsJson1_0, awsQuery",
-            "awsJson1_0",
-        ),
-        Arguments.of(
-            NO_CBOR,
-            "awsJson1_0, awsQuery",
-            "awsJson1_0",
-        ),
-        Arguments.of(
-            NO_CBOR,
-            "awsQuery",
-            "awsQuery",
-        ),
-    )
-}
+private const val ALL_PROTOCOLS = "rpcv2Cbor, awsJson1_0, awsJson1_1, restJson1, restXml, awsQuery, ec2Query"
+private const val NO_CBOR = "awsJson1_0, awsJson1_1, restJson1, restXml, awsQuery, ec2Query"
 
 private val allProtocols = ApiSettings().protocolResolutionPriority
 private fun String.nameToProtocol() = allProtocols.single { protocol -> protocol.name == this }

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/SymbolProviderTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/SymbolProviderTest.kt
@@ -18,10 +18,7 @@ import aws.smithy.kotlin.codegen.test.createSymbolProvider
 import aws.smithy.kotlin.codegen.test.defaultSettings
 import aws.smithy.kotlin.codegen.test.prependNamespaceAndService
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
-import org.junit.jupiter.params.provider.ValueSource
+import aws.smithy.kotlin.runtime.testing.parameterized
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.knowledge.NullableIndex.CheckMode
 import software.amazon.smithy.model.shapes.*
@@ -65,26 +62,26 @@ class SymbolProviderTest {
         assertEquals("kotlin", memberSymbol.namespace)
     }
 
-    @DisplayName("Creates primitives")
-    @ParameterizedTest(name = "{index} ==> ''{0}''")
-    @CsvSource(
-        "String, null, true",
-        "Integer, null, true",
-        "PrimitiveInteger, 0, false",
-        "Short, null, true",
-        "PrimitiveShort, 0.toShort(), false",
-        "Long, null, true",
-        "PrimitiveLong, 0L, false",
-        "Byte, null, true",
-        "PrimitiveByte, 0.toByte(), false",
-        "Float, null, true",
-        "PrimitiveFloat, 0f, false",
-        "Double, null, true",
-        "PrimitiveDouble, 0.0, false",
-        "Boolean, null, true",
-        "PrimitiveBoolean, false, false",
-    )
-    fun `creates primitives`(primitiveType: String, expectedDefault: String, nullable: Boolean) {
+    @Test
+    fun `creates primitives`() = parameterized(
+        listOf(
+            Triple("String", "null", true),
+            Triple("Integer", "null", true),
+            Triple("PrimitiveInteger", "0", false),
+            Triple("Short", "null", true),
+            Triple("PrimitiveShort", "0.toShort()", false),
+            Triple("Long", "null", true),
+            Triple("PrimitiveLong", "0L", false),
+            Triple("Byte", "null", true),
+            Triple("PrimitiveByte", "0.toByte()", false),
+            Triple("Float", "null", true),
+            Triple("PrimitiveFloat", "0f", false),
+            Triple("Double", "null", true),
+            Triple("PrimitiveDouble", "0.0", false),
+            Triple("Boolean", "null", true),
+            Triple("PrimitiveBoolean", "false", false),
+        ),
+    ) { (primitiveType, expectedDefault, nullable) ->
         // IDLv2.0 requires modeling a default value on primitives
         val defaultTrait = when {
             primitiveType == "PrimitiveBoolean" -> "@default(false)"
@@ -198,23 +195,24 @@ class SymbolProviderTest {
         assertTrue(memberSymbol.isNullable)
     }
 
-    @ParameterizedTest(name = "{index} ==> ''can default simple {0} type''")
-    @CsvSource(
-        "long,100,100L",
-        "integer,5,5",
-        "short,32767,32767.toShort()",
-        "float,3.14159,3.14159f",
-        "double,2.71828,2.71828",
-        "byte,10,10.toByte()",
-        "string,\"hello\",\"hello\"",
-        "blob,\"abcdefg\",\"abcdefg\".decodeBase64().encodeToByteArray()",
-        "boolean,true,true",
-        "bigInteger,5,5",
-        "bigDecimal,9.0123456789,9.0123456789",
-        "timestamp,1684869901,'Instant.fromEpochSeconds(1684869901, 0)'",
-        "timestamp,1.5,'Instant.fromEpochMilliseconds(1500)'",
-    )
-    fun `can default simple types`(typeName: String, modeledDefault: String, expectedDefault: String) {
+    @Test
+    fun `can default simple types`() = parameterized(
+        listOf(
+            Triple("long", "100", "100L"),
+            Triple("integer", "5", "5"),
+            Triple("short", "32767", "32767.toShort()"),
+            Triple("float", "3.14159", "3.14159f"),
+            Triple("double", "2.71828", "2.71828"),
+            Triple("byte", "10", "10.toByte()"),
+            Triple("string", "\"hello\"", "\"hello\""),
+            Triple("blob", "\"abcdefg\"", "\"abcdefg\".decodeBase64().encodeToByteArray()"),
+            Triple("boolean", "true", "true"),
+            Triple("bigInteger", "5", "5"),
+            Triple("bigDecimal", "9.0123456789", "9.0123456789"),
+            Triple("timestamp", "1684869901", "Instant.fromEpochSeconds(1684869901, 0)"),
+            Triple("timestamp", "1.5", "Instant.fromEpochMilliseconds(1500)"),
+        ),
+    ) { (typeName, modeledDefault, expectedDefault) ->
         val model = """
         structure MyStruct {
            @default($modeledDefault)
@@ -298,22 +296,23 @@ class SymbolProviderTest {
         assertEquals("com.test.model.Season.fromValue(2)", memberSymbol.defaultValue())
     }
 
-    @ParameterizedTest(name = "{index} ==> ''can default document with {0} type''")
-    @CsvSource(
-        "boolean,true,aws.smithy.kotlin.runtime.content.Document(true)",
-        "boolean,false,aws.smithy.kotlin.runtime.content.Document(false)",
-        "string,\"hello\",aws.smithy.kotlin.runtime.content.Document(\"hello\")",
-        "long,100,aws.smithy.kotlin.runtime.content.Document(100)",
-        "integer,5,aws.smithy.kotlin.runtime.content.Document(5)",
-        "short,32767,aws.smithy.kotlin.runtime.content.Document(32767)",
-        "float,3.14159,aws.smithy.kotlin.runtime.content.Document(3.14159)",
-        "double,2.71828,aws.smithy.kotlin.runtime.content.Document(2.71828)",
-        "byte,10,aws.smithy.kotlin.runtime.content.Document(10)",
-        "list,[],aws.smithy.kotlin.runtime.content.Document(listOf())",
-        "map,{},aws.smithy.kotlin.runtime.content.Document(mapOf())",
-    )
-    @Suppress("UNUSED_PARAMETER") // using the first parameter in the test name, but compiler doesn't acknowledge that
-    fun `can default document type`(typeName: String, modeledDefault: String, expectedDefault: String) {
+    @Test
+    @Suppress("UNUSED_PARAMETER")
+    fun `can default document type`() = parameterized(
+        listOf(
+            Triple("boolean", "true", "aws.smithy.kotlin.runtime.content.Document(true)"),
+            Triple("boolean", "false", "aws.smithy.kotlin.runtime.content.Document(false)"),
+            Triple("string", "\"hello\"", "aws.smithy.kotlin.runtime.content.Document(\"hello\")"),
+            Triple("long", "100", "aws.smithy.kotlin.runtime.content.Document(100)"),
+            Triple("integer", "5", "aws.smithy.kotlin.runtime.content.Document(5)"),
+            Triple("short", "32767", "aws.smithy.kotlin.runtime.content.Document(32767)"),
+            Triple("float", "3.14159", "aws.smithy.kotlin.runtime.content.Document(3.14159)"),
+            Triple("double", "2.71828", "aws.smithy.kotlin.runtime.content.Document(2.71828)"),
+            Triple("byte", "10", "aws.smithy.kotlin.runtime.content.Document(10)"),
+            Triple("list", "[]", "aws.smithy.kotlin.runtime.content.Document(listOf())"),
+            Triple("map", "{}", "aws.smithy.kotlin.runtime.content.Document(mapOf())"),
+        ),
+    ) { (typeName, modeledDefault, expectedDefault) ->
         val model = """
         structure MyStruct {
            @default($modeledDefault)
@@ -606,10 +605,8 @@ class SymbolProviderTest {
         assertTrue("com.test.model.Record" in refNames)
     }
 
-    @DisplayName("creates bigNumbers")
-    @ParameterizedTest(name = "{index} ==> ''{0}''")
-    @ValueSource(strings = ["BigInteger", "BigDecimal"])
-    fun `creates bigNumbers`(type: String) {
+    @Test
+    fun `creates bigNumbers`() = parameterized(listOf("BigInteger", "BigDecimal")) { type ->
         val member = MemberShape.builder().id("foo.bar#MyStruct\$quux").target("smithy.api#$type").build()
         val model = """
             structure MyStruct {
@@ -818,9 +815,10 @@ class SymbolProviderTest {
         assertEquals("com.test.model.Events", symbol.references[0].symbol.fullName)
     }
 
-    @ParameterizedTest(name = "{index} ==> ''{0}''")
-    @ValueSource(strings = ["CLIENT_CAREFUL", "CLIENT"])
-    fun `it handles client nullability for IDL v2 check modes`(rawCheckMode: String) {
+    @Test
+    fun `it handles client nullability for IDL v2 check modes`() = parameterized(
+        listOf("CLIENT_CAREFUL", "CLIENT"),
+    ) { rawCheckMode ->
         val model = """
             operation TestOp {
                 input: OpInput

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/model/SetRefactorPreprocessorTest.kt
@@ -6,12 +6,12 @@ package aws.smithy.kotlin.codegen.model
 
 import aws.smithy.kotlin.codegen.KotlinSettings
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.UniqueItemsTrait
+import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/StructureGeneratorTest.kt
@@ -20,13 +20,14 @@ import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.shouldContainWithDiff
 import aws.smithy.kotlin.codegen.test.toSmithyModel
 import aws.smithy.kotlin.codegen.trimEveryLine
-import org.junit.jupiter.api.TestInstance
+import aws.smithy.kotlin.runtime.testing.TestInstance
+import aws.smithy.kotlin.runtime.testing.TestLifecycle
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.shapes.StructureShape
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(TestLifecycle.PER_CLASS)
 class StructureGeneratorTest {
     // Structure generation is rather involved, instead of one giant substr search to see that everything is right we
     // look for parts of the whole as individual tests

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/DefaultEndpointDiscovererGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/DefaultEndpointDiscovererGeneratorTest.kt
@@ -8,8 +8,8 @@ import aws.smithy.kotlin.codegen.test.formatForTest
 import aws.smithy.kotlin.codegen.test.newTestContext
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toCodegenContext
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.build.MockManifest
+import kotlin.test.Test
 
 class DefaultEndpointDiscovererGeneratorTest {
     private val renderedCodegen: String = run {

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererInterfaceGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscovererInterfaceGeneratorTest.kt
@@ -8,8 +8,8 @@ import aws.smithy.kotlin.codegen.test.formatForTest
 import aws.smithy.kotlin.codegen.test.newTestContext
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toCodegenContext
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.build.MockManifest
+import kotlin.test.Test
 
 class EndpointDiscovererInterfaceGeneratorTest {
     @Test

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscoveryIntegrationTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/endpoints/discovery/EndpointDiscoveryIntegrationTest.kt
@@ -14,8 +14,8 @@ import aws.smithy.kotlin.codegen.test.newTestContext
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toRenderingContext
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.ServiceShape
+import kotlin.test.Test
 
 class EndpointDiscoveryIntegrationTest {
     @Test

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/samples/KDocSamplesGeneratorTest.kt
@@ -12,11 +12,11 @@ import aws.smithy.kotlin.codegen.test.newTestContext
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toCodegenContext
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.transform.ModelTransformer
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/serde/DeserializeStructGeneratorTest.kt
@@ -10,8 +10,7 @@ import aws.smithy.kotlin.codegen.test.codegenDeserializerForShape
 import aws.smithy.kotlin.codegen.test.prependNamespaceAndService
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import aws.smithy.kotlin.runtime.testing.parameterized
 import kotlin.test.Test
 
 class DeserializeStructGeneratorTest {
@@ -25,9 +24,10 @@ class DeserializeStructGeneratorTest {
         operations = listOf("Foo"),
     ).trimIndent()
 
-    @ParameterizedTest
-    @ValueSource(strings = ["String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"])
-    fun `it deserializes a structure with a simple fields`(memberType: String) {
+    @Test
+    fun `it deserializes a structure with a simple fields`() = parameterized(
+        listOf("String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"),
+    ) { memberType ->
         val model = (
             modelPrefix + """            
             structure FooResponse { 

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/serde/SerializeStructGeneratorTest.kt
@@ -12,9 +12,7 @@ import aws.smithy.kotlin.codegen.test.prependNamespaceAndService
 import aws.smithy.kotlin.codegen.test.shouldContainOnlyOnceWithDiff
 import aws.smithy.kotlin.codegen.test.stripCodegenPrefix
 import aws.smithy.kotlin.codegen.test.toSmithyModel
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
-import org.junit.jupiter.params.provider.ValueSource
+import aws.smithy.kotlin.runtime.testing.parameterized
 import software.amazon.smithy.model.knowledge.NullableIndex
 import kotlin.test.Test
 
@@ -29,9 +27,10 @@ class SerializeStructGeneratorTest {
         operations = listOf("Foo"),
     ).trimIndent()
 
-    @ParameterizedTest
-    @ValueSource(strings = ["String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"])
-    fun `it serializes a structure with a simple fields`(memberType: String) {
+    @Test
+    fun `it serializes a structure with a simple fields`() = parameterized(
+        listOf("String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"),
+    ) { memberType ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 
@@ -51,18 +50,19 @@ class SerializeStructGeneratorTest {
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        "String, \"foo\", \"foo\"",
-        "Boolean, false, false",
-        "Byte, 0, 0.toByte()",
-        "Short, 0, 0.toShort()",
-        "Integer, 2, 2",
-        "Long, 3, 3L",
-        "Float, 0, 0f",
-        "Double, 0, 0.0",
-    )
-    fun `it serializes default values only when different mode`(memberType: String, modelDefault: String, defaultValue: String) {
+    @Test
+    fun `it serializes default values only when different mode`() = parameterized(
+        listOf(
+            Triple("String", "\"foo\"", "\"foo\""),
+            Triple("Boolean", "false", "false"),
+            Triple("Byte", "0", "0.toByte()"),
+            Triple("Short", "0", "0.toShort()"),
+            Triple("Integer", "2", "2"),
+            Triple("Long", "3", "3L"),
+            Triple("Float", "0", "0f"),
+            Triple("Double", "0", "0.0"),
+        ),
+    ) { (memberType, modelDefault, defaultValue) ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 
@@ -83,18 +83,19 @@ class SerializeStructGeneratorTest {
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        "String, \"foo\"",
-        "Boolean, false",
-        "Byte, 0",
-        "Short, 0",
-        "Integer, 2",
-        "Long, 3",
-        "Float, 0",
-        "Double, 0",
-    )
-    fun `it always serializes default values using always mode`(memberType: String, modelDefault: String) {
+    @Test
+    fun `it always serializes default values using always mode`() = parameterized(
+        listOf(
+            "String" to "\"foo\"",
+            "Boolean" to "false",
+            "Byte" to "0",
+            "Short" to "0",
+            "Integer" to "2",
+            "Long" to "3",
+            "Float" to "0",
+            "Double" to "0",
+        ),
+    ) { (memberType, modelDefault) ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 
@@ -115,18 +116,19 @@ class SerializeStructGeneratorTest {
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        "String, \"foo\"",
-        "Boolean, false",
-        "Byte, 0",
-        "Short, 0",
-        "Integer, 2",
-        "Long, 3",
-        "Float, 0",
-        "Double, 0",
-    )
-    fun `it always serializes required default values`(memberType: String, modelDefault: String) {
+    @Test
+    fun `it always serializes required default values`() = parameterized(
+        listOf(
+            "String" to "\"foo\"",
+            "Boolean" to "false",
+            "Byte" to "0",
+            "Short" to "0",
+            "Integer" to "2",
+            "Long" to "3",
+            "Float" to "0",
+            "Double" to "0",
+        ),
+    ) { (memberType, modelDefault) ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 
@@ -147,9 +149,10 @@ class SerializeStructGeneratorTest {
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = ["String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"])
-    fun `it serializes a structure with simple required fields`(memberType: String) {
+    @Test
+    fun `it serializes a structure with simple required fields`() = parameterized(
+        listOf("String", "Boolean", "Byte", "Short", "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal"),
+    ) { memberType ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 
@@ -170,13 +173,14 @@ class SerializeStructGeneratorTest {
         actual.shouldContainOnlyOnceWithDiff(expected)
     }
 
-    @ParameterizedTest(name = "{index} ==> ''{0}''")
-    @CsvSource(
-        "EPOCH_SECONDS, epoch-seconds",
-        "ISO_8601, date-time",
-        "RFC_5322, http-date",
-    )
-    fun `it serializes a structure with timestamp field`(runtimeEnum: String, tsFormatTrait: String) {
+    @Test
+    fun `it serializes a structure with timestamp field`() = parameterized(
+        listOf(
+            "EPOCH_SECONDS" to "epoch-seconds",
+            "ISO_8601" to "date-time",
+            "RFC_5322" to "http-date",
+        ),
+    ) { (runtimeEnum, tsFormatTrait) ->
         val model = (
             modelPrefix + """            
             structure FooRequest { 

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/rendering/waiters/AcceptorGeneratorTest.kt
@@ -15,10 +15,10 @@ import aws.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
 import aws.smithy.kotlin.codegen.test.TestModelDefault
 import aws.smithy.kotlin.codegen.test.createSymbolProvider
 import io.kotest.matchers.string.shouldContainOnlyOnce
-import org.junit.jupiter.api.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId
+import kotlin.test.Test
 
 class AcceptorGeneratorTest {
     val acceptorListName = "acceptorList"

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -21,10 +21,8 @@ dependencies {
     compileOnly(libs.dokka.core)
 
     testImplementation(libs.jsoup)
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test.junit5)
-    testImplementation(project(":runtime:testing"))
 }
 
 tasks.test {

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test.junit5)
+    testImplementation(project(":runtime:testing"))
 }
 
 tasks.test {

--- a/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
+++ b/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
@@ -4,14 +4,11 @@
  */
 package aws.smithy.kotlin.dokka
 
-import aws.smithy.kotlin.runtime.testing.TestInstance
-import aws.smithy.kotlin.runtime.testing.TestLifecycle
 import org.jsoup.Jsoup
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-@TestInstance(TestLifecycle.PER_CLASS)
 class DokkaSmithyTest {
     @Test
     fun testLoadScripts() {

--- a/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
+++ b/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
@@ -5,12 +5,13 @@
 package aws.smithy.kotlin.dokka
 
 import org.jsoup.Jsoup
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import aws.smithy.kotlin.runtime.testing.TestInstance
+import aws.smithy.kotlin.runtime.testing.TestLifecycle
 import java.io.File
+import kotlin.test.Test
 import kotlin.test.assertTrue
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(TestLifecycle.PER_CLASS)
 class DokkaSmithyTest {
     @Test
     fun testLoadScripts() {

--- a/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
+++ b/dokka-smithy/src/test/kotlin/aws/smithy/kotlin/dokka/DokkaSmithyTest.kt
@@ -4,9 +4,9 @@
  */
 package aws.smithy.kotlin.dokka
 
-import org.jsoup.Jsoup
 import aws.smithy.kotlin.runtime.testing.TestInstance
 import aws.smithy.kotlin.runtime.testing.TestLifecycle
+import org.jsoup.Jsoup
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertTrue

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ micrometer-version = "1.16.4"
 binary-compatibility-validator-version = "0.18.1"
 kotlin-multiplatform-bignum-version = "0.3.10"
 kotlinx-datetime-version = "0.7.1"
+kotlinx-io-version = "0.9.0"
 publish-plugin-version = "2.1.1"
 smithy-gradle-plugin-version = "1.4.0"
 
@@ -65,6 +66,7 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-version
 crt-kotlin = { module = "aws.sdk.kotlin.crt:aws-crt-kotlin", version.ref = "crt-kotlin-version" }
 micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer-version" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime-version" }
+kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io-version" }
 
 smithy-codegen-core = { module = "software.amazon.smithy:smithy-codegen-core", version.ref = "smithy-version" }
 smithy-cli = { module = "software.amazon.smithy:smithy-cli", version.ref = "smithy-version" }

--- a/runtime/auth/aws-signing-default/build.gradle.kts
+++ b/runtime/auth/aws-signing-default/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(project(":runtime:auth:aws-signing-tests"))
+                implementation(project(":runtime:testing"))
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinx.serialization.json)
             }

--- a/runtime/auth/aws-signing-default/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSigningSuiteTest.kt
+++ b/runtime/auth/aws-signing-default/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSigningSuiteTest.kt
@@ -4,8 +4,8 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning
 
-import aws.smithy.kotlin.runtime.auth.awssigning.tests.Sigv4TestSuiteTest
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.SigningSuiteTestBase
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.Sigv4TestSuiteTest
 import aws.smithy.kotlin.runtime.http.request.HttpRequest
 import aws.smithy.kotlin.runtime.testing.parameterized
 import kotlinx.coroutines.runBlocking
@@ -15,8 +15,7 @@ import kotlin.test.assertEquals
 class DefaultSigningSuiteTest : SigningSuiteTestBase() {
     override val signer: AwsSigner = DefaultAwsSigner
 
-    private suspend fun canonicalRequest(request: HttpRequest, config: AwsSigningConfig): String =
-        Canonicalizer.Default.canonicalRequest(request, config).requestString
+    private suspend fun canonicalRequest(request: HttpRequest, config: AwsSigningConfig): String = Canonicalizer.Default.canonicalRequest(request, config).requestString
 
     private suspend fun signature(request: HttpRequest, config: AwsSigningConfig): String {
         val canonical = Canonicalizer.Default.canonicalRequest(request, config)

--- a/runtime/auth/aws-signing-default/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSigningSuiteTest.kt
+++ b/runtime/auth/aws-signing-default/jvm/test/aws/smithy/kotlin/runtime/auth/awssigning/DefaultSigningSuiteTest.kt
@@ -4,26 +4,44 @@
  */
 package aws.smithy.kotlin.runtime.auth.awssigning
 
-import aws.smithy.kotlin.runtime.auth.awssigning.tests.SigningStateProvider
+import aws.smithy.kotlin.runtime.auth.awssigning.tests.Sigv4TestSuiteTest
 import aws.smithy.kotlin.runtime.auth.awssigning.tests.SigningSuiteTestBase
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.testing.parameterized
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class DefaultSigningSuiteTest : SigningSuiteTestBase() {
     override val signer: AwsSigner = DefaultAwsSigner
 
-    override val canonicalRequestProvider: SigningStateProvider = { request, config ->
-        val result = Canonicalizer.Default.canonicalRequest(request, config)
-        result.requestString
-    }
+    private suspend fun canonicalRequest(request: HttpRequest, config: AwsSigningConfig): String =
+        Canonicalizer.Default.canonicalRequest(request, config).requestString
 
-    override val signatureProvider: SigningStateProvider = { request, config ->
+    private suspend fun signature(request: HttpRequest, config: AwsSigningConfig): String {
         val canonical = Canonicalizer.Default.canonicalRequest(request, config)
         val stringToSign = SignatureCalculator.SigV4.stringToSign(canonical.requestString, config)
         val signingKey = SignatureCalculator.SigV4.signingKey(config)
-        SignatureCalculator.SigV4.calculate(signingKey, stringToSign)
+        return SignatureCalculator.SigV4.calculate(signingKey, stringToSign)
     }
 
-    override val stringToSignProvider: SigningStateProvider = { request, config ->
+    private suspend fun stringToSign(request: HttpRequest, config: AwsSigningConfig): String {
         val canonical = Canonicalizer.Default.canonicalRequest(request, config)
-        SignatureCalculator.SigV4.stringToSign(canonical.requestString, config)
+        return SignatureCalculator.SigV4.stringToSign(canonical.requestString, config)
+    }
+
+    @Test
+    fun testCanonicalRequest() = parameterized(headerTestArgs() + queryTestArgs()) { test: Sigv4TestSuiteTest ->
+        assertEquals(test.canonicalRequest, runBlocking { canonicalRequest(test.request.build(), test.config) })
+    }
+
+    @Test
+    fun testSignature() = parameterized(headerTestArgs() + queryTestArgs()) { test: Sigv4TestSuiteTest ->
+        assertEquals(test.signature, runBlocking { signature(test.request.build(), test.config) })
+    }
+
+    @Test
+    fun testStringToSign() = parameterized(headerTestArgs() + queryTestArgs()) { test: Sigv4TestSuiteTest ->
+        assertEquals(test.stringToSign, runBlocking { stringToSign(test.request.build(), test.config) })
     }
 }

--- a/runtime/auth/aws-signing-tests/build.gradle.kts
+++ b/runtime/auth/aws-signing-tests/build.gradle.kts
@@ -24,10 +24,10 @@ kotlin {
             dependencies {
                 implementation(project(":runtime:protocol:http"))
                 implementation(project(":runtime:protocol:http-test"))
+                implementation(project(":runtime:testing"))
                 implementation(libs.ktor.http.cio)
                 implementation(libs.ktor.utils)
                 implementation(libs.kotlin.test.junit5)
-                implementation(libs.junit.jupiter.params)
                 implementation(libs.kotlinx.serialization.json)
             }
         }

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -30,10 +30,7 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.*
-import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import aws.smithy.kotlin.runtime.testing.parameterized
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -85,11 +82,8 @@ private val AwsSignatureType.fileNamePart: String
         else -> error("Unsupported signature type $this for test suite")
     }
 
-public typealias SigningStateProvider = suspend (HttpRequest, AwsSigningConfig) -> String
-
 // FIXME - move to common test (will require ability to access test resources in a KMP compatible way)
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) // necessary so arg factory methods can handle disabledTests
 public actual abstract class SigningSuiteTestBase : HasSigner {
     private val testDirPaths: List<Path> by lazy {
         Files
@@ -134,15 +128,8 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
         )
     }
 
-    @ParameterizedTest(name = "header middleware test {0} (#{index})")
-    @MethodSource("headerTestArgs")
-    public fun testSigv4TestSuiteHeaders(test: Sigv4TestSuiteTest) {
-        testSigv4Middleware(test)
-    }
-
-    @ParameterizedTest(name = "query param middleware test {0} (#{index})")
-    @MethodSource("queryTestArgs")
-    public fun testSigv4TestSuiteQuery(test: Sigv4TestSuiteTest) {
+    @Test
+    public fun testSigv4TestSuite() = parameterized(headerTestArgs() + queryTestArgs()) { test ->
         testSigv4Middleware(test)
     }
 
@@ -174,69 +161,6 @@ public actual abstract class SigningSuiteTestBase : HasSigner {
             println("failed to get a signed request for ${test.path}: $ex")
             throw ex
         }
-    }
-
-    @ParameterizedTest(name = "header canonical request test {0} (#{index})")
-    @MethodSource("headerTestArgs")
-    public fun testCanonicalRequestHeaders(test: Sigv4TestSuiteTest) {
-        testCanonicalRequest(test)
-    }
-
-    @ParameterizedTest(name = "query param canonical request test {0} (#{index})")
-    @MethodSource("queryTestArgs")
-    public fun testCanonicalRequestQuery(test: Sigv4TestSuiteTest) {
-        testCanonicalRequest(test)
-    }
-
-    public open val canonicalRequestProvider: SigningStateProvider? = null
-
-    private fun testCanonicalRequest(test: Sigv4TestSuiteTest) = runBlocking {
-        assumeTrue(canonicalRequestProvider != null)
-        val expected = test.canonicalRequest
-        val actual = canonicalRequestProvider!!(test.request.build(), test.config)
-        assertEquals(expected, actual)
-    }
-
-    @ParameterizedTest(name = "header signature test {0} (#{index})")
-    @MethodSource("headerTestArgs")
-    public fun testSignatureHeaders(test: Sigv4TestSuiteTest) {
-        testSignature(test)
-    }
-
-    @ParameterizedTest(name = "query param signature test {0} (#{index})")
-    @MethodSource("queryTestArgs")
-    public fun testSignatureQuery(test: Sigv4TestSuiteTest) {
-        testSignature(test)
-    }
-
-    public open val signatureProvider: SigningStateProvider? = null
-
-    private fun testSignature(test: Sigv4TestSuiteTest) = runBlocking {
-        assumeTrue(signatureProvider != null)
-        val expected = test.signature
-        val actual = signatureProvider!!(test.request.build(), test.config)
-        assertEquals(expected, actual)
-    }
-
-    @ParameterizedTest(name = "header string to sign test {0} (#{index})")
-    @MethodSource("headerTestArgs")
-    public fun testStringToSignHeaders(test: Sigv4TestSuiteTest) {
-        testStringToSign(test)
-    }
-
-    @ParameterizedTest(name = "query param string to sign test {0} (#{index})")
-    @MethodSource("queryTestArgs")
-    public fun testStringToSignQuery(test: Sigv4TestSuiteTest) {
-        testStringToSign(test)
-    }
-
-    public open val stringToSignProvider: SigningStateProvider? = null
-
-    private fun testStringToSign(test: Sigv4TestSuiteTest) = runBlocking {
-        assumeTrue(stringToSignProvider != null)
-        val expected = test.stringToSign
-        val actual = stringToSignProvider!!(test.request.build(), test.config)
-        assertEquals(expected, actual)
     }
 
     /**

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource

--- a/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
+++ b/runtime/auth/aws-signing-tests/jvm/src/aws/smithy/kotlin/runtime/auth/awssigning/tests/SigningSuiteTestBaseJVM.kt
@@ -24,13 +24,13 @@ import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.identity.asIdentityProviderConfig
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import aws.smithy.kotlin.runtime.testing.parameterized
 import aws.smithy.kotlin.runtime.time.Instant
 import io.ktor.http.cio.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.*
-import aws.smithy.kotlin.runtime.testing.parameterized
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -129,9 +129,6 @@ subprojects {
     }
 
     tasks.withType<AbstractTestTask> {
-        if (this is Test) {
-            useJUnitPlatform()
-        }
 
         testLogging {
             events("passed", "skipped", "failed", "standardOut", "standardError")

--- a/runtime/observability/telemetry-provider-micrometer/jvm/test/aws/smithy/kotlin/runtime/telemetry/micrometer/MicrometerMeterProviderTest.kt
+++ b/runtime/observability/telemetry-provider-micrometer/jvm/test/aws/smithy/kotlin/runtime/telemetry/micrometer/MicrometerMeterProviderTest.kt
@@ -20,10 +20,10 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.AfterTest
+import kotlin.test.Test
 
 class MicrometerMeterProviderTest {
 
@@ -47,7 +47,7 @@ class MicrometerMeterProviderTest {
         Tag.of("scope", scope),
     )
 
-    @AfterEach
+    @AfterTest
     fun tearDown() {
         meterRegistry.clear()
     }

--- a/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-default/jvm/test/aws/smithy/kotlin/runtime/http/engine/HttpEngineConfigImplTest.kt
@@ -9,7 +9,6 @@ import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngineConfig
 import aws.smithy.kotlin.runtime.io.closeIfCloseable
-import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class HttpEngineConfigImplTest {

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptorTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/MetricsInterceptorTest.kt
@@ -9,31 +9,42 @@ import aws.smithy.kotlin.runtime.collections.emptyAttributes
 import aws.smithy.kotlin.runtime.http.engine.internal.HttpClientMetrics
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.telemetry.otel.OpenTelemetryProvider
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.metrics.data.MetricData
-import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.blackholeSink
 import okio.buffer
-import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
 @OptIn(ExperimentalApi::class)
 class MetricsInterceptorTest {
-    companion object {
-        @JvmField
-        @RegisterExtension
-        val otelTesting = OpenTelemetryExtension.create()
-    }
-
-    private val provider = OpenTelemetryProvider(otelTesting.openTelemetry)
+    private val metricReader = InMemoryMetricReader.create()
+    private val sdkMeterProvider = SdkMeterProvider.builder()
+        .registerMetricReader(metricReader)
+        .build()
+    private val otel: OpenTelemetry = OpenTelemetrySdk.builder()
+        .setMeterProvider(sdkMeterProvider)
+        .build()
+    private val provider = OpenTelemetryProvider(otel)
     private val meter = provider.meterProvider.getOrCreateMeter("test")
+    private val metrics: List<MetricData> get() = metricReader.collectAllMetrics().toList()
+
+    @BeforeTest
+    fun resetMetrics() {
+        SdkMeterProviderUtil.resetForTest(sdkMeterProvider)
+    }
 
     @Test
     fun testInstrumentedSource() {
@@ -50,7 +61,7 @@ class MetricsInterceptorTest {
 
         assertEquals(data.length.toLong(), sink.size)
 
-        val counted = otelTesting.metrics.first().longCounterSum()
+        val counted = metrics.first().longCounterSum()
         assertEquals(data.length.toLong(), counted)
     }
 
@@ -70,7 +81,7 @@ class MetricsInterceptorTest {
 
         assertEquals(data.length.toLong(), sink.size)
 
-        val counted = otelTesting.metrics.first().longCounterSum()
+        val counted = metrics.first().longCounterSum()
         assertEquals(data.length.toLong(), counted)
     }
 
@@ -109,10 +120,10 @@ class MetricsInterceptorTest {
         val actualRespData = resp.body.source().readByteArray().decodeToString()
         assertEquals(respData, actualRespData)
 
-        val actualBytesSent = otelTesting.metrics
+        val actualBytesSent = this.metrics
             .find { it.name == "smithy.client.http.bytes_sent" } ?: fail("expected bytes_sent")
 
-        val actualBytesReceived = otelTesting.metrics
+        val actualBytesReceived = this.metrics
             .find { it.name == "smithy.client.http.bytes_received" } ?: fail("expected bytes_received")
 
         assertEquals(reqData.length.toLong(), actualBytesSent.longCounterSum())

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpExceptionTest.kt
@@ -7,7 +7,6 @@ package aws.smithy.kotlin.runtime.http.engine.okhttp
 
 import aws.smithy.kotlin.runtime.http.HttpErrorCode
 import aws.smithy.kotlin.runtime.http.HttpException
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.EOFException
 import java.io.IOException
 import java.net.ConnectException
@@ -16,6 +15,7 @@ import javax.net.ssl.SSLHandshakeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class OkHttpExceptionTest {
     data class ExceptionTest(

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpRequestTest.kt
@@ -15,8 +15,8 @@ import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.operation.ExecutionContext
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import okio.Buffer
-import org.junit.jupiter.api.Test
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/OkHttpResponseTest.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import org.junit.jupiter.api.Test
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 

--- a/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
+++ b/runtime/protocol/http-client-engines/http-client-engine-okhttp/jvm/test/aws/smithy/kotlin/runtime/http/engine/okhttp/StreamingRequestBodyTest.kt
@@ -13,7 +13,6 @@ import aws.smithy.kotlin.runtime.text.encoding.encodeToHex
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import okio.Buffer
-import org.junit.jupiter.api.Test
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/ProxyTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/ProxyTest.kt
@@ -17,14 +17,15 @@ import aws.smithy.kotlin.runtime.http.test.util.AbstractEngineTest
 import aws.smithy.kotlin.runtime.http.test.util.engineConfig
 import aws.smithy.kotlin.runtime.http.test.util.test
 import aws.smithy.kotlin.runtime.net.url.Url
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import aws.smithy.kotlin.runtime.testing.AfterAll
+import aws.smithy.kotlin.runtime.testing.BeforeAll
+import aws.smithy.kotlin.runtime.testing.TestInstance
+import aws.smithy.kotlin.runtime.testing.TestLifecycle
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
+@TestInstance(TestLifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
 @EnabledIfSystemProperty(named = "aws.test.http.enableProxyTests", matches = "true")
 class ProxyTest : AbstractEngineTest() {
     private lateinit var mitmProxy: MitmContainer
@@ -54,7 +55,7 @@ class ProxyTest : AbstractEngineTest() {
     }
 }
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
+@TestInstance(TestLifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
 @EnabledIfSystemProperty(named = "aws.test.http.enableProxyTests", matches = "true")
 class ProxyAuthTest : AbstractEngineTest() {
     private lateinit var mitmProxy: MitmContainer

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
@@ -4,8 +4,6 @@
  */
 package aws.smithy.kotlin.runtime.hashing
 
-import org.junit.jupiter.api.condition.EnabledForJreRange
-import org.junit.jupiter.api.condition.JRE
 import java.security.*
 import java.security.interfaces.*
 import java.security.spec.*
@@ -102,9 +100,10 @@ class EcdsaJVMTest {
     }
 
     @Test
-    // SHA256withECDSAinP1363Format algorithm was introduced in Java 11, skip on Java 8
-    @EnabledForJreRange(min = JRE.JAVA_11)
+    // SHA256withECDSAinP1363Format algorithm was introduced in Java 9, skip on Java 8
     fun testVerifyRawSignature() {
+        if (runCatching { Signature.getInstance("SHA256withECDSAinP1363Format") }.isFailure) return
+
         val keyGen = KeyPairGenerator.getInstance("EC")
         keyGen.initialize(ECGenParameterSpec("secp256r1"))
         val keyPair = keyGen.generateKeyPair()

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
@@ -99,8 +99,8 @@ class EcdsaJVMTest {
         assertTrue(verifier.verify(signature))
     }
 
-    @Test
     // SHA256withECDSAinP1363Format algorithm was introduced in Java 9, skip on Java 8
+    @Test
     fun testVerifyRawSignature() {
         if (runCatching { Signature.getInstance("SHA256withECDSAinP1363Format") }.isFailure) return
 

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
@@ -102,7 +102,7 @@ class EcdsaJVMTest {
     // SHA256withECDSAinP1363Format algorithm was introduced in Java 9, skip on Java 8
     @Test
     fun testVerifyRawSignature() {
-        if (runCatching { Signature.getInstance("SHA256withECDSAinP1363Format") }.isFailure) return
+        val verifier = runCatching { Signature.getInstance("SHA256withECDSAinP1363Format") }.getOrElse { return }
 
         val keyGen = KeyPairGenerator.getInstance("EC")
         keyGen.initialize(ECGenParameterSpec("secp256r1"))
@@ -113,7 +113,6 @@ class EcdsaJVMTest {
         val message = "Hello, World!".toByteArray()
         val signature = ecdsaSecp256r1Rs(privateKey, message)
 
-        val verifier = Signature.getInstance("SHA256withECDSAinP1363Format")
         verifier.initVerify(publicKey)
         verifier.update(message)
 

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/hashing/EcdsaJVMTest.kt
@@ -4,14 +4,14 @@
  */
 package aws.smithy.kotlin.runtime.hashing
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.security.*
 import java.security.interfaces.*
 import java.security.spec.*
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class EcdsaJVMTest {
     // Helper function to generate valid test key

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/net/IpAddrJvmTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/net/IpAddrJvmTest.kt
@@ -5,8 +5,8 @@
 
 package aws.smithy.kotlin.runtime.net
 
-import org.junit.jupiter.api.Test
 import java.net.InetAddress
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class IpAddrJvmTest {

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/StandardRetryIntegrationTest.kt
@@ -15,7 +15,6 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.assertThrows
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -52,7 +51,7 @@ class StandardRetryIntegrationTest {
                     assertEquals(Ok, result.getOrThrow().getOrThrow(), "Unexpected outcome for $name")
 
                 TestOutcome.MaxAttemptsExceeded -> {
-                    val e = assertThrows<HttpCodeException>("Expected exception for $name") {
+                    val e = assertFailsWith<HttpCodeException>("Expected exception for $name") {
                         result.getOrThrow()
                     }
 
@@ -60,7 +59,7 @@ class StandardRetryIntegrationTest {
                 }
 
                 TestOutcome.RetryQuotaExceeded -> {
-                    val e = assertThrows<HttpCodeException>("Expected exception for $name") {
+                    val e = assertFailsWith<HttpCodeException>("Expected exception for $name") {
                         result.getOrThrow()
                     }
 

--- a/runtime/testing/build.gradle.kts
+++ b/runtime/testing/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.io.core)
                 implementation(project(":runtime:runtime-core")) // for Uuid
             }
         }

--- a/runtime/testing/build.gradle.kts
+++ b/runtime/testing/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlin.test)
-                implementation(libs.kotlinx.io.core)
+                api(libs.kotlinx.io.core)
                 implementation(project(":runtime:runtime-core")) // for Uuid
             }
         }

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/Parameterized.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/Parameterized.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.testing
+
+import kotlin.test.fail
+
+/**
+ * Runs [test] for each element in [cases], collecting all failures and reporting them at the end.
+ * This is a cross-platform alternative to JUnit's `@ParameterizedTest`.
+ *
+ * Example (single parameter):
+ * ```
+ * @Test
+ * fun testPrimitives() = parameterized(listOf("String", "Boolean", "Byte")) { type ->
+ *     val symbol = provider.toSymbol(model.expectShape("smithy.api#$type"))
+ *     assertEquals("kotlin", symbol.namespace)
+ * }
+ * ```
+ *
+ * Example (multiple parameters using [Pair]):
+ * ```
+ * @Test
+ * fun testTimestamps() = parameterized(
+ *     listOf(
+ *         "EPOCH_SECONDS" to "epoch-seconds",
+ *         "ISO_8601" to "date-time",
+ *     ),
+ * ) { (runtimeEnum, formatTrait) ->
+ *     // ...
+ * }
+ * ```
+ *
+ * Example (multiple parameters using [Triple]):
+ * ```
+ * @Test
+ * fun testDefaults() = parameterized(
+ *     listOf(
+ *         Triple("String", "\"foo\"", "\"foo\""),
+ *         Triple("Boolean", "false", "false"),
+ *     ),
+ * ) { (type, modelDefault, expectedDefault) ->
+ *     // ...
+ * }
+ * ```
+ */
+public fun <T> parameterized(cases: List<T>, test: (T) -> Unit) {
+    val failures = cases.mapNotNull { case ->
+        runCatching { test(case) }.exceptionOrNull()?.let { case to it }
+    }
+    if (failures.isNotEmpty()) {
+        fail(
+            buildString {
+                appendLine("${failures.size}/${cases.size} case(s) failed:")
+                failures.forEach { (case, error) ->
+                    appendLine("  [$case]: ${error.message}")
+                }
+            },
+        )
+    }
+}

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
@@ -16,8 +16,10 @@ import kotlinx.io.files.SystemTemporaryDirectory
 public enum class TempDirCleanupMode {
     /** Always delete the directory after the block completes, regardless of success or failure. */
     ALWAYS,
+
     /** Only delete the directory if the block completes successfully. On failure, preserve for debugging. */
     ON_SUCCESS,
+
     /** Never delete the directory. */
     NEVER,
 }

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
@@ -32,14 +32,16 @@ public enum class TempDirCleanupMode {
  * Example:
  * ```
  * @Test
- * fun testSomething() = withTempDir { dir ->
- *     val file = Path(dir, "test.txt")
- *     // ...
+ * fun testSomething() = runTest {
+ *     withTempDir { dir ->
+ *         val file = Path(dir, "test.txt")
+ *         // ...
+ *     }
  * }
  * ```
  */
 @OptIn(InternalApi::class)
-public fun <T> withTempDir(cleanup: TempDirCleanupMode = TempDirCleanupMode.ON_SUCCESS, block: (dir: Path) -> T): T {
+public suspend fun <T> withTempDir(cleanup: TempDirCleanupMode = TempDirCleanupMode.ON_SUCCESS, block: suspend (dir: Path) -> T): T {
     val dir = Path(SystemTemporaryDirectory, "test-${Uuid.random()}")
     SystemFileSystem.createDirectories(dir)
     try {

--- a/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
+++ b/runtime/testing/common/src/aws/smithy/kotlin/runtime/testing/TempDir.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.testing
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.util.Uuid
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+
+/**
+ * Cleanup behavior for temporary directories created by [withTempDir].
+ */
+public enum class TempDirCleanupMode {
+    /** Always delete the directory after the block completes, regardless of success or failure. */
+    ALWAYS,
+    /** Only delete the directory if the block completes successfully. On failure, preserve for debugging. */
+    ON_SUCCESS,
+    /** Never delete the directory. */
+    NEVER,
+}
+
+/**
+ * Creates a temporary directory, runs [block] with the directory [Path], and cleans up based on [cleanup] mode.
+ *
+ * This is a cross-platform replacement for JUnit's `@TempDir`.
+ *
+ * Example:
+ * ```
+ * @Test
+ * fun testSomething() = withTempDir { dir ->
+ *     val file = Path(dir, "test.txt")
+ *     // ...
+ * }
+ * ```
+ */
+@OptIn(InternalApi::class)
+public fun <T> withTempDir(cleanup: TempDirCleanupMode = TempDirCleanupMode.ON_SUCCESS, block: (dir: Path) -> T): T {
+    val dir = Path(SystemTemporaryDirectory, "test-${Uuid.random()}")
+    SystemFileSystem.createDirectories(dir)
+    try {
+        val result = block(dir)
+        if (cleanup != TempDirCleanupMode.NEVER) {
+            dir.deleteRecursively()
+        }
+        return result
+    } catch (e: Throwable) {
+        if (cleanup == TempDirCleanupMode.ALWAYS) {
+            dir.deleteRecursively()
+        }
+        throw e
+    }
+}
+
+private fun Path.deleteRecursively() {
+    if (!SystemFileSystem.exists(this)) return
+    val metadata = SystemFileSystem.metadataOrNull(this)
+    if (metadata?.isDirectory == true) {
+        SystemFileSystem.list(this).forEach { child ->
+            child.deleteRecursively()
+        }
+    }
+    SystemFileSystem.delete(this)
+}


### PR DESCRIPTION
### Description

Replaces JUnit-specific APIs with kotlin.test and cross-platform utilities in `runtime:testing`, as part of the effort to standardize on `kotlin-test` across our repositories.

### Changes

#### New cross-platform utilities in runtime:testing

- **parameterized()** — cross-platform alternative to JUnit's `@ParameterizedTest`. Runs a test block for each case, collects all failures, and reports them at the end with case-level detail.
- **withTempDir()** — cross-platform alternative to JUnit's `@TempDir`. Creates a temporary directory using `kotlinx-io`, runs a block, and cleans up based on `TempDirCleanupMode` (ALWAYS, ON_SUCCESS, NEVER). Default is ON_SUCCESS (matches JUnit's `CleanupMode.ON_SUCCESS`).
- Added `kotlinx-io-core` dependency for cross-platform filesystem operations.

#### JUnit removals

- **@ParameterizedTest / @MethodSource** — Tests converted to use `parameterized()`.
- **@ParameterizedTest / @MethodSource / assumeTrue** — Provider-specific tests (canonical request, signature, string-to-sign) moved from the base class into `DefaultSigningSuiteTest` directly, eliminating the need for assumeTrue to skip tests when providers are null in `CrtSigningSuiteTest`.
- **@RegisterExtension** — Replaced JUnit's OpenTelemetryExtension with manual InMemoryMetricReader + SdkMeterProvider + OpenTelemetrySdk setup. Metrics are reset via `@BeforeTest`.
- **@EnabledForJreRange** — Removed from EcdsaJVMTest. Replaced with a runtime check that returns early if `SHA256withECDSAinP1363Format` is unavailable (Java 8). Also fixed the comment: this algorithm was 
introduced in Java 9, not Java 11.
- **@TestInstance(PER_CLASS)** — Removed from DokkaSmithyTest (unnecessary, no shared state).

#### Kept as-is (documented)

- **@EnabledIfSystemProperty** in ProxyTest.kt — Required for class-level skip of Docker-dependent proxy tests. Gradle sets the property based on environment (not CodeBuild + Linux). Replacing would require Gradle test filtering or runtime guards in @BeforeAll.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.