### PR TITLE
add legacy strategy

### DIFF
--- a/codegen/codegen/api/codegen.api
+++ b/codegen/codegen/api/codegen.api
@@ -714,6 +714,7 @@ public final class aws/smithy/kotlin/codegen/core/RuntimeTypes$Core$Net$Url : aw
 
 public final class aws/smithy/kotlin/codegen/core/RuntimeTypes$Core$Retries : aws/smithy/kotlin/codegen/core/RuntimeTypePackage {
 	public static final field INSTANCE Laws/smithy/kotlin/codegen/core/RuntimeTypes$Core$Retries;
+	public final fun getLegacyRetryStrategy ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getOutcome ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getRetryStrategy ()Lsoftware/amazon/smithy/codegen/core/Symbol;
 	public final fun getStandardRetryStrategy ()Lsoftware/amazon/smithy/codegen/core/Symbol;

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/RuntimeTypes.kt
@@ -153,6 +153,7 @@ object RuntimeTypes {
             val Outcome = symbol("Outcome")
             val RetryStrategy = symbol("RetryStrategy")
             val StandardRetryStrategy = symbol("StandardRetryStrategy")
+            val LegacyRetryStrategy = symbol("LegacyRetryStrategy")
 
             object Delay : RuntimeTypePackage(KotlinDependency.CORE, "retries.delay") {
                 val InfiniteTokenBucket = symbol("InfiniteTokenBucket")

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
@@ -15,6 +15,7 @@ import aws.smithy.kotlin.runtime.http.request.toBuilder
 import aws.smithy.kotlin.runtime.io.Handler
 import aws.smithy.kotlin.runtime.io.middleware.Middleware
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
+import aws.smithy.kotlin.runtime.retries.LegacyRetryStrategy
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
@@ -49,6 +50,7 @@ internal class RetryMiddleware<I, O>(
             val outcome = strategy.retry(wrappedPolicy) {
                 withSpan<RetryMiddleware<*, *>, _>("Attempt-$attempt") {
                     when (strategy::class) {
+                        LegacyRetryStrategy::class -> modified.context.emitBusinessMetric(SmithyBusinessMetric.RETRY_MODE_LEGACY)
                         StandardRetryStrategy::class -> modified.context.emitBusinessMetric(SmithyBusinessMetric.RETRY_MODE_STANDARD)
                         AdaptiveRetryStrategy::class -> modified.context.emitBusinessMetric(SmithyBusinessMetric.RETRY_MODE_ADAPTIVE)
                     }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -129,6 +129,7 @@ public final class aws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetri
 	public static final field PROTOCOL_RPC_V2_CBOR Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static final field RESOLVED_ACCOUNT_ID Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static final field RETRY_MODE_ADAPTIVE Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
+	public static final field RETRY_MODE_LEGACY Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static final field RETRY_MODE_STANDARD Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static final field SERVICE_ENDPOINT_OVERRIDE Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
 	public static final field SIGV4A_SIGNING Laws/smithy/kotlin/runtime/businessmetrics/SmithyBusinessMetric;
@@ -1768,6 +1769,52 @@ public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Confi
 
 public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config$Companion {
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;
+}
+
+public class aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy : aws/smithy/kotlin/runtime/retries/RetryStrategy {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Companion;
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun afterTry (ILjava/lang/Object;Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun beforeInitialTry (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun beforeRetry (ILjava/lang/Object;Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
+	public fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public class aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config$Companion;
+	public static final field DEFAULT_MAX_ATTEMPTS I
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config$Builder;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public class aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config$Builder : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config$Builder {
+	public fun <init> ()V
+	public final fun delayProvider (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun delayProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
+	public fun getMaxAttempts ()I
+	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
+	public final fun setDelayProvider (Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
+	public fun setMaxAttempts (I)V
+	public final fun setTokenBucket (Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;)V
+	public final fun tokenBucket (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
+	public final fun tokenBucket (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config$Companion {
+	public final fun default ()Laws/smithy/kotlin/runtime/retries/LegacyRetryStrategy$Config;
 }
 
 public abstract class aws/smithy/kotlin/runtime/retries/Outcome {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtils.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/businessmetrics/BusinessMetricsUtils.kt
@@ -82,6 +82,7 @@ public interface BusinessMetric {
 public enum class SmithyBusinessMetric(public override val identifier: String) : BusinessMetric {
     WAITER("B"), // TODO: Emit this metric
     PAGINATOR("C"), // TODO: Emit this metric
+    RETRY_MODE_LEGACY("D"),
     RETRY_MODE_STANDARD("E"),
     RETRY_MODE_ADAPTIVE("F"),
     GZIP_REQUEST_COMPRESSION("L"),

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/LegacyRetryStrategy.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries
+
+import aws.smithy.kotlin.runtime.ClientErrorContext
+import aws.smithy.kotlin.runtime.ErrorMetadata
+import aws.smithy.kotlin.runtime.ServiceException
+import aws.smithy.kotlin.runtime.collections.appendValue
+import aws.smithy.kotlin.runtime.retries.delay.*
+import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import aws.smithy.kotlin.runtime.util.DslBuilderProperty
+import aws.smithy.kotlin.runtime.util.DslFactory
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Implements a retry strategy utilizing backoff delayer and a token bucket for rate limiting and circuit breaking. Note
+ * that the backoff delayer and token bucket work independently of each other. Either can delay retries (and the token
+ * bucket can delay the initial try). The delayer is called first so that the token bucket can refill as appropriate.
+ *
+ * [LegacyRetryStrategy] is the old retry mode for the majority of use cases.
+ * @param config The options that control the functionality of this strategy.
+ */
+public open class LegacyRetryStrategy(override val config: Config = Config.default()) : RetryStrategy {
+    public companion object : DslFactory<Config.Builder, LegacyRetryStrategy> {
+        public override operator fun invoke(block: Config.Builder.() -> Unit): LegacyRetryStrategy = LegacyRetryStrategy(Config(Config.Builder().apply(block)))
+    }
+
+    /**
+     * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
+     * outcomes from retrying.
+     */
+    override suspend fun <R> retry(policy: RetryPolicy<R>, block: suspend () -> R): Outcome<R> {
+        try {
+            beforeInitialTry()
+        } catch (ex: RetryCapacityExceededException) {
+            throwCapacityExceeded<Unit>(ex, 1, null)
+        }
+
+        return doTryLoop(block, policy, 1, config.tokenBucket.acquireToken())
+    }
+
+    /**
+     * Perform a single iteration of the try loop. Execute the block of code, evaluate the result, and take action to
+     * terminate or enter the next iteration of the try loop.
+     * @param block The block of code to retry.
+     * @param policy The [RetryPolicy] to use for evaluating the execution result.
+     * @param attempt The ordinal index of the retry loop (starting at 1).
+     * @param fromToken A [RetryToken] which grants the strategy capacity to execute a try. This token is resolved
+     * inside the function by calling [notifySuccess][RetryToken.notifySuccess],
+     * [notifyFailure][RetryToken.notifyFailure], or [scheduleRetry][RetryToken.scheduleRetry].
+     * @return The successful [Outcome] from the final try.
+     */
+    private tailrec suspend fun <R> doTryLoop(
+        block: suspend () -> R,
+        policy: RetryPolicy<R>,
+        attempt: Int,
+        fromToken: RetryToken,
+    ): Outcome<R> {
+        val callResult = runCatching { block() }
+        (callResult.exceptionOrNull() as? CancellationException)?.let { throw it }
+        val evaluation = policy.evaluate(callResult)
+
+        val nextToken = try {
+            afterTry(attempt, callResult, evaluation, policy)
+
+            when (evaluation) {
+                is RetryDirective.TerminateAndSucceed ->
+                    return success(fromToken, attempt, callResult)
+
+                is RetryDirective.TerminateAndFail ->
+                    throwFailure(attempt, callResult)
+
+                is RetryDirective.RetryError ->
+                    if (attempt >= config.maxAttempts) {
+                        throwTooManyAttempts(attempt, callResult)
+                    } else {
+                        // Prep for another loop
+                        config.delayProvider.backoff(attempt)
+                        fromToken.scheduleRetry(evaluation.reason)
+                    }
+            }.also {
+                beforeRetry(attempt + 1, callResult, evaluation, policy)
+            }
+        } catch (ex: RetryCapacityExceededException) {
+            throwCapacityExceeded(ex, attempt, callResult)
+        } catch (ex: Throwable) {
+            fromToken.notifyFailure()
+            throw ex
+        }
+
+        return doTryLoop(block, policy, attempt + 1, nextToken)
+    }
+
+    protected open suspend fun beforeInitialTry() {
+        // No action necessary by default
+    }
+
+    protected open suspend fun <R> afterTry(
+        attempt: Int,
+        callResult: Result<R>,
+        evaluation: RetryDirective,
+        policy: RetryPolicy<R>,
+    ) {
+        // No action necessary by default
+    }
+
+    protected open suspend fun <R> beforeRetry(
+        attempt: Int,
+        callResult: Result<R>,
+        evaluation: RetryDirective,
+        policy: RetryPolicy<R>,
+    ) {
+        // No action necessary by default
+    }
+
+    /**
+     * Handles the successful termination of the retry loop by marking the [RetryToken] as successful and getting the
+     * [Result]'s value.
+     * @param token The [RetryToken] used in the attempt that was successful.
+     * @param result The [Result] that was evaluated to be successful.
+     * @return The [Result]'s value.
+     */
+    private suspend fun <R> success(token: RetryToken, attempt: Int, result: Result<R>): Outcome<R> {
+        token.notifySuccess()
+        return when (val response = result.getOrNull()) {
+            null -> Outcome.Exception(attempt, result.exceptionOrNull()!!)
+            else -> Outcome.Response(attempt, response)
+        }
+    }
+
+    private fun <R> throwCapacityExceeded(
+        cause: RetryCapacityExceededException,
+        attempt: Int,
+        result: Result<R>?,
+    ): Nothing {
+        val capacityMessage = buildString {
+            append("Insufficient client capacity to attempt retry, halting on attempt ")
+            append(attempt)
+            append(" of ")
+            append(config.maxAttempts)
+        }
+
+        throw when (val retryableException = result?.exceptionOrNull()) {
+            null -> throw TooManyAttemptsException(
+                capacityMessage,
+                cause,
+                attempt,
+                result?.getOrNull(),
+                result?.exceptionOrNull(),
+            )
+
+            is ServiceException -> retryableException.apply {
+                val addCtx = ClientErrorContext("Early retry termination", capacityMessage)
+                sdkErrorMetadata.attributes.appendValue(ErrorMetadata.ClientContext, addCtx)
+            }
+
+            else -> retryableException
+        }
+    }
+
+    /**
+     * Handles the termination of the retry loop because of a non-retryable failure by throwing a
+     * [RetryFailureException].
+     * @param attempt The number of attempts completed.
+     * @param result The [Result] that yielded the non-retryable condition.
+     */
+    private fun <R> throwFailure(attempt: Int, result: Result<R>): Nothing = when (val ex = result.exceptionOrNull()) {
+        null -> throw RetryFailureException(
+            "The operation resulted in a non-retryable failure",
+            null,
+            attempt,
+            result.getOrNull(),
+        )
+        else -> throw ex
+    }
+
+    /**
+     * Handles the termination of the retry loop because too many attempts have been made by throwing a
+     * [TimedOutException].
+     * @param attempt The number of attempts completed.
+     * @param result The [Result] that yielded a retryable condition (but which won't be retried because we've already
+     * tried too many times).
+     */
+    private fun <R> throwTooManyAttempts(attempt: Int, result: Result<R>): Nothing = when (val ex = result.exceptionOrNull()) {
+        null -> throw TooManyAttemptsException(
+            "Took more than ${config.maxAttempts} attempts to get a successful response",
+            null,
+            attempt,
+            result.getOrNull(),
+            result.exceptionOrNull(),
+        )
+        else -> throw ex
+    }
+
+    /**
+     * Configuration options for [LegacyRetryStrategy]
+     */
+    public open class Config(builder: Builder) : RetryStrategy.Config {
+        public companion object {
+            /**
+             * Creates a new default configuration instance. A new instance is returned for each method call so that a
+             * single token bucket isn't shared across all instances. Callers that desire shared token bucket scopes
+             * should pass an explicit token bucket instance.
+             */
+            public fun default(): Config = Config(Builder())
+
+            /**
+             * The default number of maximum attempts for new config instances
+             */
+            public const val DEFAULT_MAX_ATTEMPTS: Int = 3
+        }
+
+        /**
+         * A delayer that can back off after the initial try to spread out the retries.
+         */
+        public val delayProvider: DelayProvider = builder.delayProviderProperty.supply()
+
+        override val maxAttempts: Int = builder.maxAttempts
+
+        /**
+         * The token bucket instance. Utilizing an existing token bucket will share call capacity between scopes.
+         */
+        public val tokenBucket: RetryTokenBucket = builder.tokenBucketProperty.supply()
+
+        override fun toBuilderApplicator(): RetryStrategy.Config.Builder.() -> Unit = {
+            if (this is Builder) {
+                delayProvider = this@Config.delayProvider
+                maxAttempts = this@Config.maxAttempts
+                tokenBucket = this@Config.tokenBucket
+            }
+        }
+
+        /**
+         * A mutable builder for a [Config]
+         */
+        public open class Builder : RetryStrategy.Config.Builder {
+            internal val delayProviderProperty = DslBuilderProperty<DelayProvider.Config.Builder, DelayProvider>(
+                ExponentialBackoffWithJitter,
+                { config.toBuilderApplicator() },
+            )
+
+            /**
+             * A delayer that can back off after the initial try to spread out the retries.
+             */
+            public var delayProvider: DelayProvider? by delayProviderProperty::instance
+
+            /**
+             * Configure a new exponential backoff delayer
+             * @param block A DSL block which sets the parameters for the exponential backoff delayer
+             */
+            public fun delayProvider(block: ExponentialBackoffWithJitter.Config.Builder.() -> Unit) {
+                delayProviderProperty.dsl(ExponentialBackoffWithJitter, block)
+            }
+
+            /**
+             * Configure a new delayer
+             * @param factory The delay provider factory to use for building a new instance
+             * @param block A DSL block which sets the parameters for the delay provider
+             */
+            public fun <B : DelayProvider.Config.Builder, D : DelayProvider> delayProvider(
+                factory: DslFactory<B, D>,
+                block: B.() -> Unit,
+            ) {
+                delayProviderProperty.dsl(factory, block)
+            }
+
+            /**
+             * The maximum number of attempts to make (including the first attempt)
+             */
+            public override var maxAttempts: Int = DEFAULT_MAX_ATTEMPTS
+
+            internal val tokenBucketProperty = DslBuilderProperty<RetryTokenBucket.Config.Builder, RetryTokenBucket>(
+                StandardRetryTokenBucket,
+                { config.toBuilderApplicator() },
+            )
+
+            /**
+             * The token bucket instance. Utilizing an existing token bucket will share call capacity between scopes.
+             */
+            public var tokenBucket: RetryTokenBucket? by tokenBucketProperty::instance
+
+            /**
+             * Configure a new standard token bucket instance.
+             * @param block A DSL block which sets the parameters for the token bucket
+             */
+            public fun tokenBucket(block: StandardRetryTokenBucket.Config.Builder.() -> Unit) {
+                tokenBucketProperty.dsl(StandardRetryTokenBucket, block)
+            }
+
+            /**
+             * Configure a new token bucket instance.
+             * @param factory The token bucket factory to use for building a new instance
+             * @param block A DSL block which sets the parameters for the token bucket
+             */
+            public fun <B : RetryTokenBucket.Config.Builder, T : RetryTokenBucket> tokenBucket(
+                factory: DslFactory<B, T>,
+                block: B.() -> Unit,
+            ) {
+                tokenBucketProperty.dsl(factory, block)
+            }
+        }
+    }
+}

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/LegacyRetryStrategyTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/LegacyRetryStrategyTest.kt
@@ -8,12 +8,12 @@ package aws.smithy.kotlin.runtime.retries
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
-class StandardRetryStrategyTest {
+class LegacyRetryStrategyTest {
     @Test
     fun testInitialSuccess() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             tokenBucket = bucket
             delayProvider = delayer
         }
@@ -30,7 +30,7 @@ class StandardRetryStrategyTest {
     fun testRetryableFailures() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             maxAttempts = 10
             tokenBucket = bucket
             delayProvider = delayer
@@ -60,7 +60,7 @@ class StandardRetryStrategyTest {
     fun testNonretryableFailureFromException() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             tokenBucket = bucket
             delayProvider = delayer
         }
@@ -80,7 +80,7 @@ class StandardRetryStrategyTest {
     fun testNonretryableFailureFromResult() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             tokenBucket = bucket
             delayProvider = delayer
         }
@@ -102,7 +102,7 @@ class StandardRetryStrategyTest {
     fun testTooManyAttemptsFromException() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             tokenBucket = bucket
             delayProvider = delayer
         }
@@ -132,7 +132,7 @@ class StandardRetryStrategyTest {
     fun testTooManyAttemptsFromResult() = runTest {
         val bucket = RecordingTokenBucket()
         val delayer = RecordingDelayer()
-        val retryer = StandardRetryStrategy {
+        val retryer = LegacyRetryStrategy {
             tokenBucket = bucket
             delayProvider = delayer
         }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/RetryStrategyTestHelpers.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/RetryStrategyTestHelpers.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries
+
+import aws.smithy.kotlin.runtime.retries.delay.DelayProvider
+import aws.smithy.kotlin.runtime.retries.delay.RetryToken
+import aws.smithy.kotlin.runtime.retries.delay.RetryTokenBucket
+import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import kotlin.test.*
+
+fun block(
+    retryPolicy: RetryPolicy<String>,
+    bucket: RecordingTokenBucket,
+    delayer: RecordingDelayer,
+    vararg results: Any,
+): suspend () -> String {
+    val container = object {
+        var currentIndex = 0
+        var lastToken: RecordingToken? = null
+
+        suspend fun doIt(): String {
+            val expectedDelayAttempt = if (currentIndex < 1) null else currentIndex
+            assertEquals(expectedDelayAttempt, delayer.lastAttempt)
+
+            lastToken = if (currentIndex == 0) {
+                bucket.lastTokenAcquired!!
+            } else {
+                val expectedRetryDirective = retryPolicy.evaluate(wrap(currentIndex - 1))
+                val expectedRetryError = assertIs<RetryDirective.RetryError>(
+                    expectedRetryDirective,
+                    "Unexpected $expectedRetryDirective",
+                )
+                assertEquals(expectedRetryError.reason, lastToken!!.retryReason)
+                lastToken!!.nextToken!!
+            }
+
+            return wrap(currentIndex++).getOrThrow()
+        }
+
+        private fun wrap(atIndex: Int): Result<String> {
+            val result = results[atIndex]
+            return if (result is Throwable) Result.failure(result) else Result.success(result.toString())
+        }
+    }
+
+    return container::doIt
+}
+
+class RecordingTokenBucket : RetryTokenBucket {
+    override val config: RetryTokenBucket.Config = object : RetryTokenBucket.Config {
+        override fun toBuilderApplicator(): RetryTokenBucket.Config.Builder.() -> Unit = { }
+    }
+
+    var lastTokenAcquired: RecordingToken? = null
+
+    override suspend fun acquireToken(): RetryToken = RecordingToken().also { lastTokenAcquired = it }
+}
+
+class RecordingToken : RetryToken {
+    var isFailure: Boolean = false
+    var isSuccess: Boolean = false
+    var retryReason: RetryErrorType? = null
+    var nextToken: RecordingToken? = null
+
+    override suspend fun notifyFailure() {
+        requireCleanState()
+        isFailure = true
+    }
+
+    override suspend fun notifySuccess() {
+        requireCleanState()
+        isSuccess = true
+    }
+
+    override suspend fun scheduleRetry(reason: RetryErrorType): RetryToken {
+        requireCleanState()
+        retryReason = reason
+        return RecordingToken().also { nextToken = it }
+    }
+
+    private fun requireCleanState() {
+        require(!isFailure) { "This token has already been marked failed" }
+        require(!isSuccess) { "This token has already been marked succeeded" }
+        require(retryReason == null) { "This token has already been retried for $retryReason" }
+        require(nextToken == null) { "This token already returned a new token" }
+    }
+}
+
+class RecordingDelayer : DelayProvider {
+    override val config: DelayProvider.Config = object : DelayProvider.Config {
+        override fun toBuilderApplicator(): DelayProvider.Config.Builder.() -> Unit = { }
+    }
+
+    var lastAttempt: Int? = null
+    override suspend fun backoff(attempt: Int) {
+        val expectedLastAttempt = if (attempt == 1) null else attempt - 1
+        require(lastAttempt == expectedLastAttempt) {
+            "This delayer was called for attempt $attempt but the prior attempt was $lastAttempt"
+        }
+        lastAttempt = attempt
+    }
+}
+
+class StringRetryPolicy : RetryPolicy<String> {
+    override fun evaluate(result: Result<String>): RetryDirective = when (result.getOrNull()) {
+        "success" -> RetryDirective.TerminateAndSucceed
+        "fail" -> RetryDirective.TerminateAndFail
+        "client-error" -> RetryDirective.RetryError(RetryErrorType.ClientSide)
+        "server-error" -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+        "transient" -> RetryDirective.RetryError(RetryErrorType.Transient)
+        "throttled" -> RetryDirective.RetryError(RetryErrorType.Throttling)
+        null -> {
+            assertNotNull(result.exceptionOrNull()) // If the value is null, this must be an exception
+            when (result.exceptionOrNull()) {
+                is ConcurrentModificationException -> RetryDirective.RetryError(RetryErrorType.ClientSide)
+                else -> RetryDirective.TerminateAndFail
+            }
+        }
+        else -> throw IllegalArgumentException("Bad value in policy evaluation: $result", result.exceptionOrNull())
+    }
+}

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -12,7 +12,7 @@ import aws.smithy.kotlin.runtime.InternalApi
 @InternalApi
 public enum class RetryMode {
     /**
-     * The legacy retry mode preserves the pre-SEP 2.1 retry behavior.
+     * The legacy retry mode preserves the old retry behavior.
      * With this, the client will use the
      * [LegacyRetryStrategy][aws.smithy.kotlin.runtime.retries.LegacyRetryStrategy].
      */

--- a/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
+++ b/runtime/smithy-client/common/src/aws/smithy/kotlin/runtime/client/config/RetryMode.kt
@@ -12,8 +12,9 @@ import aws.smithy.kotlin.runtime.InternalApi
 @InternalApi
 public enum class RetryMode {
     /**
-     * The legacy retry mode is supported for compatibility with other SDKs and existing configurations for them,
-     * but it works exactly the same as the standard retry mode for this SDK.
+     * The legacy retry mode preserves the pre-SEP 2.1 retry behavior.
+     * With this, the client will use the
+     * [LegacyRetryStrategy][aws.smithy.kotlin.runtime.retries.LegacyRetryStrategy].
      */
     LEGACY,
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
Legacy retry strategy now uses the old standard retry strategy. Legacy still uses some standard classes now, this will be addressed in the future PR


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
