### PR TITLE
chore: bump Kotlin to 2.3.20 and add unit test to verify codegen version stays in sync

### DIFF
--- a/.changes/f7ac04e3-79b4-40ae-be9b-610c1a755f58.json
+++ b/.changes/f7ac04e3-79b4-40ae-be9b-610c1a755f58.json
@@ -1,0 +1,5 @@
+{
+    "id": "f7ac04e3-79b4-40ae-be9b-610c1a755f58",
+    "type": "misc",
+    "description": "Bumping Kotlin version to 2.3.20"
+}

--- a/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/KotlinDependency.kt
+++ b/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/KotlinDependency.kt
@@ -37,7 +37,7 @@ private fun getDefaultRuntimeVersion(): String {
 // publishing info
 const val RUNTIME_GROUP: String = "aws.smithy.kotlin"
 val RUNTIME_VERSION: String = System.getProperty("smithy.kotlin.codegen.clientRuntimeVersion", getDefaultRuntimeVersion())
-val KOTLIN_COMPILER_VERSION: String = System.getProperty("smithy.kotlin.codegen.kotlinCompilerVersion", "2.3.0")
+val KOTLIN_COMPILER_VERSION: String = System.getProperty("smithy.kotlin.codegen.kotlinCompilerVersion", "2.3.20")
 
 enum class SourceSet {
     CommonMain,

--- a/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
+++ b/codegen/codegen/src/test/kotlin/aws/smithy/kotlin/codegen/core/KotlinDependencyTest.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.codegen.core
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -32,5 +33,12 @@ class KotlinDependencyTest {
         invalidVersions.forEach {
             assertFalse(isValidVersion(it))
         }
+    }
+
+    @Test
+    fun testKotlinVersionSynchronization() {
+        val runningVersion = KotlinVersion.CURRENT.toString()
+        val codegenVersion = KOTLIN_COMPILER_VERSION
+        assertEquals(runningVersion, codegenVersion, "`KOTLIN_COMPILER_VERSION` declared in codegen must match the Kotlin version declared in gradle/libs.versions.toml")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin-version = "2.3.0"
+kotlin-version = "2.3.20"
 dokka-version = "2.2.0"
 
 aws-kotlin-repo-tools-version = "0.5.8"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change bumps the Kotlin stdlib and compiler version from **2.3.0** to **2.3.20**. It also adds a unit test to verify that the codegen string constant [`KOTLIN_COMPILER_VERSION`](https://github.com/smithy-lang/smithy-kotlin/blob/79ba7ac74d31d3e36daef24419afc09716a7a1f8/codegen/codegen/src/main/kotlin/aws/smithy/kotlin/codegen/core/KotlinDependency.kt#L40) stays in sync with the Gradle version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
