### PR TITLE
fix junit dependencies

### DIFF
--- a/codegen/aws-codegen/build.gradle.kts
+++ b/codegen/aws-codegen/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(libs.smithy.aws.endpoints)
 
     testImplementation(libs.kotest.assertions.core.jvm)
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
     testImplementation(project(":codegen:codegen-testutils"))
 
     testImplementation(libs.slf4j.api)

--- a/codegen/codegen-testutils/build.gradle.kts
+++ b/codegen/codegen-testutils/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     // Test dependencies
     implementation(libs.kotest.assertions.core.jvm)
     implementation(libs.kotlin.test)
-    implementation(libs.kotlin.test.junit5)
 }
 
 tasks.withType<KotlinCompile> {

--- a/codegen/codegen/build.gradle.kts
+++ b/codegen/codegen/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     // Test dependencies
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.kotlin.test.junit5)
     testImplementation(project(":codegen:codegen-testutils"))
     testImplementation(project(":runtime:testing"))
 }

--- a/dokka-smithy/build.gradle.kts
+++ b/dokka-smithy/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
     testImplementation(libs.jsoup)
     testImplementation(libs.kotest.assertions.core.jvm)
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }
 
 tasks.test {

--- a/runtime/auth/aws-signing-tests/build.gradle.kts
+++ b/runtime/auth/aws-signing-tests/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
                 implementation(project(":runtime:testing"))
                 implementation(libs.ktor.http.cio)
                 implementation(libs.ktor.utils)
-                implementation(libs.kotlin.test)
+                implementation(libs.kotlin.test.junit5)
                 implementation(libs.kotlinx.serialization.json)
             }
         }

--- a/runtime/auth/aws-signing-tests/build.gradle.kts
+++ b/runtime/auth/aws-signing-tests/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
                 implementation(project(":runtime:testing"))
                 implementation(libs.ktor.http.cio)
                 implementation(libs.ktor.utils)
-                implementation(libs.kotlin.test.junit5)
+                implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.serialization.json)
             }
         }

--- a/runtime/smithy-test/build.gradle.kts
+++ b/runtime/smithy-test/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(libs.kotlin.test)
+                implementation(libs.kotlin.test.junit5)
             }
         }
 

--- a/runtime/testing/build.gradle.kts
+++ b/runtime/testing/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
         jvmMain {
             dependencies {
                 api(libs.junit.jupiter)
-                implementation(libs.kotlin.test)
+                implementation(libs.kotlin.test.junit5)
                 api(libs.kotlinx.coroutines.test)
             }
         }

--- a/tests/codegen/nullability-tests/build.gradle.kts
+++ b/tests/codegen/nullability-tests/build.gradle.kts
@@ -65,5 +65,5 @@ dependencies {
     implementation(project(":runtime:observability:telemetry-api"))
     implementation(project(":runtime:observability:telemetry-defaults"))
 
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }

--- a/tests/codegen/paginator-tests/build.gradle.kts
+++ b/tests/codegen/paginator-tests/build.gradle.kts
@@ -61,5 +61,5 @@ dependencies {
     implementation(project(":runtime:observability:telemetry-api"))
     implementation(project(":runtime:observability:telemetry-defaults"))
 
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }

--- a/tests/codegen/serde-tests/build.gradle.kts
+++ b/tests/codegen/serde-tests/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation(project(":runtime:serde:serde-xml"))
     implementation(project(":runtime:smithy-test"))
 
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }
 
 val generatedSrcDir = project.layout.projectDirectory.dir("generated-src/main/kotlin")

--- a/tests/codegen/waiter-tests/build.gradle.kts
+++ b/tests/codegen/waiter-tests/build.gradle.kts
@@ -64,5 +64,5 @@ dependencies {
     implementation(project(":runtime:observability:telemetry-defaults"))
 
     testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }

--- a/tests/compile/build.gradle.kts
+++ b/tests/compile/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
     testImplementation(libs.kotest.assertions.core.jvm)
     testImplementation(libs.kotlin.compile.testing)
-    testImplementation(libs.kotlin.test.junit5)
+    testImplementation(libs.kotlin.test)
 }
 
 tasks.test {

--- a/tests/integration/slf4j-1x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-1x-consumer/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     }
 
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.kotlin.test.junit5)
 }
 
 tasks.withType<KotlinCompile> {

--- a/tests/integration/slf4j-2x-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-2x-consumer/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(project(":runtime:observability:logging-slf4j2"))
     implementation(libs.slf4j.simple)
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.kotlin.test.junit5)
 }
 
 tasks.withType<KotlinCompile> {

--- a/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
+++ b/tests/integration/slf4j-hybrid-consumer/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     // In this test, we have a slf4j2x present in the classpath, but we declare a slf4j1x Logger interface.
     testImplementation(libs.slf4j.api)
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.kotlin.test.junit5)
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
Replace `kotlin.test.junit5` with `kotlin.test` and let it to auto resolve `kotlin.test.junit5`
Remove reduntant `kotlin.test.junit5` import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
