### PR TITLE
fix: use platform-safe conversion for fseek offset in native

### DIFF
--- a/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderBase.kt
+++ b/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderBase.kt
@@ -74,7 +74,9 @@ public abstract class SystemDefaultProviderBase : PlatformProvider {
         val file = fopen(path, mode) ?: throw IOException("Cannot open file for writing: $path")
         try {
             if (writeType is WriteType.OFFSET) {
-                fseek(file, writeType.offset, SEEK_SET)
+                // Handles offset being int or long depending on platform with convert
+                @OptIn(UnsafeNumber::class)
+                fseek(file, writeType.offset.convert(), SEEK_SET)
             }
             val wc = fwrite(data.refTo(0), 1uL, data.size.toULong(), file)
             if (wc != data.size.toULong()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Fixes release failure during linux build: 
```
> Task :runtime:runtime-core:compileNativeMainKotlinMetadata FAILED
--
e: file:///codebuild/output/src1658181663/src/smithy-kotlin/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderBase.kt:77:17 The declaration is using numbers with different bit widths in least two actual platforms. Such types shall not be used in user-defined 'expect fun' signatures
e: file:///codebuild/output/src1658181663/src/smithy-kotlin/runtime/runtime-core/native/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderBase.kt:77:29 Argument type mismatch: actual type is 'Long', but 'Int' was expected.
```
(https://tiny.amazon.com/94eefg13/IsenLink)

Reproduce error by running this **with KN enabled**:
```
./gradlew :runtime:runtime-core:compileNativeMainKotlinMetadata --rerun-tasks -Paws.kotlin.native.enableAllTargets=true
```

Root cause is different platforms handling `fseek` differently (some use int and others long and we need to opt in to this and also use convert). It's a pattern we follow elsewhere in the file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
