### PR TITLE
Replace junit with kotlin test

### DIFF
--- a/codegen/aws-codegen/build.gradle.kts
+++ b/codegen/aws-codegen/build.gradle.kts
@@ -27,8 +27,6 @@ dependencies {
     api(libs.smithy.protocol.traits)
     implementation(libs.smithy.aws.endpoints)
 
-    testImplementation(libs.junit.jupiter)
-    testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(project(":codegen:codegen-testutils"))

--- a/codegen/codegen-testutils/build.gradle.kts
+++ b/codegen/codegen-testutils/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     api(project(":codegen:codegen"))
 
     // Test dependencies
-    implementation(libs.junit.jupiter)
     implementation(libs.kotest.assertions.core.jvm)
     implementation(libs.kotlin.test)
     implementation(libs.kotlin.test.junit5)

--- a/codegen/codegen/build.gradle.kts
+++ b/codegen/codegen/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(libs.jsoup)
 
     // Test dependencies
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit5)

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testImplementation(libs.jsoup)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test.junit5)
+    testImplementation(project(":runtime:testing"))
 }
 
 tasks.test {

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     testImplementation(libs.jsoup)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test.junit5)
-    testImplementation(project(":runtime:testing"))
 }
 
 tasks.test {

--- a/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/ProxyTest.kt
+++ b/runtime/protocol/http-client-engines/test-suite/jvm/test/aws/smithy/kotlin/runtime/http/test/ProxyTest.kt
@@ -21,66 +21,73 @@ import aws.smithy.kotlin.runtime.testing.AfterAll
 import aws.smithy.kotlin.runtime.testing.BeforeAll
 import aws.smithy.kotlin.runtime.testing.TestInstance
 import aws.smithy.kotlin.runtime.testing.TestLifecycle
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+private fun proxyTestsEnabled() = System.getProperty("aws.test.http.enableProxyTests") == "true"
+
 @TestInstance(TestLifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
-@EnabledIfSystemProperty(named = "aws.test.http.enableProxyTests", matches = "true")
 class ProxyTest : AbstractEngineTest() {
-    private lateinit var mitmProxy: MitmContainer
+    private var mitmProxy: MitmContainer? = null
 
     @BeforeAll
     fun setUp() {
+        if (!proxyTestsEnabled()) return
         mitmProxy = MitmContainer("--set", "fakeupstream=aws.amazon.com")
     }
 
     @AfterAll
     fun cleanUp() {
-        mitmProxy.close()
+        mitmProxy?.close()
     }
 
     @Test
-    fun testHttpProxy() = testEngines {
-        engineConfig {
-            val hostPort = mitmProxy.hostPort
-            proxySelector = ProxySelector {
-                ProxyConfig.Http("http://127.0.0.1:$hostPort")
+    fun testHttpProxy() {
+        val proxy = mitmProxy ?: return
+        testEngines {
+            engineConfig {
+                val hostPort = proxy.hostPort
+                proxySelector = ProxySelector {
+                    ProxyConfig.Http("http://127.0.0.1:$hostPort")
+                }
             }
-        }
 
-        test { _, client ->
-            testProxyResponse(client)
+            test { _, client ->
+                testProxyResponse(client)
+            }
         }
     }
 }
 
 @TestInstance(TestLifecycle.PER_CLASS) // enables non-static @BeforeAll/@AfterAll methods
-@EnabledIfSystemProperty(named = "aws.test.http.enableProxyTests", matches = "true")
 class ProxyAuthTest : AbstractEngineTest() {
-    private lateinit var mitmProxy: MitmContainer
+    private var mitmProxy: MitmContainer? = null
 
     @BeforeAll
     fun setUp() {
+        if (!proxyTestsEnabled()) return
         mitmProxy = MitmContainer("--proxyauth", "testuser:testpass", "--set", "fakeupstream=aws.amazon.com")
     }
 
     @AfterAll
     fun cleanUp() {
-        mitmProxy.close()
+        mitmProxy?.close()
     }
 
     @Test
-    fun testHttpProxyAuth() = testEngines {
-        engineConfig {
-            val hostPort = mitmProxy.hostPort
-            proxySelector = ProxySelector {
-                ProxyConfig.Http("http://testuser:testpass@127.0.0.1:$hostPort")
+    fun testHttpProxyAuth() {
+        val proxy = mitmProxy ?: return
+        testEngines {
+            engineConfig {
+                val hostPort = proxy.hostPort
+                proxySelector = ProxySelector {
+                    ProxyConfig.Http("http://testuser:testpass@127.0.0.1:$hostPort")
+                }
             }
-        }
 
-        test { _, client ->
-            testProxyResponse(client)
+            test { _, client ->
+                testProxyResponse(client)
+            }
         }
     }
 }

--- a/tests/compile/build.gradle.kts
+++ b/tests/compile/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     testImplementation(libs.smithy.protocol.test.traits)
     testImplementation(libs.smithy.aws.traits)
 
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.compile.testing)
     testImplementation(libs.kotlin.test.junit5)

--- a/tests/integration/slf4j-1x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-1x-consumer/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
         }
     }
 
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit5)
 }

--- a/tests/integration/slf4j-2x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-2x-consumer/build.gradle.kts
@@ -15,7 +15,6 @@ skipPublishing()
 dependencies {
     implementation(project(":runtime:observability:logging-slf4j2"))
     implementation(libs.slf4j.simple)
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit5)
 }

--- a/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(project(":runtime:observability:logging-slf4j2"))
     // In this test, we have a slf4j2x present in the classpath, but we declare a slf4j1x Logger interface.
     testImplementation(libs.slf4j.api)
-    testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit5)
 }


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                 
Replaces JUnit's `@EnabledIfSystemProperty` annotation in `ProxyTest.kt` with a runtime system property check, removing the last direct `org.junit` import from modules.

## Changes
- Replaced `@EnabledIfSystemProperty` with a `proxyTestsEnabled()` helper that checks `aws.test.http.enableProxyTests` at runtime.
- Guard in `@BeforeAll` prevents Docker/MitmContainer from starting when the property is not set.

## Note
These tests remain JVM-only due to Docker dependency and cannot be moved to common source sets. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
