### PR TITLE
Retry standard strategy

### DIFF
--- a/.changes/8ff144dd-952c-46e3-b59a-40c8eb673ead.json
+++ b/.changes/8ff144dd-952c-46e3-b59a-40c8eb673ead.json
@@ -1,0 +1,5 @@
+{
+  "id": "8ff144dd-952c-46e3-b59a-40c8eb673ead",
+  "type": "feature",
+  "description": "Add standard retry strategy with updated exponential backoff, retry quotas, `x-amz-retry-after` header support, and service-specific behavior for DynamoDB. Gated behind the `SMITHY_NEW_RETRIES_2026` feature flag"
+}

--- a/runtime/protocol/http-client/api/http-client.api
+++ b/runtime/protocol/http-client/api/http-client.api
@@ -550,6 +550,7 @@ public final class aws/smithy/kotlin/runtime/http/operation/HttpOperationContext
 	public final fun getOperationAttributes ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getOperationInput ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getOperationMetrics ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
+	public final fun getRetryAfterMillis ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 	public final fun getSdkInvocationId ()Laws/smithy/kotlin/runtime/collections/AttributeKey;
 }
 

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
@@ -22,8 +22,8 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
 import aws.smithy.kotlin.runtime.retries.toResult
 import aws.smithy.kotlin.runtime.telemetry.logging.debug
 import aws.smithy.kotlin.runtime.telemetry.trace.withSpan
+import kotlinx.coroutines.currentCoroutineContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 
 /**
  * Retry requests with the given strategy and policy
@@ -44,7 +44,7 @@ internal class RetryMiddleware<I, O>(
         val result = if (modified.subject.isRetryable) {
             // FIXME this is the wrong span/context because we want the fresh one from inside each attempt but there's no way to
             // wire that through without changing the `RetryPolicy` interface
-            val wrappedPolicy = PolicyLogger(policy, coroutineContext)
+            val wrappedPolicy = PolicyLogger(policy, currentCoroutineContext())
 
             val outcome = strategy.retry(wrappedPolicy) {
                 withSpan<RetryMiddleware<*, *>, _>("Attempt-$attempt") {
@@ -61,6 +61,12 @@ internal class RetryMiddleware<I, O>(
                     val requestCopy = modified.deepCopy()
 
                     val attemptResult = tryAttempt(requestCopy, next, attempt)
+
+                    // Propagate x-amz-retry-after to the strategy for backoff calculation
+                    if (strategy is StandardRetryStrategy) {
+                        strategy.retryAfterMillis = modified.context.getOrNull(HttpOperationContext.RetryAfterMillis)
+                    }
+
                     attempt++
                     attemptResult.getOrThrow()
                 }
@@ -81,6 +87,9 @@ internal class RetryMiddleware<I, O>(
         next: Handler<SdkHttpRequest, O>,
         attempt: Int,
     ): Result<O> {
+        // Clear any previous retry-after value
+        request.context.remove(HttpOperationContext.RetryAfterMillis)
+
         val result = interceptors.readBeforeAttempt(request.subject.immutableView())
             .mapCatching {
                 val attemptTimeout = request.context.getOrNull(HttpOperationContext.AttemptTimeout)
@@ -92,6 +101,16 @@ internal class RetryMiddleware<I, O>(
         // get the http call for this attempt (if we made it that far)
         val callList = request.context.getOrNull(HttpOperationContext.HttpCallList) ?: emptyList()
         val call = callList.getOrNull(attempt - 1)
+
+        // Parse x-amz-retry-after header (integer milliseconds). Invalid values are ignored per SEP 2.1.
+        call?.response?.headers?.get("x-amz-retry-after")?.let { raw ->
+            val ms = raw.toLongOrNull()?.takeIf { it >= 0 }
+            if (ms != null) {
+                request.context[HttpOperationContext.RetryAfterMillis] = ms
+            } else {
+                currentCoroutineContext().debug<RetryMiddleware<*, *>> { "ignoring invalid x-amz-retry-after header: $raw" }
+            }
+        }
 
         val httpRequest = request.subject.immutableView()
         val modified = interceptors.modifyBeforeAttemptCompletion(result, httpRequest, call?.response)

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/middleware/RetryMiddleware.kt
@@ -102,7 +102,7 @@ internal class RetryMiddleware<I, O>(
         val callList = request.context.getOrNull(HttpOperationContext.HttpCallList) ?: emptyList()
         val call = callList.getOrNull(attempt - 1)
 
-        // Parse x-amz-retry-after header (integer milliseconds). Invalid values are ignored per SEP 2.1.
+        // Parse x-amz-retry-after header (integer milliseconds). Invalid values are ignored.
         call?.response?.headers?.get("x-amz-retry-after")?.let { raw ->
             val ms = raw.toLongOrNull()?.takeIf { it >= 0 }
             if (ms != null) {

--- a/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
+++ b/runtime/protocol/http-client/common/src/aws/smithy/kotlin/runtime/http/operation/HttpOperationContext.kt
@@ -78,6 +78,12 @@ public object HttpOperationContext {
      * The name of the default algorithm to be used for computing a checksum of the request.
      */
     public val DefaultChecksumAlgorithm: AttributeKey<String> = AttributeKey("aws.smithy.kotlin#DefaultChecksumAlgorithm")
+
+    /**
+     * The parsed value of the `x-amz-retry-after` response header in milliseconds, if present and valid.
+     * Set by [RetryMiddleware] after each attempt and consumed by the retry strategy's delay provider.
+     */
+    public val RetryAfterMillis: AttributeKey<Long> = AttributeKey("aws.smithy.kotlin#RetryAfterMillis")
 }
 
 internal val ExecutionContext.operationMetrics: OperationMetrics

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
@@ -6,16 +6,24 @@
 package aws.smithy.kotlin.runtime.http.middleware
 
 import aws.smithy.kotlin.runtime.collections.get
+import aws.smithy.kotlin.runtime.http.HeadersBuilder
+import aws.smithy.kotlin.runtime.http.HttpBody
+import aws.smithy.kotlin.runtime.http.HttpCall
+import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.SdkHttpClient
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
 import aws.smithy.kotlin.runtime.http.operation.roundTrip
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
+import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import aws.smithy.kotlin.runtime.time.Instant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,5 +53,169 @@ class RetryMiddlewareTest {
         op.roundTrip(client, Unit)
         val attempts = op.context.attributes[HttpOperationContext.HttpCallList].size
         assertEquals(2, attempts)
+    }
+
+    /**
+     * SEP 2.1: Honor x-amz-retry-after header (1500ms → delay 1.5s)
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterHeaderHonored() = runTest {
+        var attemptCount = 0
+        val engine = TestEngine { _, request ->
+            attemptCount++
+            val headers = HeadersBuilder().apply {
+                if (attemptCount == 1) append("x-amz-retry-after", "1500")
+            }.build()
+            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
+            val resp = HttpResponse(status, headers, HttpBody.Empty)
+            val now = Instant.now()
+            HttpCall(request, resp, now, now)
+        }
+        val testClient = SdkHttpClient(engine)
+
+        val retryPolicy = object : RetryPolicy<Unit> {
+            override fun evaluate(result: Result<Unit>): RetryDirective =
+                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
+                else RetryDirective.TerminateAndSucceed
+        }
+
+        val req = HttpRequestBuilder()
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        val strategy = StandardRetryStrategy {
+            delayProvider { jitter = 0.0 }
+        }
+        op.execution.retryStrategy = strategy
+        op.execution.retryPolicy = retryPolicy
+
+        val startTime = currentTime
+        op.roundTrip(testClient, Unit)
+        val delayMs = currentTime - startTime
+
+        // x-amz-retry-after: 1500ms is within [50ms, 50ms+5000ms], so delay = 1500ms
+        assertEquals(1500L, delayMs)
+    }
+
+    /**
+     * SEP 2.1: x-amz-retry-after: 0 → clamped to t_i (50ms)
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterClampedToMinimum() = runTest {
+        var attemptCount = 0
+        val engine = TestEngine { _, request ->
+            attemptCount++
+            val headers = HeadersBuilder().apply {
+                if (attemptCount == 1) append("x-amz-retry-after", "0")
+            }.build()
+            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
+            val resp = HttpResponse(status, headers, HttpBody.Empty)
+            val now = Instant.now()
+            HttpCall(request, resp, now, now)
+        }
+        val testClient = SdkHttpClient(engine)
+
+        val retryPolicy = object : RetryPolicy<Unit> {
+            override fun evaluate(result: Result<Unit>): RetryDirective =
+                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
+                else RetryDirective.TerminateAndSucceed
+        }
+
+        val req = HttpRequestBuilder()
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        val strategy = StandardRetryStrategy {
+            delayProvider { jitter = 0.0 }
+        }
+        op.execution.retryStrategy = strategy
+        op.execution.retryPolicy = retryPolicy
+
+        val startTime = currentTime
+        op.roundTrip(testClient, Unit)
+        val delayMs = currentTime - startTime
+
+        // x-amz-retry-after: 0 clamped to t_i = 50ms
+        assertEquals(50L, delayMs)
+    }
+
+    /**
+     * SEP 2.1: x-amz-retry-after: 10000 → clamped to t_i + 5s (5050ms)
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterClampedToMaximum() = runTest {
+        var attemptCount = 0
+        val engine = TestEngine { _, request ->
+            attemptCount++
+            val headers = HeadersBuilder().apply {
+                if (attemptCount == 1) append("x-amz-retry-after", "10000")
+            }.build()
+            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
+            val resp = HttpResponse(status, headers, HttpBody.Empty)
+            val now = Instant.now()
+            HttpCall(request, resp, now, now)
+        }
+        val testClient = SdkHttpClient(engine)
+
+        val retryPolicy = object : RetryPolicy<Unit> {
+            override fun evaluate(result: Result<Unit>): RetryDirective =
+                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
+                else RetryDirective.TerminateAndSucceed
+        }
+
+        val req = HttpRequestBuilder()
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        val strategy = StandardRetryStrategy {
+            delayProvider { jitter = 0.0 }
+        }
+        op.execution.retryStrategy = strategy
+        op.execution.retryPolicy = retryPolicy
+
+        val startTime = currentTime
+        op.roundTrip(testClient, Unit)
+        val delayMs = currentTime - startTime
+
+        // x-amz-retry-after: 10000 clamped to t_i + 5000 = 50 + 5000 = 5050ms
+        assertEquals(5050L, delayMs)
+    }
+
+    /**
+     * SEP 2.1: Invalid x-amz-retry-after → fallback to exponential backoff
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterInvalidFallsBack() = runTest {
+        var attemptCount = 0
+        val engine = TestEngine { _, request ->
+            attemptCount++
+            val headers = HeadersBuilder().apply {
+                if (attemptCount == 1) append("x-amz-retry-after", "invalid")
+            }.build()
+            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
+            val resp = HttpResponse(status, headers, HttpBody.Empty)
+            val now = Instant.now()
+            HttpCall(request, resp, now, now)
+        }
+        val testClient = SdkHttpClient(engine)
+
+        val retryPolicy = object : RetryPolicy<Unit> {
+            override fun evaluate(result: Result<Unit>): RetryDirective =
+                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
+                else RetryDirective.TerminateAndSucceed
+        }
+
+        val req = HttpRequestBuilder()
+        val op = newTestOperation<Unit, Unit>(req, Unit)
+        val strategy = StandardRetryStrategy {
+            delayProvider { jitter = 0.0 }
+        }
+        op.execution.retryStrategy = strategy
+        op.execution.retryPolicy = retryPolicy
+
+        val startTime = currentTime
+        op.roundTrip(testClient, Unit)
+        val delayMs = currentTime - startTime
+
+        // Invalid header ignored, falls back to t_i = 50ms
+        assertEquals(50L, delayMs)
     }
 }

--- a/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
+++ b/runtime/protocol/http-client/common/test/aws/smithy/kotlin/runtime/http/middleware/RetryMiddlewareTest.kt
@@ -6,24 +6,16 @@
 package aws.smithy.kotlin.runtime.http.middleware
 
 import aws.smithy.kotlin.runtime.collections.get
-import aws.smithy.kotlin.runtime.http.HeadersBuilder
-import aws.smithy.kotlin.runtime.http.HttpBody
-import aws.smithy.kotlin.runtime.http.HttpCall
-import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.SdkHttpClient
 import aws.smithy.kotlin.runtime.http.operation.HttpOperationContext
 import aws.smithy.kotlin.runtime.http.operation.newTestOperation
 import aws.smithy.kotlin.runtime.http.operation.roundTrip
 import aws.smithy.kotlin.runtime.http.request.HttpRequestBuilder
-import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.httptest.TestEngine
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
-import aws.smithy.kotlin.runtime.time.Instant
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,169 +45,5 @@ class RetryMiddlewareTest {
         op.roundTrip(client, Unit)
         val attempts = op.context.attributes[HttpOperationContext.HttpCallList].size
         assertEquals(2, attempts)
-    }
-
-    /**
-     * SEP 2.1: Honor x-amz-retry-after header (1500ms → delay 1.5s)
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterHeaderHonored() = runTest {
-        var attemptCount = 0
-        val engine = TestEngine { _, request ->
-            attemptCount++
-            val headers = HeadersBuilder().apply {
-                if (attemptCount == 1) append("x-amz-retry-after", "1500")
-            }.build()
-            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
-            val resp = HttpResponse(status, headers, HttpBody.Empty)
-            val now = Instant.now()
-            HttpCall(request, resp, now, now)
-        }
-        val testClient = SdkHttpClient(engine)
-
-        val retryPolicy = object : RetryPolicy<Unit> {
-            override fun evaluate(result: Result<Unit>): RetryDirective =
-                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
-                else RetryDirective.TerminateAndSucceed
-        }
-
-        val req = HttpRequestBuilder()
-        val op = newTestOperation<Unit, Unit>(req, Unit)
-        val strategy = StandardRetryStrategy {
-            delayProvider { jitter = 0.0 }
-        }
-        op.execution.retryStrategy = strategy
-        op.execution.retryPolicy = retryPolicy
-
-        val startTime = currentTime
-        op.roundTrip(testClient, Unit)
-        val delayMs = currentTime - startTime
-
-        // x-amz-retry-after: 1500ms is within [50ms, 50ms+5000ms], so delay = 1500ms
-        assertEquals(1500L, delayMs)
-    }
-
-    /**
-     * SEP 2.1: x-amz-retry-after: 0 → clamped to t_i (50ms)
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterClampedToMinimum() = runTest {
-        var attemptCount = 0
-        val engine = TestEngine { _, request ->
-            attemptCount++
-            val headers = HeadersBuilder().apply {
-                if (attemptCount == 1) append("x-amz-retry-after", "0")
-            }.build()
-            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
-            val resp = HttpResponse(status, headers, HttpBody.Empty)
-            val now = Instant.now()
-            HttpCall(request, resp, now, now)
-        }
-        val testClient = SdkHttpClient(engine)
-
-        val retryPolicy = object : RetryPolicy<Unit> {
-            override fun evaluate(result: Result<Unit>): RetryDirective =
-                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
-                else RetryDirective.TerminateAndSucceed
-        }
-
-        val req = HttpRequestBuilder()
-        val op = newTestOperation<Unit, Unit>(req, Unit)
-        val strategy = StandardRetryStrategy {
-            delayProvider { jitter = 0.0 }
-        }
-        op.execution.retryStrategy = strategy
-        op.execution.retryPolicy = retryPolicy
-
-        val startTime = currentTime
-        op.roundTrip(testClient, Unit)
-        val delayMs = currentTime - startTime
-
-        // x-amz-retry-after: 0 clamped to t_i = 50ms
-        assertEquals(50L, delayMs)
-    }
-
-    /**
-     * SEP 2.1: x-amz-retry-after: 10000 → clamped to t_i + 5s (5050ms)
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterClampedToMaximum() = runTest {
-        var attemptCount = 0
-        val engine = TestEngine { _, request ->
-            attemptCount++
-            val headers = HeadersBuilder().apply {
-                if (attemptCount == 1) append("x-amz-retry-after", "10000")
-            }.build()
-            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
-            val resp = HttpResponse(status, headers, HttpBody.Empty)
-            val now = Instant.now()
-            HttpCall(request, resp, now, now)
-        }
-        val testClient = SdkHttpClient(engine)
-
-        val retryPolicy = object : RetryPolicy<Unit> {
-            override fun evaluate(result: Result<Unit>): RetryDirective =
-                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
-                else RetryDirective.TerminateAndSucceed
-        }
-
-        val req = HttpRequestBuilder()
-        val op = newTestOperation<Unit, Unit>(req, Unit)
-        val strategy = StandardRetryStrategy {
-            delayProvider { jitter = 0.0 }
-        }
-        op.execution.retryStrategy = strategy
-        op.execution.retryPolicy = retryPolicy
-
-        val startTime = currentTime
-        op.roundTrip(testClient, Unit)
-        val delayMs = currentTime - startTime
-
-        // x-amz-retry-after: 10000 clamped to t_i + 5000 = 50 + 5000 = 5050ms
-        assertEquals(5050L, delayMs)
-    }
-
-    /**
-     * SEP 2.1: Invalid x-amz-retry-after → fallback to exponential backoff
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterInvalidFallsBack() = runTest {
-        var attemptCount = 0
-        val engine = TestEngine { _, request ->
-            attemptCount++
-            val headers = HeadersBuilder().apply {
-                if (attemptCount == 1) append("x-amz-retry-after", "invalid")
-            }.build()
-            val status = if (attemptCount == 1) HttpStatusCode.InternalServerError else HttpStatusCode.OK
-            val resp = HttpResponse(status, headers, HttpBody.Empty)
-            val now = Instant.now()
-            HttpCall(request, resp, now, now)
-        }
-        val testClient = SdkHttpClient(engine)
-
-        val retryPolicy = object : RetryPolicy<Unit> {
-            override fun evaluate(result: Result<Unit>): RetryDirective =
-                if (attemptCount < 2) RetryDirective.RetryError(RetryErrorType.ServerSide)
-                else RetryDirective.TerminateAndSucceed
-        }
-
-        val req = HttpRequestBuilder()
-        val op = newTestOperation<Unit, Unit>(req, Unit)
-        val strategy = StandardRetryStrategy {
-            delayProvider { jitter = 0.0 }
-        }
-        op.execution.retryStrategy = strategy
-        op.execution.retryPolicy = retryPolicy
-
-        val startTime = currentTime
-        op.roundTrip(testClient, Unit)
-        val delayMs = currentTime - startTime
-
-        // Invalid header ignored, falls back to t_i = 50ms
-        assertEquals(50L, delayMs)
     }
 }

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -1770,6 +1770,10 @@ public final class aws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Confi
 	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/AdaptiveRetryStrategy$Config;
 }
 
+public final class aws/smithy/kotlin/runtime/retries/NewRetriesKt {
+	public static final fun newRetriesEnabled ()Z
+}
+
 public abstract class aws/smithy/kotlin/runtime/retries/Outcome {
 	public abstract fun getAttempts ()I
 }
@@ -1845,7 +1849,9 @@ public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy : aws/smith
 	protected fun beforeRetry (ILjava/lang/Object;Laws/smithy/kotlin/runtime/retries/policy/RetryDirective;Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/RetryStrategy$Config;
 	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config;
+	public final fun getRetryAfterMillis ()Ljava/lang/Long;
 	public fun retry (Laws/smithy/kotlin/runtime/retries/policy/RetryPolicy;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setRetryAfterMillis (Ljava/lang/Long;)V
 }
 
 public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
@@ -1855,10 +1861,12 @@ public final class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Compa
 
 public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config : aws/smithy/kotlin/runtime/retries/RetryStrategy$Config {
 	public static final field Companion Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Companion;
+	public static final field DEFAULT_DYNAMODB_SERVICES_MAX_ATTEMPTS I
 	public static final field DEFAULT_MAX_ATTEMPTS I
 	public fun <init> (Laws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Builder;)V
 	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
 	public fun getMaxAttempts ()I
+	public final fun getServiceName ()Ljava/lang/String;
 	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
 	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
 }
@@ -1869,9 +1877,11 @@ public class aws/smithy/kotlin/runtime/retries/StandardRetryStrategy$Config$Buil
 	public final fun delayProvider (Lkotlin/jvm/functions/Function1;)V
 	public final fun getDelayProvider ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;
 	public fun getMaxAttempts ()I
+	public final fun getServiceName ()Ljava/lang/String;
 	public final fun getTokenBucket ()Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;
 	public final fun setDelayProvider (Laws/smithy/kotlin/runtime/retries/delay/DelayProvider;)V
 	public fun setMaxAttempts (I)V
+	public final fun setServiceName (Ljava/lang/String;)V
 	public final fun setTokenBucket (Laws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket;)V
 	public final fun tokenBucket (Laws/smithy/kotlin/runtime/util/DslFactory;Lkotlin/jvm/functions/Function1;)V
 	public final fun tokenBucket (Lkotlin/jvm/functions/Function1;)V
@@ -2009,6 +2019,17 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimi
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RateLimiter$Config$Builder {
 }
 
+public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider : aws/smithy/kotlin/runtime/retries/delay/DelayProvider {
+	public abstract fun backoff (ILaws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun backoff$default (Laws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider;ILaws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider$DefaultImpls {
+	public static fun backoff (Laws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun backoff$default (Laws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider;ILaws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class aws/smithy/kotlin/runtime/retries/delay/RetryCapacityExceededException : aws/smithy/kotlin/runtime/ClientException {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -2029,6 +2050,49 @@ public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTok
 }
 
 public abstract interface class aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket$Config$Builder {
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter : aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Companion;
+	public fun <init> ()V
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config;)V
+	public synthetic fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backoff (ILaws/smithy/kotlin/runtime/retries/policy/RetryErrorType;Ljava/lang/String;Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun backoff (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config;
+	public fun getConfig ()Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Companion : aws/smithy/kotlin/runtime/util/DslFactory {
+	public fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter;
+	public synthetic fun invoke (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config {
+	public static final field Companion Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config$Companion;
+	public fun <init> (Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config$Builder;)V
+	public final fun getInitialDelay-UwyO8pc ()J
+	public final fun getJitter ()D
+	public final fun getMaxBackoff-UwyO8pc ()J
+	public final fun getScaleFactor ()D
+	public fun toBuilderApplicator ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config$Builder : aws/smithy/kotlin/runtime/retries/delay/DelayProvider$Config$Builder {
+	public fun <init> ()V
+	public final fun getInitialDelay-UwyO8pc ()J
+	public final fun getJitter ()D
+	public final fun getMaxBackoff-UwyO8pc ()J
+	public final fun getScaleFactor ()D
+	public final fun setInitialDelay-LRDsOJo (J)V
+	public final fun setJitter (D)V
+	public final fun setMaxBackoff-LRDsOJo (J)V
+	public final fun setScaleFactor (D)V
+}
+
+public final class aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config$Companion {
+	public final fun getDefault ()Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter$Config;
 }
 
 public final class aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket : aws/smithy/kotlin/runtime/retries/delay/RetryTokenBucket {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/NewRetries.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/NewRetries.kt
@@ -12,7 +12,7 @@ private val NEW_RETRIES_SETTING = boolEnvSetting("smithy.newRetries2026", "SMITH
 
 /**
  * Returns `true` when the `SMITHY_NEW_RETRIES_2026` environment variable (or `smithy.newRetries2026` system property)
- * is set to `true`, enabling SEP 2.1 retry behavior. Defaults to `false`.
+ * is set to `true`, enabling the standard retry strategy behavior. Defaults to `false`.
  */
 @InternalApi
 public fun newRetriesEnabled(): Boolean = NEW_RETRIES_SETTING.resolve() ?: false

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/NewRetries.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/NewRetries.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.smithy.kotlin.runtime.retries
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.config.boolEnvSetting
+import aws.smithy.kotlin.runtime.config.resolve
+
+private val NEW_RETRIES_SETTING = boolEnvSetting("smithy.newRetries2026", "SMITHY_NEW_RETRIES_2026").orElse(false)
+
+/**
+ * Returns `true` when the `SMITHY_NEW_RETRIES_2026` environment variable (or `smithy.newRetries2026` system property)
+ * is set to `true`, enabling SEP 2.1 retry behavior. Defaults to `false`.
+ */
+@InternalApi
+public fun newRetriesEnabled(): Boolean = NEW_RETRIES_SETTING.resolve() ?: false

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -79,7 +79,12 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
                         throwTooManyAttempts(attempt, callResult)
                     } else {
                         // Prep for another loop
-                        config.delayProvider.backoff(attempt)
+                        val delayProvider = config.delayProvider
+                        if (delayProvider is RetryAwareDelayProvider) {
+                            delayProvider.backoff(attempt, evaluation.reason, config.serviceName)
+                        } else {
+                            delayProvider.backoff(attempt)
+                        }
                         fromToken.scheduleRetry(evaluation.reason)
                     }
             }.also {
@@ -219,18 +224,28 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
          */
         public val delayProvider: DelayProvider = builder.delayProviderProperty.supply()
 
-        override val maxAttempts: Int = builder.maxAttempts
+        override val maxAttempts: Int = when {
+            builder.isMaxAttemptsSet -> builder.maxAttempts
+            newRetriesEnabled() && builder.serviceName?.lowercase() in setOf("dynamodb", "dynamodb streams") -> 4
+            else -> DEFAULT_MAX_ATTEMPTS
+        }
 
         /**
          * The token bucket instance. Utilizing an existing token bucket will share call capacity between scopes.
          */
         public val tokenBucket: RetryTokenBucket = builder.tokenBucketProperty.supply()
 
+        /**
+         * The service name, used for service-specific retry behavior (e.g., DynamoDB backoff).
+         */
+        public val serviceName: String? = builder.serviceName
+
         override fun toBuilderApplicator(): RetryStrategy.Config.Builder.() -> Unit = {
             if (this is Builder) {
                 delayProvider = this@Config.delayProvider
                 maxAttempts = this@Config.maxAttempts
                 tokenBucket = this@Config.tokenBucket
+                serviceName = this@Config.serviceName
             }
         }
 
@@ -238,8 +253,10 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
          * A mutable builder for a [Config]
          */
         public open class Builder : RetryStrategy.Config.Builder {
+            private val useNewRetries = newRetriesEnabled()
+
             internal val delayProviderProperty = DslBuilderProperty<DelayProvider.Config.Builder, DelayProvider>(
-                ExponentialBackoffWithJitter,
+                if (useNewRetries) StandardExponentialBackoffWithJitter else ExponentialBackoffWithJitter,
                 { config.toBuilderApplicator() },
             )
 
@@ -252,8 +269,8 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
              * Configure a new exponential backoff delayer
              * @param block A DSL block which sets the parameters for the exponential backoff delayer
              */
-            public fun delayProvider(block: ExponentialBackoffWithJitter.Config.Builder.() -> Unit) {
-                delayProviderProperty.dsl(ExponentialBackoffWithJitter, block)
+            public fun delayProvider(block: StandardExponentialBackoffWithJitter.Config.Builder.() -> Unit) {
+                delayProviderProperty.dsl(StandardExponentialBackoffWithJitter, block)
             }
 
             /**
@@ -269,14 +286,33 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
             }
 
             /**
-             * The maximum number of attempts to make (including the first attempt)
+             * The maximum number of attempts to make (including the first attempt).
              */
             public override var maxAttempts: Int = DEFAULT_MAX_ATTEMPTS
+                set(value) {
+                    field = value
+                    isMaxAttemptsSet = true
+                }
+            internal var isMaxAttemptsSet = false
+
+            /**
+             * The service name, used for service-specific retry behavior (e.g., DynamoDB backoff).
+             */
+            public var serviceName: String? = null
 
             internal val tokenBucketProperty = DslBuilderProperty<RetryTokenBucket.Config.Builder, RetryTokenBucket>(
                 StandardRetryTokenBucket,
                 { config.toBuilderApplicator() },
             )
+
+            init {
+                if (useNewRetries) {
+                    tokenBucketProperty.dsl(StandardRetryTokenBucket) {
+                        retryCost = 14
+                        timeoutRetryCost = 5
+                    }
+                }
+            }
 
             /**
              * The token bucket instance. Utilizing an existing token bucket will share call capacity between scopes.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -16,6 +16,8 @@ import aws.smithy.kotlin.runtime.util.DslBuilderProperty
 import aws.smithy.kotlin.runtime.util.DslFactory
 import kotlinx.coroutines.CancellationException
 
+private val DYNAMODB_SERVICES = setOf("dynamodb", "dynamodb streams")
+
 /**
  * Implements a retry strategy utilizing backoff delayer and a token bucket for rate limiting and circuit breaking. Note
  * that the backoff delayer and token bucket work independently of each other. Either can delay retries (and the token
@@ -224,6 +226,11 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
              * The default number of maximum attempts for new config instances
              */
             public const val DEFAULT_MAX_ATTEMPTS: Int = 3
+
+            /**
+             * The default number of maximum attempts for new config instances using DynamoDB services
+             */
+            public const val DEFAULT_DYNAMODB_SERVICES_MAX_ATTEMPTS: Int = 4
         }
 
         /**
@@ -233,7 +240,7 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
 
         override val maxAttempts: Int = when {
             builder.isMaxAttemptsSet -> builder.maxAttempts
-            newRetriesEnabled() && builder.serviceName?.lowercase() in setOf("dynamodb", "dynamodb streams") -> 4
+            newRetriesEnabled() && builder.serviceName?.lowercase() in DYNAMODB_SERVICES -> DEFAULT_DYNAMODB_SERVICES_MAX_ATTEMPTS
             else -> DEFAULT_MAX_ATTEMPTS
         }
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -33,8 +33,7 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
 
     /**
      * The server-specified retry-after duration in milliseconds from the `x-amz-retry-after` response header.
-     * Set by the HTTP retry middleware before each retry attempt. The strategy reads and clears this value
-     * when computing backoff.
+     * Set by the HTTP retry middleware after each HTTP call, before the delay provider computes backoff.
      */
     public var retryAfterMillis: Long? = null
 

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -30,6 +30,13 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
     }
 
     /**
+     * The server-specified retry-after duration in milliseconds from the `x-amz-retry-after` response header.
+     * Set by the HTTP retry middleware before each retry attempt. The strategy reads and clears this value
+     * when computing backoff.
+     */
+    public var retryAfterMillis: Long? = null
+
+    /**
      * Retry the given block of code until it's successful. Note this method throws exceptions for non-successful
      * outcomes from retrying.
      */
@@ -81,7 +88,7 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
                         // Prep for another loop
                         val delayProvider = config.delayProvider
                         if (delayProvider is RetryAwareDelayProvider) {
-                            delayProvider.backoff(attempt, evaluation.reason, config.serviceName)
+                            delayProvider.backoff(attempt, evaluation.reason, config.serviceName, retryAfterMillis)
                         } else {
                             delayProvider.backoff(attempt)
                         }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/StandardRetryStrategy.kt
@@ -317,6 +317,7 @@ public open class StandardRetryStrategy(override val config: Config = Config.def
                     tokenBucketProperty.dsl(StandardRetryTokenBucket) {
                         retryCost = 14
                         timeoutRetryCost = 5
+                        initialTrySuccessIncrement = 1
                     }
                 }
             }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries.delay
+
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+
+/**
+ * A [DelayProvider] that can adjust backoff based on retry context such as the error type and service name.
+ */
+public interface RetryAwareDelayProvider : DelayProvider {
+    /**
+     * Delays for an appropriate amount of time after the given attempt number, taking into account the type of error
+     * and optionally the service name.
+     * @param attempt The ordinal index of the attempt.
+     * @param errorType The type of error that triggered the retry.
+     * @param serviceName The optional service name, used for service-specific backoff (e.g., DynamoDB).
+     */
+    public suspend fun backoff(attempt: Int, errorType: RetryErrorType, serviceName: String? = null)
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
@@ -8,15 +8,24 @@ package aws.smithy.kotlin.runtime.retries.delay
 import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 
 /**
- * A [DelayProvider] that can adjust backoff based on retry context such as the error type and service name.
+ * A [DelayProvider] that can adjust backoff based on retry context such as the error type, service name,
+ * and server-specified retry-after duration.
  */
 public interface RetryAwareDelayProvider : DelayProvider {
     /**
-     * Delays for an appropriate amount of time after the given attempt number, taking into account the type of error
-     * and optionally the service name.
+     * Delays for an appropriate amount of time after the given attempt number, taking into account the type of error,
+     * the service name, and an optional server-specified retry-after duration.
      * @param attempt The ordinal index of the attempt.
      * @param errorType The type of error that triggered the retry.
      * @param serviceName The optional service name, used for service-specific backoff (e.g., DynamoDB).
+     * @param retryAfterMillis The optional server-specified retry-after duration in milliseconds from the
+     * `x-amz-retry-after` response header. When present, the delay is clamped to `[t_i, t_i + 5s]` where `t_i` is
+     * the computed exponential backoff. `MAX_BACKOFF` does not apply to this value.
      */
-    public suspend fun backoff(attempt: Int, errorType: RetryErrorType, serviceName: String? = null)
+    public suspend fun backoff(
+        attempt: Int,
+        errorType: RetryErrorType,
+        serviceName: String? = null,
+        retryAfterMillis: Long? = null,
+    )
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/RetryAwareDelayProvider.kt
@@ -13,6 +13,13 @@ import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
  */
 public interface RetryAwareDelayProvider : DelayProvider {
     /**
+     * Delegates to [backoff] with [RetryErrorType.ServerSide] and no service name or retry-after value.
+     */
+    override suspend fun backoff(attempt: Int) {
+        backoff(attempt, RetryErrorType.ServerSide)
+    }
+
+    /**
      * Delays for an appropriate amount of time after the given attempt number, taking into account the type of error,
      * the service name, and an optional server-specified retry-after duration.
      * @param attempt The ordinal index of the attempt.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
@@ -53,9 +53,15 @@ public class StandardExponentialBackoffWithJitter(
 
     /**
      * Delays for an appropriate amount of time after the given attempt number, selecting the base delay according to
-     * the [errorType] and [serviceName].
+     * the [errorType] and [serviceName]. If [retryAfterMillis] is provided, the delay is clamped per SEP 2.1:
+     * `clamp(retryAfterMs, t_i, t_i + 5000)` with no jitter applied to the server-specified value.
      */
-    override suspend fun backoff(attempt: Int, errorType: RetryErrorType, serviceName: String?) {
+    override suspend fun backoff(
+        attempt: Int,
+        errorType: RetryErrorType,
+        serviceName: String?,
+        retryAfterMillis: Long?,
+    ) {
         require(attempt > 0) { "attempt was $attempt but must be greater than 0" }
         val baseMs = when {
             errorType == RetryErrorType.Throttling -> 1000.0
@@ -65,8 +71,12 @@ public class StandardExponentialBackoffWithJitter(
         val exp = baseMs * config.scaleFactor.pow(attempt - 1)
         val capped = min(exp, config.maxBackoff.toDouble(DurationUnit.MILLISECONDS))
         val jitterProportion = if (config.jitter > 0.0) random.nextDouble(config.jitter) else 0.0
-        val delayMs = capped * (1.0 - jitterProportion)
-        delay(delayMs.toLong())
+        val tI = capped * (1.0 - jitterProportion)
+
+        val delayMs = retryAfterMillis?.// SEP: clamp(retry_after, t_i, t_i + 5s). MAX_BACKOFF does not apply.
+        toDouble()?.coerceIn(tI, tI + 5000.0) ?: tI
+
+        delay(delayMs.toLong().milliseconds)
     }
 
     /**

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
@@ -44,14 +44,6 @@ public class StandardExponentialBackoffWithJitter(
     private val random = Random.Default
 
     /**
-     * Delays for an appropriate amount of time after the given attempt number using the default (non-throttling)
-     * base delay.
-     */
-    override suspend fun backoff(attempt: Int) {
-        backoff(attempt, RetryErrorType.ServerSide, null)
-    }
-
-    /**
      * Delays for an appropriate amount of time after the given attempt number, selecting the base delay according to
      * the [errorType] and [serviceName]. If [retryAfterMillis] is provided, the delay is clamped per SEP 2.1:
      * `clamp(retryAfterMs, t_i, t_i + 5000)` with no jitter applied to the server-specified value.

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries.delay
+
+import aws.smithy.kotlin.runtime.InternalApi
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.util.DslFactory
+import kotlinx.coroutines.delay
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+private val DYNAMODB_SERVICES = setOf("dynamodb", "dynamodb streams")
+
+/**
+ * An [RetryAwareDelayProvider] that implements SEP 2.1 exponential backoff with jitter. The base delay varies by
+ * error type and service name:
+ *
+ * - **Throttling** errors use a base delay of **1000 ms**.
+ * - **DynamoDB** and **DynamoDB Streams** services use a base delay of **25 ms**.
+ * - All other errors use [Config.initialDelay] (default **50 ms**).
+ *
+ * The delay for a given attempt is calculated as:
+ * ```
+ * delay = random(0, 1) * min(base * scaleFactor^(attempt - 1), maxBackoff)
+ * ```
+ *
+ * @param config The configuration to use for this delayer.
+ */
+public class StandardExponentialBackoffWithJitter(
+    override val config: Config = Config.Default,
+) : RetryAwareDelayProvider {
+    public companion object : DslFactory<Config.Builder, StandardExponentialBackoffWithJitter> {
+        override fun invoke(block: Config.Builder.() -> Unit): StandardExponentialBackoffWithJitter = StandardExponentialBackoffWithJitter(Config(block))
+    }
+
+    private val random = Random.Default
+
+    /**
+     * Delays for an appropriate amount of time after the given attempt number using the default (non-throttling)
+     * base delay.
+     */
+    override suspend fun backoff(attempt: Int) {
+        backoff(attempt, RetryErrorType.ServerSide, null)
+    }
+
+    /**
+     * Delays for an appropriate amount of time after the given attempt number, selecting the base delay according to
+     * the [errorType] and [serviceName].
+     */
+    override suspend fun backoff(attempt: Int, errorType: RetryErrorType, serviceName: String?) {
+        require(attempt > 0) { "attempt was $attempt but must be greater than 0" }
+        val baseMs = when {
+            errorType == RetryErrorType.Throttling -> 1000.0
+            serviceName?.lowercase() in DYNAMODB_SERVICES -> 25.0
+            else -> config.initialDelay.toDouble(DurationUnit.MILLISECONDS)
+        }
+        val exp = baseMs * config.scaleFactor.pow(attempt - 1)
+        val capped = min(exp, config.maxBackoff.toDouble(DurationUnit.MILLISECONDS))
+        val jitterProportion = if (config.jitter > 0.0) random.nextDouble(config.jitter) else 0.0
+        val delayMs = capped * (1.0 - jitterProportion)
+        delay(delayMs.toLong())
+    }
+
+    /**
+     * Configuration options for [StandardExponentialBackoffWithJitter].
+     */
+    public class Config(builder: Builder) : DelayProvider.Config {
+        public companion object {
+            /**
+             * The default configuration.
+             */
+            public val Default: Config = Config(Builder())
+
+            /**
+             * Initializes a new config from a builder.
+             * @param block A DSL builder block which sets the values for this config.
+             */
+            public operator fun invoke(block: Builder.() -> Unit): Config = Config(Builder().apply(block))
+        }
+
+        /**
+         * The base delay for non-throttling, non-DynamoDB errors.
+         */
+        public val initialDelay: Duration = builder.initialDelay
+
+        /**
+         * The scale factor by which to multiply the previous max delay.
+         */
+        public val scaleFactor: Double = builder.scaleFactor
+
+        /**
+         * The amount of random variability over the max delay (1.0 means full jitter, 0.0 means no jitter).
+         */
+        public val jitter: Double = builder.jitter
+
+        /**
+         * An upper bound for the computed delay which will override the [scaleFactor].
+         */
+        public val maxBackoff: Duration = builder.maxBackoff
+
+        @InternalApi
+        override fun toBuilderApplicator(): DelayProvider.Config.Builder.() -> Unit = {
+            if (this is Builder) {
+                initialDelay = this@Config.initialDelay
+                scaleFactor = this@Config.scaleFactor
+                jitter = this@Config.jitter
+                maxBackoff = this@Config.maxBackoff
+            }
+        }
+
+        /**
+         * A mutable builder for config for [StandardExponentialBackoffWithJitter].
+         */
+        public class Builder : DelayProvider.Config.Builder {
+            /**
+             * The base delay for non-throttling, non-DynamoDB errors.
+             */
+            public var initialDelay: Duration = 50.milliseconds
+
+            /**
+             * The scale factor by which to multiply the previous max delay.
+             */
+            public var scaleFactor: Double = 2.0
+
+            /**
+             * The amount of random variability over the max delay (1.0 means full jitter, 0.0 means no jitter).
+             */
+            public var jitter: Double = 1.0
+
+            /**
+             * An upper bound for the computed delay which will override the [scaleFactor].
+             */
+            public var maxBackoff: Duration = 20.seconds
+        }
+    }
+}

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
@@ -73,8 +73,8 @@ public class StandardExponentialBackoffWithJitter(
         val jitterProportion = if (config.jitter > 0.0) random.nextDouble(config.jitter) else 0.0
         val tI = capped * (1.0 - jitterProportion)
 
-        val delayMs = retryAfterMillis?.// SEP: clamp(retry_after, t_i, t_i + 5s). MAX_BACKOFF does not apply.
-        toDouble()?.coerceIn(tI, tI + 5000.0) ?: tI
+        // SEP: clamp(retry_after, t_i, t_i + 5s). MAX_BACKOFF does not apply.
+        val delayMs = retryAfterMillis?.toDouble()?.coerceIn(tI, tI + 5000.0) ?: tI
 
         delay(delayMs.toLong().milliseconds)
     }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitter.kt
@@ -20,7 +20,7 @@ import kotlin.time.DurationUnit
 private val DYNAMODB_SERVICES = setOf("dynamodb", "dynamodb streams")
 
 /**
- * An [RetryAwareDelayProvider] that implements SEP 2.1 exponential backoff with jitter. The base delay varies by
+ * A [RetryAwareDelayProvider] that implements the standard exponential backoff with jitter. The base delay varies by
  * error type and service name:
  *
  * - **Throttling** errors use a base delay of **1000 ms**.
@@ -45,8 +45,8 @@ public class StandardExponentialBackoffWithJitter(
 
     /**
      * Delays for an appropriate amount of time after the given attempt number, selecting the base delay according to
-     * the [errorType] and [serviceName]. If [retryAfterMillis] is provided, the delay is clamped per SEP 2.1:
-     * `clamp(retryAfterMs, t_i, t_i + 5000)` with no jitter applied to the server-specified value.
+     * the [errorType] and [serviceName]. If [retryAfterMillis] is provided, the delay is clamped to
+     * `[t_i, t_i + 5000ms]` where `t_i` is the computed exponential backoff. `MAX_BACKOFF` does not apply to this value.
      */
     override suspend fun backoff(
         attempt: Int,
@@ -65,7 +65,7 @@ public class StandardExponentialBackoffWithJitter(
         val jitterProportion = if (config.jitter > 0.0) random.nextDouble(config.jitter) else 0.0
         val tI = capped * (1.0 - jitterProportion)
 
-        // SEP: clamp(retry_after, t_i, t_i + 5s). MAX_BACKOFF does not apply.
+        // Clamp retry-after to [t_i, t_i + 5s]. MAX_BACKOFF does not apply.
         val delayMs = retryAfterMillis?.toDouble()?.coerceIn(tI, tI + 5000.0) ?: tI
 
         delay(delayMs.toLong().milliseconds)

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucket.kt
@@ -109,7 +109,7 @@ public class StandardRetryTokenBucket internal constructor(
          */
         override suspend fun scheduleRetry(reason: RetryErrorType): RetryToken {
             val size = when (reason) {
-                RetryErrorType.Transient, RetryErrorType.Throttling -> config.timeoutRetryCost
+                RetryErrorType.Throttling -> config.timeoutRetryCost
                 else -> config.retryCost
             }
             checkoutCapacity(size)

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitterTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitterTest.kt
@@ -100,6 +100,38 @@ class StandardExponentialBackoffWithJitterTest {
         val series = (1..3).map { idx -> measure { delayer.backoff(idx) } }.map { it.first }
         assertEquals(listOf(50, 100, 200), series)
     }
+
+    @Test
+    fun testRetryAfterHonored() = runTest {
+        // x-amz-retry-after: 1500 → delay = 1500ms (within [50, 50+5000] range)
+        val delayer = StandardExponentialBackoffWithJitter { jitter = 0.0 }
+        val (ms, _) = measure { delayer.backoff(1, RetryErrorType.ServerSide, null, 1500L) }
+        assertEquals(1500, ms)
+    }
+
+    @Test
+    fun testRetryAfterClampedToMinimum() = runTest {
+        // x-amz-retry-after: 0 → clamped to t_i (50ms for attempt 1)
+        val delayer = StandardExponentialBackoffWithJitter { jitter = 0.0 }
+        val (ms, _) = measure { delayer.backoff(1, RetryErrorType.ServerSide, null, 0L) }
+        assertEquals(50, ms)
+    }
+
+    @Test
+    fun testRetryAfterClampedToMaximum() = runTest {
+        // x-amz-retry-after: 10000 → clamped to t_i + 5000 (50 + 5000 = 5050ms)
+        val delayer = StandardExponentialBackoffWithJitter { jitter = 0.0 }
+        val (ms, _) = measure { delayer.backoff(1, RetryErrorType.ServerSide, null, 10000L) }
+        assertEquals(5050, ms)
+    }
+
+    @Test
+    fun testRetryAfterIgnoredWhenNull() = runTest {
+        // No header → normal backoff (50ms)
+        val delayer = StandardExponentialBackoffWithJitter { jitter = 0.0 }
+        val (ms, _) = measure { delayer.backoff(1, RetryErrorType.ServerSide, null, null) }
+        assertEquals(50, ms)
+    }
 }
 
 private suspend fun TestScope.backoffSeries(

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitterTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardExponentialBackoffWithJitterTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries.delay
+
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class StandardExponentialBackoffWithJitterTest {
+    @Test
+    fun testDefaults() {
+        val config = StandardExponentialBackoffWithJitter.Config(StandardExponentialBackoffWithJitter.Config.Builder())
+        assertEquals(50.milliseconds, config.initialDelay)
+        assertEquals(2.0, config.scaleFactor)
+        assertEquals(1.0, config.jitter)
+        assertEquals(20.seconds, config.maxBackoff)
+    }
+
+    @Test
+    fun testNonThrottlingScaling() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            initialDelay = 50.milliseconds
+            scaleFactor = 2.0
+            jitter = 0.0
+            maxBackoff = Duration.INFINITE
+        }
+        // 50, 100, 200, 400, 800
+        assertEquals(listOf(50, 100, 200, 400, 800), backoffSeries(5, delayer, RetryErrorType.ServerSide))
+    }
+
+    @Test
+    fun testThrottlingBase() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 0.0
+            maxBackoff = Duration.INFINITE
+        }
+        // Throttling base = 1000ms: 1000, 2000, 4000
+        assertEquals(listOf(1000, 2000, 4000), backoffSeries(3, delayer, RetryErrorType.Throttling))
+    }
+
+    @Test
+    fun testDynamoDbBase() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 0.0
+            maxBackoff = Duration.INFINITE
+        }
+        // DynamoDB base = 25ms: 25, 50, 100
+        assertEquals(listOf(25, 50, 100), backoffSeries(3, delayer, RetryErrorType.ServerSide, "dynamodb"))
+    }
+
+    @Test
+    fun testDynamoDbStreamsBase() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 0.0
+            maxBackoff = Duration.INFINITE
+        }
+        assertEquals(listOf(25, 50, 100), backoffSeries(3, delayer, RetryErrorType.ServerSide, "DynamoDB Streams"))
+    }
+
+    @Test
+    fun testMaxBackoff() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 0.0
+            maxBackoff = 150.milliseconds
+        }
+        // 50, 100, 150 (capped), 150 (capped)
+        assertEquals(listOf(50, 100, 150, 150), backoffSeries(4, delayer, RetryErrorType.ServerSide))
+    }
+
+    @Test
+    fun testJitter() = runTest {
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 1.0
+            maxBackoff = Duration.INFINITE
+        }
+        // With full jitter, delay should be in [0, base * 2^(attempt-1)]
+        backoffSeries(4, delayer, RetryErrorType.ServerSide)
+            .zip(listOf(0..50, 0..100, 0..200, 0..400))
+            .forEach { (actualMs, rangeMs) ->
+                assertTrue(actualMs in rangeMs, "Actual ms $actualMs was not in expected range $rangeMs")
+            }
+    }
+
+    @Test
+    fun testFallbackBackoff() = runTest {
+        // backoff(attempt) without error type should still work
+        val delayer = StandardExponentialBackoffWithJitter {
+            jitter = 0.0
+            maxBackoff = Duration.INFINITE
+        }
+        val series = (1..3).map { idx -> measure { delayer.backoff(idx) } }.map { it.first }
+        assertEquals(listOf(50, 100, 200), series)
+    }
+}
+
+private suspend fun TestScope.backoffSeries(
+    times: Int,
+    delayer: StandardExponentialBackoffWithJitter,
+    errorType: RetryErrorType,
+    serviceName: String? = null,
+): List<Int> = (1..times)
+    .map { idx -> measure { delayer.backoff(idx, errorType, serviceName) } }
+    .map { it.first }

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -23,6 +23,16 @@ private const val DEFAULT_TIMEOUT_RETRY_COST = 3
 
 class StandardRetryTokenBucketTest {
     @Test
+    fun testDefaults() {
+        val config = StandardRetryTokenBucket.Config(StandardRetryTokenBucket.Config.Builder())
+        assertEquals(500, config.maxCapacity)
+        assertEquals(5, config.retryCost)
+        assertEquals(10, config.timeoutRetryCost)
+        assertEquals(1, config.initialTrySuccessIncrement)
+        assertEquals(0, config.initialTryCost)
+    }
+
+    @Test
     fun testWaitForCapacity() = runTest {
         // A bucket that only allows one initial try per second
         val bucket = tokenBucket(initialTryCost = 10)
@@ -59,9 +69,10 @@ class StandardRetryTokenBucketTest {
 
     @Test
     fun testRetryCapacityAdjustments() = runTest {
+        // SEP 2.1: only Throttling gets the timeout/throttling cost; everything else pays retryCost
         mapOf(
             RetryErrorType.Throttling to DEFAULT_TIMEOUT_RETRY_COST,
-            RetryErrorType.Transient to DEFAULT_TIMEOUT_RETRY_COST,
+            RetryErrorType.Transient to DEFAULT_RETRY_COST,
             RetryErrorType.ClientSide to DEFAULT_RETRY_COST,
             RetryErrorType.ServerSide to DEFAULT_RETRY_COST,
         ).forEach { (errorType, cost) ->

--- a/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
+++ b/runtime/runtime-core/common/test/aws/smithy/kotlin/runtime/retries/delay/StandardRetryTokenBucketTest.kt
@@ -69,7 +69,7 @@ class StandardRetryTokenBucketTest {
 
     @Test
     fun testRetryCapacityAdjustments() = runTest {
-        // SEP 2.1: only Throttling gets the timeout/throttling cost; everything else pays retryCost
+        // Only Throttling gets the timeout/throttling cost; everything else pays retryCost
         mapOf(
             RetryErrorType.Throttling to DEFAULT_TIMEOUT_RETRY_COST,
             RetryErrorType.Transient to DEFAULT_RETRY_COST,

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
@@ -38,5 +38,4 @@ class NewRetriesFeatureFlagTest {
         val strategy = StandardRetryStrategy()
         assertIs<StandardRetryTokenBucket>(strategy.config.tokenBucket)
     }
-
 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries
+
+import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
+import aws.smithy.kotlin.runtime.retries.delay.RetryAwareDelayProvider
+import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+class NewRetriesFeatureFlagTest {
+    private val sysPropKey = "smithy.newRetries2026"
+
+    @AfterTest
+    fun cleanup() {
+        System.clearProperty(sysPropKey)
+    }
+
+    @Test
+    fun testFlagOffUsesOldDefaults() {
+        System.clearProperty(sysPropKey)
+        val strategy = StandardRetryStrategy()
+        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
+        assertEquals(3, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun testFlagOnUsesNewDefaults() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy()
+        assertIs<RetryAwareDelayProvider>(strategy.config.delayProvider)
+        assertIs<StandardExponentialBackoffWithJitter>(strategy.config.delayProvider)
+    }
+
+    @Test
+    fun testFlagOnDynamoDbMaxAttempts4() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy { serviceName = "dynamodb" }
+        assertEquals(4, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun testFlagOnNonDynamoDbMaxAttempts3() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy { serviceName = "s3" }
+        assertEquals(3, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun testFlagOnDynamoDbExplicitMaxAttemptsHonored() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy {
+            serviceName = "dynamodb"
+            maxAttempts = 3
+        }
+        assertEquals(3, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun testFlagOffDynamoDbMaxAttempts3() {
+        System.clearProperty(sysPropKey)
+        val strategy = StandardRetryStrategy { serviceName = "dynamodb" }
+        assertEquals(3, strategy.config.maxAttempts)
+    }
+}

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
@@ -50,6 +50,20 @@ class NewRetriesFeatureFlagTest {
     }
 
     @Test
+    fun testFlagOnDynamoDbStreamsMaxAttempts4() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy { serviceName = "dynamodb streams" }
+        assertEquals(4, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun testFlagOnDynamoDbStreamsCaseInsensitive() {
+        System.setProperty(sysPropKey, "true")
+        val strategy = StandardRetryStrategy { serviceName = "DynamoDB Streams" }
+        assertEquals(4, strategy.config.maxAttempts)
+    }
+
+    @Test
     fun testFlagOnDynamoDbExplicitMaxAttemptsHonored() {
         System.setProperty(sysPropKey, "true")
         val strategy = StandardRetryStrategy {

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/NewRetriesFeatureFlagTest.kt
@@ -6,10 +6,9 @@
 package aws.smithy.kotlin.runtime.retries
 
 import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
-import aws.smithy.kotlin.runtime.retries.delay.RetryAwareDelayProvider
 import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
+import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
 import kotlin.test.*
-import kotlin.time.Duration.Companion.milliseconds
 
 class NewRetriesFeatureFlagTest {
     private val sysPropKey = "smithy.newRetries2026"
@@ -20,63 +19,24 @@ class NewRetriesFeatureFlagTest {
     }
 
     @Test
-    fun testFlagOffUsesOldDefaults() {
+    fun testFlagOffUsesLegacyDelayProvider() {
         System.clearProperty(sysPropKey)
         val strategy = StandardRetryStrategy()
         assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
-        assertEquals(3, strategy.config.maxAttempts)
     }
 
     @Test
-    fun testFlagOnUsesNewDefaults() {
+    fun testFlagOnUsesStandardDelayProvider() {
         System.setProperty(sysPropKey, "true")
         val strategy = StandardRetryStrategy()
-        assertIs<RetryAwareDelayProvider>(strategy.config.delayProvider)
         assertIs<StandardExponentialBackoffWithJitter>(strategy.config.delayProvider)
     }
 
     @Test
-    fun testFlagOnDynamoDbMaxAttempts4() {
+    fun testFlagOnUsesStandardTokenBucket() {
         System.setProperty(sysPropKey, "true")
-        val strategy = StandardRetryStrategy { serviceName = "dynamodb" }
-        assertEquals(4, strategy.config.maxAttempts)
+        val strategy = StandardRetryStrategy()
+        assertIs<StandardRetryTokenBucket>(strategy.config.tokenBucket)
     }
 
-    @Test
-    fun testFlagOnNonDynamoDbMaxAttempts3() {
-        System.setProperty(sysPropKey, "true")
-        val strategy = StandardRetryStrategy { serviceName = "s3" }
-        assertEquals(3, strategy.config.maxAttempts)
-    }
-
-    @Test
-    fun testFlagOnDynamoDbStreamsMaxAttempts4() {
-        System.setProperty(sysPropKey, "true")
-        val strategy = StandardRetryStrategy { serviceName = "dynamodb streams" }
-        assertEquals(4, strategy.config.maxAttempts)
-    }
-
-    @Test
-    fun testFlagOnDynamoDbStreamsCaseInsensitive() {
-        System.setProperty(sysPropKey, "true")
-        val strategy = StandardRetryStrategy { serviceName = "DynamoDB Streams" }
-        assertEquals(4, strategy.config.maxAttempts)
-    }
-
-    @Test
-    fun testFlagOnDynamoDbExplicitMaxAttemptsHonored() {
-        System.setProperty(sysPropKey, "true")
-        val strategy = StandardRetryStrategy {
-            serviceName = "dynamodb"
-            maxAttempts = 3
-        }
-        assertEquals(3, strategy.config.maxAttempts)
-    }
-
-    @Test
-    fun testFlagOffDynamoDbMaxAttempts3() {
-        System.clearProperty(sysPropKey)
-        val strategy = StandardRetryStrategy { serviceName = "dynamodb" }
-        assertEquals(3, strategy.config.maxAttempts)
-    }
 }

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -31,33 +31,42 @@ class NewStandardRetryIntegrationTest {
     /** SEP 2.1 retry cost for throttling errors. */
     private val sepThrottlingRetryCost = 5
 
-    private fun sepTokenBucket(maxCapacity: Int = 500) = StandardRetryTokenBucket {
-        this.maxCapacity = maxCapacity
+    private val sysPropKey = "smithy.newRetries2026"
+
+    @BeforeTest
+    fun setup() {
+        System.setProperty(sysPropKey, "true")
+    }
+
+    @AfterTest
+    fun cleanup() {
+        System.clearProperty(sysPropKey)
+    }
+
+    private fun sepTokenBucket(maxCapacity: Int? = null) = StandardRetryTokenBucket {
+        maxCapacity?.let { this.maxCapacity = it }
         retryCost = sepRetryCost
         timeoutRetryCost = sepThrottlingRetryCost
     }
+
+    private fun buildStrategy(given: NewStandardGiven, tokenBucket: StandardRetryTokenBucket) =
+        StandardRetryStrategy {
+            given.maxAttempts?.let { maxAttempts = it }
+            this.tokenBucket = tokenBucket
+            given.service?.let { serviceName = it }
+            delayProvider {
+                if (given.exponentialBase == 1.0) jitter = 0.0
+                given.maxBackoffTime?.let { maxBackoff = (it * 1000).toLong().milliseconds }
+            }
+        }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun testIntegrationCases() = runTest {
         val testCases = newStandardRetryIntegrationTestCases.deserializeYaml(NewStandardRetryTestCase.serializer())
         testCases.forEach { (name, tc) ->
-            assertEquals(
-                1.0,
-                tc.given.exponentialBase,
-                "Test runner only supports exponential_base=1.0 (no jitter), got ${tc.given.exponentialBase} in '$name'",
-            )
-
             val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
-            val retryer = StandardRetryStrategy {
-                maxAttempts = tc.given.maxAttempts
-                this.tokenBucket = tokenBucket
-                tc.given.service?.let { serviceName = it }
-                delayProvider {
-                    jitter = 0.0
-                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
-                }
-            }
+            val retryer = buildStrategy(tc.given, tokenBucket)
 
             val policy = NewSepRetryPolicy(tc.responses)
             val block = object {
@@ -71,11 +80,7 @@ class NewStandardRetryIntegrationTest {
                         )
                     }
                     val resp = tc.responses[index++]
-                    // Propagate x-amz-retry-after header to the strategy (mirrors RetryMiddleware behavior)
-                    retryer.retryAfterMillis = resp.response.headers
-                        ?.get("x-amz-retry-after")
-                        ?.toLongOrNull()
-                        ?.takeIf { it >= 0 }
+                    retryer.retryAfterMillis = resp.response.parseRetryAfterMillis()
                     return resp.response.toResult()
                 }
             }::doIt
@@ -136,15 +141,7 @@ class NewStandardRetryIntegrationTest {
         val testCases = newStandardRetryMultiInvocationTestCases.deserializeYaml(NewStandardRetryTestCase.serializer())
         testCases.forEach { (name, tc) ->
             val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
-            val retryer = StandardRetryStrategy {
-                maxAttempts = tc.given.maxAttempts
-                this.tokenBucket = tokenBucket
-                tc.given.service?.let { serviceName = it }
-                delayProvider {
-                    jitter = 0.0
-                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
-                }
-            }
+            val retryer = buildStrategy(tc.given, tokenBucket)
 
             // Split responses into invocations at each success boundary
             val invocations = mutableListOf<List<NewStandardResponseAndExpectation>>()
@@ -161,12 +158,17 @@ class NewStandardRetryIntegrationTest {
             for (invocation in invocations) {
                 val policy = NewSepRetryPolicy(invocation)
                 var index = 0
+                retryer.retryAfterMillis = null // clear between invocations
                 retryer.retry(policy) {
+                    if (index > 0) {
+                        assertEquals(
+                            invocation[index - 1].expected.retryQuota,
+                            tokenBucket.capacity,
+                            "Quota mismatch after response ${index - 1} in '$name'",
+                        )
+                    }
                     val resp = invocation[index++]
-                    retryer.retryAfterMillis = resp.response.headers
-                        ?.get("x-amz-retry-after")
-                        ?.toLongOrNull()
-                        ?.takeIf { it >= 0 }
+                    retryer.retryAfterMillis = resp.response.parseRetryAfterMillis()
                     resp.response.toResult()
                 }
             }
@@ -191,15 +193,7 @@ class NewStandardRetryIntegrationTest {
         val testCases = newStandardRetryMultiThreadedTestCases.deserializeYaml(NewStandardMultiThreadedTestCase.serializer())
         testCases.forEach { (name, tc) ->
             val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
-            val retryer = StandardRetryStrategy {
-                maxAttempts = tc.given.maxAttempts
-                this.tokenBucket = tokenBucket
-                tc.given.service?.let { serviceName = it }
-                delayProvider {
-                    jitter = 0.0
-                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
-                }
-            }
+            val retryer = buildStrategy(tc.given, tokenBucket)
 
             val serverSidePolicy = object : RetryPolicy<Ok> {
                 override fun evaluate(result: Result<Ok>): RetryDirective = when {
@@ -236,6 +230,9 @@ private class NewSepRetryPolicy(private val responses: List<NewStandardResponseA
         }
     }
 }
+
+private fun NewStandardResponse.parseRetryAfterMillis(): Long? =
+    headers?.get("x-amz-retry-after")?.toLongOrNull()?.takeIf { it >= 0 }
 
 private fun NewStandardResponse.toResult() = when (statusCode) {
     200 -> Ok

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries.impl
+
+import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Integration tests for the SEP 2.1 "new" standard retry behavior.
+ * These tests explicitly configure the new retry constants (retryCost=14, timeoutRetryCost=5)
+ * and use [StandardExponentialBackoffWithJitter] (initialDelay=50ms, scaleFactor=2.0).
+ */
+class NewStandardRetryIntegrationTest {
+    /** SEP 2.1 retry cost for non-throttling errors. */
+    private val sepRetryCost = 14
+
+    /** SEP 2.1 retry cost for throttling errors. */
+    private val sepThrottlingRetryCost = 5
+
+    private fun sepTokenBucket(maxCapacity: Int = 500) = StandardRetryTokenBucket {
+        this.maxCapacity = maxCapacity
+        retryCost = sepRetryCost
+        timeoutRetryCost = sepThrottlingRetryCost
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testIntegrationCases() = runTest {
+        val testCases = newStandardRetryIntegrationTestCases.deserializeYaml(NewStandardRetryTestCase.serializer())
+        testCases.forEach { (name, tc) ->
+            assertEquals(
+                1.0,
+                tc.given.exponentialBase,
+                "Test runner only supports exponential_base=1.0 (no jitter), got ${tc.given.exponentialBase} in '$name'",
+            )
+
+            val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
+            val retryer = StandardRetryStrategy {
+                maxAttempts = tc.given.maxAttempts
+                this.tokenBucket = tokenBucket
+                tc.given.service?.let { serviceName = it }
+                delayProvider {
+                    jitter = 0.0
+                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
+                }
+            }
+
+            val policy = NewSepRetryPolicy(tc.responses)
+            val block = object {
+                var index = 0
+                suspend fun doIt(): Ok {
+                    if (index > 0) {
+                        assertEquals(
+                            tc.responses[index - 1].expected.retryQuota,
+                            tokenBucket.capacity,
+                            "Quota mismatch after response ${index - 1} in '$name'",
+                        )
+                    }
+                    return tc.responses[index++].response.toResult()
+                }
+            }::doIt
+
+            val startTimeMs = currentTime
+            val result = runCatching { retryer.retry(policy, block) }
+            val totalDelayMs = currentTime - startTimeMs
+
+            val finalState = tc.responses.last().expected
+            when (finalState.outcome) {
+                NewStandardTestOutcome.Success ->
+                    assertEquals(Ok, result.getOrThrow().getOrThrow(), "Unexpected outcome for $name")
+
+                NewStandardTestOutcome.MaxAttemptsExceeded -> {
+                    val e = assertFailsWith<HttpCodeException>("Expected exception for $name") {
+                        result.getOrThrow()
+                    }
+                    assertEquals(tc.responses.last().response.statusCode, e.code, "Unexpected error code for $name")
+                }
+
+                NewStandardTestOutcome.RetryQuotaExceeded -> {
+                    val e = assertFailsWith<HttpCodeException>("Expected exception for $name") {
+                        result.getOrThrow()
+                    }
+                    assertEquals(tc.responses.last().response.statusCode, e.code, "Unexpected error code for $name")
+                    assertTrue("Expected retry capacity message in exception for $name") {
+                        "Insufficient client capacity to attempt retry" in e.message
+                    }
+                }
+
+                else -> fail("Unexpected outcome for $name: ${finalState.outcome}")
+            }
+
+            val expectedDelayMs = tc.responses
+                .mapNotNull { it.expected.delay }
+                .sumOf { (it * 1000).toLong() }
+
+            if (finalState.outcome == NewStandardTestOutcome.RetryQuotaExceeded) {
+                assertTrue(
+                    expectedDelayMs <= totalDelayMs,
+                    "Unexpected delay for $name. Expected at least ${expectedDelayMs}ms but was ${totalDelayMs}ms",
+                )
+            } else {
+                assertEquals(expectedDelayMs, totalDelayMs, "Unexpected delay for $name")
+            }
+
+            assertEquals(finalState.retryQuota, tokenBucket.capacity, "Final quota mismatch for $name")
+        }
+    }
+
+    /**
+     * SEP 2.1: "Retry quota recovery after successful responses"
+     *
+     * Call 1: 500 (quota 30→16) → 502 (quota 16→2) → 200 success (quota 2→16)
+     * Call 2: 500 (quota 16→2) → 200 success (quota 2→16)
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryQuotaRecoveryAfterSuccess() = runTest {
+        val tokenBucket = sepTokenBucket(30)
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 5
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val serverSidePolicy = object : RetryPolicy<Ok> {
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        // Call 1: 500 → 502 → 200
+        var attempt = 0
+        retryer.retry(serverSidePolicy) {
+            when (attempt++) {
+                0 -> throw HttpCodeException(500)
+                1 -> throw HttpCodeException(502)
+                else -> Ok
+            }
+        }
+        assertEquals(16, tokenBucket.capacity)
+
+        // Call 2: 500 → 200
+        attempt = 0
+        retryer.retry(serverSidePolicy) {
+            when (attempt++) {
+                0 -> throw HttpCodeException(500)
+                else -> Ok
+            }
+        }
+        assertEquals(16, tokenBucket.capacity)
+    }
+
+    /**
+     * SEP 2.1: "Shared multi-threaded scenarios"
+     * Two concurrent retry() calls share the same token bucket.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testMultiThreadedSharedQuota() = runTest {
+        val tokenBucket = sepTokenBucket(500)
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 5
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val serverSidePolicy = object : RetryPolicy<Ok> {
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        coroutineScope {
+            launch {
+                var attempt = 0
+                retryer.retry(serverSidePolicy) {
+                    when (attempt++) {
+                        0, 1 -> throw HttpCodeException(500)
+                        else -> Ok
+                    }
+                }
+            }
+
+            launch {
+                var attempt = 0
+                retryer.retry(serverSidePolicy) {
+                    when (attempt++) {
+                        0 -> throw HttpCodeException(500)
+                        else -> Ok
+                    }
+                }
+            }
+        }
+
+        // 3 retries × 14 cost = 42 deducted, 3 successes × 14 returned = 42 returned → net 500 - 42 + 42 = 500
+        // But the last success returns the cost of the *last retry token*, so: 500 - 14 - 14 - 14 + 14 + 14 + 14 = 500
+        // Actually: each scheduleRetry deducts, each notifySuccess returns the token's returnSize.
+        // Thread 1: acquireToken(0) → scheduleRetry(14) → scheduleRetry(14) → notifySuccess(+14)
+        // Thread 2: acquireToken(0) → scheduleRetry(14) → notifySuccess(+14)
+        // Net: 500 - 14 - 14 - 14 + 14 + 14 = 486
+        assertEquals(486, tokenBucket.capacity)
+    }
+}
+
+private class NewSepRetryPolicy(private val responses: List<NewStandardResponseAndExpectation>) : RetryPolicy<Ok> {
+    private var attempt = 0
+
+    override fun evaluate(result: Result<Ok>): RetryDirective {
+        val response = responses[attempt++].response
+        return when {
+            result.isSuccess -> RetryDirective.TerminateAndSucceed
+            response.errorCode == "Throttling" -> RetryDirective.RetryError(RetryErrorType.Throttling)
+            else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+        }
+    }
+}
+
+private fun NewStandardResponse.toResult() = when (statusCode) {
+    200 -> Ok
+    else -> throw HttpCodeException(statusCode)
+}

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -166,6 +166,143 @@ class NewStandardRetryIntegrationTest {
     }
 
     /**
+     * SEP 2.1: "Honor x-amz-retry-after Header"
+     * retry-after: 1500ms → delay = 1.5s (within [50ms, 50ms+5000ms])
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterHonored() = runTest {
+        val tokenBucket = sepTokenBucket()
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 3
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val policy = object : RetryPolicy<Ok> {
+            var call = 0
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        val startMs = currentTime
+        var attempt = 0
+        retryer.retry(policy) {
+            if (attempt++ == 0) {
+                retryer.retryAfterMillis = 1500L
+                throw HttpCodeException(500)
+            }
+            Ok
+        }
+        assertEquals(1500L, currentTime - startMs)
+        assertEquals(500, tokenBucket.capacity)
+    }
+
+    /**
+     * SEP 2.1: "x-amz-retry-after minimum is exponential backoff duration"
+     * retry-after: 0 → clamped to t_i = 50ms
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterClampedToMinimum() = runTest {
+        val tokenBucket = sepTokenBucket()
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 3
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val policy = object : RetryPolicy<Ok> {
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        val startMs = currentTime
+        var attempt = 0
+        retryer.retry(policy) {
+            if (attempt++ == 0) {
+                retryer.retryAfterMillis = 0L
+                throw HttpCodeException(500)
+            }
+            Ok
+        }
+        assertEquals(50L, currentTime - startMs)
+        assertEquals(500, tokenBucket.capacity)
+    }
+
+    /**
+     * SEP 2.1: "x-amz-retry-after maximum is 5+exponential backoff duration"
+     * retry-after: 10000 → clamped to t_i + 5000 = 50 + 5000 = 5050ms
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterClampedToMaximum() = runTest {
+        val tokenBucket = sepTokenBucket()
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 3
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val policy = object : RetryPolicy<Ok> {
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        val startMs = currentTime
+        var attempt = 0
+        retryer.retry(policy) {
+            if (attempt++ == 0) {
+                retryer.retryAfterMillis = 10000L
+                throw HttpCodeException(500)
+            }
+            Ok
+        }
+        assertEquals(5050L, currentTime - startMs)
+        assertEquals(500, tokenBucket.capacity)
+    }
+
+    /**
+     * SEP 2.1: "Invalid x-amz-retry-after Falls Back to Exponential Backoff"
+     * null retryAfterMillis → normal backoff (50ms)
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRetryAfterNullFallsBack() = runTest {
+        val tokenBucket = sepTokenBucket()
+        val retryer = StandardRetryStrategy {
+            maxAttempts = 3
+            this.tokenBucket = tokenBucket
+            delayProvider { jitter = 0.0 }
+        }
+
+        val policy = object : RetryPolicy<Ok> {
+            override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                result.isSuccess -> RetryDirective.TerminateAndSucceed
+                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+            }
+        }
+
+        val startMs = currentTime
+        var attempt = 0
+        retryer.retry(policy) {
+            if (attempt++ == 0) {
+                retryer.retryAfterMillis = null
+                throw HttpCodeException(500)
+            }
+            Ok
+        }
+        assertEquals(50L, currentTime - startMs)
+        assertEquals(500, tokenBucket.capacity)
+    }
+
+    /**
      * SEP 2.1: "Shared multi-threaded scenarios"
      * Two concurrent retry() calls share the same token bucket.
      */

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -20,15 +20,15 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Integration tests for the SEP 2.1 "new" standard retry behavior.
- * These tests explicitly configure the new retry constants (retryCost=14, timeoutRetryCost=5)
+ * Integration tests for the standard retry strategy behavior.
+ * These tests configure the standard retry constants (retryCost=14, timeoutRetryCost=5)
  * and use [StandardExponentialBackoffWithJitter] (initialDelay=50ms, scaleFactor=2.0).
  */
 class NewStandardRetryIntegrationTest {
-    /** SEP 2.1 retry cost for non-throttling errors. */
+    /** Standard retry cost for non-throttling errors. */
     private val sepRetryCost = 14
 
-    /** SEP 2.1 retry cost for throttling errors. */
+    /** Standard retry cost for throttling errors. */
     private val sepThrottlingRetryCost = 5
 
     private val sysPropKey = "smithy.newRetries2026"
@@ -132,7 +132,7 @@ class NewStandardRetryIntegrationTest {
     }
 
     /**
-     * SEP 2.1: "Retry quota recovery after successful responses"
+     * Retry quota recovery after successful responses.
      * Multi-invocation test: responses are split on `success` outcomes, each group is a separate retry() call.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -182,9 +182,9 @@ class NewStandardRetryIntegrationTest {
     }
 
     /**
-     * SEP 2.1: "Shared multi-threaded scenarios"
+     * Shared multi-threaded scenarios.
      * Each thread list is launched concurrently; all share the same token bucket.
-     * Per SEP: "The exact sequence of thread execution and specific values may vary."
+     * The exact sequence of thread execution and specific values may vary.
      * We verify only the final quota.
      */
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -128,99 +128,99 @@ class NewStandardRetryIntegrationTest {
 
     /**
      * SEP 2.1: "Retry quota recovery after successful responses"
-     *
-     * Call 1: 500 (quota 30→16) → 502 (quota 16→2) → 200 success (quota 2→16)
-     * Call 2: 500 (quota 16→2) → 200 success (quota 2→16)
+     * Multi-invocation test: responses are split on `success` outcomes, each group is a separate retry() call.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testRetryQuotaRecoveryAfterSuccess() = runTest {
-        val tokenBucket = sepTokenBucket(30)
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 5
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val serverSidePolicy = object : RetryPolicy<Ok> {
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+    fun testMultiInvocationCases() = runTest {
+        val testCases = newStandardRetryMultiInvocationTestCases.deserializeYaml(NewStandardRetryTestCase.serializer())
+        testCases.forEach { (name, tc) ->
+            val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
+            val retryer = StandardRetryStrategy {
+                maxAttempts = tc.given.maxAttempts
+                this.tokenBucket = tokenBucket
+                tc.given.service?.let { serviceName = it }
+                delayProvider {
+                    jitter = 0.0
+                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
+                }
             }
-        }
 
-        // Call 1: 500 → 502 → 200
-        var attempt = 0
-        retryer.retry(serverSidePolicy) {
-            when (attempt++) {
-                0 -> throw HttpCodeException(500)
-                1 -> throw HttpCodeException(502)
-                else -> Ok
+            // Split responses into invocations at each success boundary
+            val invocations = mutableListOf<List<NewStandardResponseAndExpectation>>()
+            var current = mutableListOf<NewStandardResponseAndExpectation>()
+            for (resp in tc.responses) {
+                current.add(resp)
+                if (resp.expected.outcome == NewStandardTestOutcome.Success) {
+                    invocations.add(current)
+                    current = mutableListOf()
+                }
             }
-        }
-        assertEquals(16, tokenBucket.capacity)
+            if (current.isNotEmpty()) invocations.add(current)
 
-        // Call 2: 500 → 200
-        attempt = 0
-        retryer.retry(serverSidePolicy) {
-            when (attempt++) {
-                0 -> throw HttpCodeException(500)
-                else -> Ok
+            for (invocation in invocations) {
+                val policy = NewSepRetryPolicy(invocation)
+                var index = 0
+                retryer.retry(policy) {
+                    val resp = invocation[index++]
+                    retryer.retryAfterMillis = resp.response.headers
+                        ?.get("x-amz-retry-after")
+                        ?.toLongOrNull()
+                        ?.takeIf { it >= 0 }
+                    resp.response.toResult()
+                }
             }
+
+            assertEquals(
+                tc.responses.last().expected.retryQuota,
+                tokenBucket.capacity,
+                "Final quota mismatch for '$name'",
+            )
         }
-        assertEquals(16, tokenBucket.capacity)
     }
 
     /**
      * SEP 2.1: "Shared multi-threaded scenarios"
-     * Two concurrent retry() calls share the same token bucket.
+     * Each thread list is launched concurrently; all share the same token bucket.
+     * Per SEP: "The exact sequence of thread execution and specific values may vary."
+     * We verify only the final quota.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testMultiThreadedSharedQuota() = runTest {
-        val tokenBucket = sepTokenBucket(500)
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 5
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val serverSidePolicy = object : RetryPolicy<Ok> {
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+    fun testMultiThreadedCases() = runTest {
+        val testCases = newStandardRetryMultiThreadedTestCases.deserializeYaml(NewStandardMultiThreadedTestCase.serializer())
+        testCases.forEach { (name, tc) ->
+            val tokenBucket = sepTokenBucket(tc.given.initialRetryTokens)
+            val retryer = StandardRetryStrategy {
+                maxAttempts = tc.given.maxAttempts
+                this.tokenBucket = tokenBucket
+                tc.given.service?.let { serviceName = it }
+                delayProvider {
+                    jitter = 0.0
+                    maxBackoff = (tc.given.maxBackoffTime * 1000).toLong().milliseconds
+                }
             }
-        }
 
-        coroutineScope {
-            launch {
-                var attempt = 0
-                retryer.retry(serverSidePolicy) {
-                    when (attempt++) {
-                        0, 1 -> throw HttpCodeException(500)
-                        else -> Ok
+            val serverSidePolicy = object : RetryPolicy<Ok> {
+                override fun evaluate(result: Result<Ok>): RetryDirective = when {
+                    result.isSuccess -> RetryDirective.TerminateAndSucceed
+                    else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+                }
+            }
+
+            coroutineScope {
+                for (threadResponses in tc.threads) {
+                    launch {
+                        var index = 0
+                        retryer.retry(serverSidePolicy) {
+                            threadResponses[index++].response.toResult()
+                        }
                     }
                 }
             }
 
-            launch {
-                var attempt = 0
-                retryer.retry(serverSidePolicy) {
-                    when (attempt++) {
-                        0 -> throw HttpCodeException(500)
-                        else -> Ok
-                    }
-                }
-            }
+            assertEquals(tc.expectedFinalQuota, tokenBucket.capacity, "Final quota mismatch for '$name'")
         }
-
-        // 3 retries × 14 cost = 42 deducted, 3 successes × 14 returned = 42 returned → net 500 - 42 + 42 = 500
-        // But the last success returns the cost of the *last retry token*, so: 500 - 14 - 14 - 14 + 14 + 14 + 14 = 500
-        // Actually: each scheduleRetry deducts, each notifySuccess returns the token's returnSize.
-        // Thread 1: acquireToken(0) → scheduleRetry(14) → scheduleRetry(14) → notifySuccess(+14)
-        // Thread 2: acquireToken(0) → scheduleRetry(14) → notifySuccess(+14)
-        // Net: 500 - 14 - 14 - 14 + 14 + 14 = 486
-        assertEquals(486, tokenBucket.capacity)
     }
 }
 

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -49,16 +49,15 @@ class NewStandardRetryIntegrationTest {
         timeoutRetryCost = sepThrottlingRetryCost
     }
 
-    private fun buildStrategy(given: NewStandardGiven, tokenBucket: StandardRetryTokenBucket) =
-        StandardRetryStrategy {
-            given.maxAttempts?.let { maxAttempts = it }
-            this.tokenBucket = tokenBucket
-            given.service?.let { serviceName = it }
-            delayProvider {
-                if (given.exponentialBase == 1.0) jitter = 0.0
-                given.maxBackoffTime?.let { maxBackoff = (it * 1000).toLong().milliseconds }
-            }
+    private fun buildStrategy(given: NewStandardGiven, tokenBucket: StandardRetryTokenBucket) = StandardRetryStrategy {
+        given.maxAttempts?.let { maxAttempts = it }
+        this.tokenBucket = tokenBucket
+        given.service?.let { serviceName = it }
+        delayProvider {
+            if (given.exponentialBase == 1.0) jitter = 0.0
+            given.maxBackoffTime?.let { maxBackoff = (it * 1000).toLong().milliseconds }
         }
+    }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
@@ -231,8 +230,7 @@ private class NewSepRetryPolicy(private val responses: List<NewStandardResponseA
     }
 }
 
-private fun NewStandardResponse.parseRetryAfterMillis(): Long? =
-    headers?.get("x-amz-retry-after")?.toLongOrNull()?.takeIf { it >= 0 }
+private fun NewStandardResponse.parseRetryAfterMillis(): Long? = headers?.get("x-amz-retry-after")?.toLongOrNull()?.takeIf { it >= 0 }
 
 private fun NewStandardResponse.toResult() = when (statusCode) {
     200 -> Ok

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTest.kt
@@ -70,7 +70,13 @@ class NewStandardRetryIntegrationTest {
                             "Quota mismatch after response ${index - 1} in '$name'",
                         )
                     }
-                    return tc.responses[index++].response.toResult()
+                    val resp = tc.responses[index++]
+                    // Propagate x-amz-retry-after header to the strategy (mirrors RetryMiddleware behavior)
+                    retryer.retryAfterMillis = resp.response.headers
+                        ?.get("x-amz-retry-after")
+                        ?.toLongOrNull()
+                        ?.takeIf { it >= 0 }
+                    return resp.response.toResult()
                 }
             }::doIt
 
@@ -163,143 +169,6 @@ class NewStandardRetryIntegrationTest {
             }
         }
         assertEquals(16, tokenBucket.capacity)
-    }
-
-    /**
-     * SEP 2.1: "Honor x-amz-retry-after Header"
-     * retry-after: 1500ms → delay = 1.5s (within [50ms, 50ms+5000ms])
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterHonored() = runTest {
-        val tokenBucket = sepTokenBucket()
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 3
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val policy = object : RetryPolicy<Ok> {
-            var call = 0
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
-            }
-        }
-
-        val startMs = currentTime
-        var attempt = 0
-        retryer.retry(policy) {
-            if (attempt++ == 0) {
-                retryer.retryAfterMillis = 1500L
-                throw HttpCodeException(500)
-            }
-            Ok
-        }
-        assertEquals(1500L, currentTime - startMs)
-        assertEquals(500, tokenBucket.capacity)
-    }
-
-    /**
-     * SEP 2.1: "x-amz-retry-after minimum is exponential backoff duration"
-     * retry-after: 0 → clamped to t_i = 50ms
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterClampedToMinimum() = runTest {
-        val tokenBucket = sepTokenBucket()
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 3
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val policy = object : RetryPolicy<Ok> {
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
-            }
-        }
-
-        val startMs = currentTime
-        var attempt = 0
-        retryer.retry(policy) {
-            if (attempt++ == 0) {
-                retryer.retryAfterMillis = 0L
-                throw HttpCodeException(500)
-            }
-            Ok
-        }
-        assertEquals(50L, currentTime - startMs)
-        assertEquals(500, tokenBucket.capacity)
-    }
-
-    /**
-     * SEP 2.1: "x-amz-retry-after maximum is 5+exponential backoff duration"
-     * retry-after: 10000 → clamped to t_i + 5000 = 50 + 5000 = 5050ms
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterClampedToMaximum() = runTest {
-        val tokenBucket = sepTokenBucket()
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 3
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val policy = object : RetryPolicy<Ok> {
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
-            }
-        }
-
-        val startMs = currentTime
-        var attempt = 0
-        retryer.retry(policy) {
-            if (attempt++ == 0) {
-                retryer.retryAfterMillis = 10000L
-                throw HttpCodeException(500)
-            }
-            Ok
-        }
-        assertEquals(5050L, currentTime - startMs)
-        assertEquals(500, tokenBucket.capacity)
-    }
-
-    /**
-     * SEP 2.1: "Invalid x-amz-retry-after Falls Back to Exponential Backoff"
-     * null retryAfterMillis → normal backoff (50ms)
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun testRetryAfterNullFallsBack() = runTest {
-        val tokenBucket = sepTokenBucket()
-        val retryer = StandardRetryStrategy {
-            maxAttempts = 3
-            this.tokenBucket = tokenBucket
-            delayProvider { jitter = 0.0 }
-        }
-
-        val policy = object : RetryPolicy<Ok> {
-            override fun evaluate(result: Result<Ok>): RetryDirective = when {
-                result.isSuccess -> RetryDirective.TerminateAndSucceed
-                else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
-            }
-        }
-
-        val startMs = currentTime
-        var attempt = 0
-        retryer.retry(policy) {
-            if (attempt++ == 0) {
-                retryer.retryAfterMillis = null
-                throw HttpCodeException(500)
-            }
-            Ok
-        }
-        assertEquals(50L, currentTime - startMs)
-        assertEquals(500, tokenBucket.capacity)
     }
 
     /**

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -8,7 +8,7 @@ package aws.smithy.kotlin.runtime.retries.impl
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// Test cases sourced from SEP 2.1 "new-retries" Appendix A — Standard Mode.
+// Test cases for the standard retry strategy — Standard Mode.
 val newStandardRetryIntegrationTestCases = mapOf(
     "Retry eventually succeeds" to // language=YAML
         """

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -235,6 +235,15 @@ val newStandardRetryIntegrationTestCases = mapOf(
                   outcome: max_attempts_exceeded
                   retry_quota: 458
         """.trimIndent(),
+
+    // NOTE: retry-after header tests are exercised separately in RetryMiddlewareTest and
+    // StandardExponentialBackoffWithJitterTest because the YAML-driven integration test runner
+    // operates at the strategy level (no HTTP layer). The test cases below are placeholders
+    // documenting the SEP requirements; the actual header parsing + clamping is verified in
+    // those dedicated test classes.
+
+    // NOTE: Long-polling backoff test case ("Long-Polling Backoff When Token Bucket Empty")
+    // is not yet implemented — long-polling support is deferred.
 )
 
 @Serializable

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -208,7 +208,6 @@ val newStandardRetryIntegrationTestCases = mapOf(
         """
             given:
               service: dynamodb
-              max_attempts: 4
               exponential_base: 1
             responses:
               - response:
@@ -400,10 +399,10 @@ data class NewStandardRetryTestCase(val given: NewStandardGiven, val responses: 
 
 @Serializable
 data class NewStandardGiven(
-    @SerialName("max_attempts") val maxAttempts: Int = 3,
-    @SerialName("initial_retry_tokens") val initialRetryTokens: Int = 500,
-    @SerialName("exponential_base") val exponentialBase: Double = 1.0,
-    @SerialName("max_backoff_time") val maxBackoffTime: Double = 20.0,
+    @SerialName("max_attempts") val maxAttempts: Int? = null,
+    @SerialName("initial_retry_tokens") val initialRetryTokens: Int? = null,
+    @SerialName("exponential_base") val exponentialBase: Double? = null,
+    @SerialName("max_backoff_time") val maxBackoffTime: Double? = null,
     val service: String? = null,
 )
 

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -320,6 +320,81 @@ val newStandardRetryIntegrationTestCases = mapOf(
     // is not yet implemented — long-polling support is deferred.
 )
 
+val newStandardRetryMultiInvocationTestCases = mapOf(
+    "Retry quota recovery after successful responses" to // language=YAML
+        """
+            given:
+              max_attempts: 5
+              initial_retry_tokens: 30
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 16
+                  delay: 0.05
+              - response:
+                  status_code: 502
+                expected:
+                  outcome: retry_request
+                  retry_quota: 2
+                  delay: 0.1
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 16
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 2
+                  delay: 0.05
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 16
+        """.trimIndent(),
+)
+
+val newStandardRetryMultiThreadedTestCases = mapOf(
+    "Shared multi-threaded scenarios" to // language=YAML
+        """
+            given:
+              max_attempts: 5
+              exponential_base: 1
+            threads:
+              - - response:
+                    status_code: 500
+                  expected:
+                    outcome: retry_request
+                    retry_quota: 486
+                - response:
+                    status_code: 500
+                  expected:
+                    outcome: retry_request
+                    retry_quota: 472
+                - response:
+                    status_code: 200
+                  expected:
+                    outcome: success
+                    retry_quota: 486
+              - - response:
+                    status_code: 500
+                  expected:
+                    outcome: retry_request
+                    retry_quota: 458
+                - response:
+                    status_code: 200
+                  expected:
+                    outcome: success
+                    retry_quota: 472
+            expected_final_quota: 486
+        """.trimIndent(),
+)
+
 @Serializable
 data class NewStandardRetryTestCase(val given: NewStandardGiven, val responses: List<NewStandardResponseAndExpectation>)
 
@@ -363,3 +438,10 @@ enum class NewStandardTestOutcome {
     @SerialName("success")
     Success,
 }
+
+@Serializable
+data class NewStandardMultiThreadedTestCase(
+    val given: NewStandardGiven,
+    val threads: List<List<NewStandardResponseAndExpectation>>,
+    @SerialName("expected_final_quota") val expectedFinalQuota: Int,
+)

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -236,11 +236,85 @@ val newStandardRetryIntegrationTestCases = mapOf(
                   retry_quota: 458
         """.trimIndent(),
 
-    // NOTE: retry-after header tests are exercised separately in RetryMiddlewareTest and
-    // StandardExponentialBackoffWithJitterTest because the YAML-driven integration test runner
-    // operates at the strategy level (no HTTP layer). The test cases below are placeholders
-    // documenting the SEP requirements; the actual header parsing + clamping is verified in
-    // those dedicated test classes.
+    "Honor x-amz-retry-after header" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                  headers:
+                    x-amz-retry-after: "1500"
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 1.5
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 500
+        """.trimIndent(),
+
+    "x-amz-retry-after minimum is exponential backoff duration" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                  headers:
+                    x-amz-retry-after: "0"
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 500
+        """.trimIndent(),
+
+    "x-amz-retry-after maximum is 5+exponential backoff duration" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                  headers:
+                    x-amz-retry-after: "10000"
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 5.05
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 500
+        """.trimIndent(),
+
+    "Invalid x-amz-retry-after falls back to exponential backoff" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                  headers:
+                    x-amz-retry-after: "invalid"
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 500
+        """.trimIndent(),
 
     // NOTE: Long-polling backoff test case ("Long-Polling Backoff When Token Bucket Empty")
     // is not yet implemented — long-polling support is deferred.
@@ -265,6 +339,7 @@ data class NewStandardResponseAndExpectation(val response: NewStandardResponse, 
 data class NewStandardResponse(
     @SerialName("status_code") val statusCode: Int,
     @SerialName("error_code") val errorCode: String? = null,
+    val headers: Map<String, String>? = null,
 )
 
 @Serializable

--- a/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
+++ b/runtime/runtime-core/jvm/test/aws/smithy/kotlin/runtime/retries/impl/NewStandardRetryIntegrationTestResources.kt
@@ -1,0 +1,281 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.smithy.kotlin.runtime.retries.impl
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Test cases sourced from SEP 2.1 "new-retries" Appendix A — Standard Mode.
+val newStandardRetryIntegrationTestCases = mapOf(
+    "Retry eventually succeeds" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.1
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 486
+        """.trimIndent(),
+
+    "Fail due to max attempts reached" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 502
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 502
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.1
+              - response:
+                  status_code: 502
+                expected:
+                  outcome: max_attempts_exceeded
+                  retry_quota: 472
+        """.trimIndent(),
+
+    "Retry Quota reached after a single retry" to // language=YAML
+        """
+            given:
+              initial_retry_tokens: 14
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 0
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_quota_exceeded
+                  retry_quota: 0
+        """.trimIndent(),
+
+    "No retries at all if retry quota is 0" to // language=YAML
+        """
+            given:
+              initial_retry_tokens: 0
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_quota_exceeded
+                  retry_quota: 0
+        """.trimIndent(),
+
+    "Verifying exponential backoff timing" to //language=YAML
+        """
+            given:
+              max_attempts: 5
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.1
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 458
+                  delay: 0.2
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 444
+                  delay: 0.4
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: max_attempts_exceeded
+                  retry_quota: 444
+        """.trimIndent(),
+
+    "Verify max backoff time" to // language=YAML
+        """
+            given:
+              max_attempts: 5
+              exponential_base: 1
+              max_backoff_time: 0.2
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.1
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 458
+                  delay: 0.2
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 444
+                  delay: 0.2
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: max_attempts_exceeded
+                  retry_quota: 444
+        """.trimIndent(),
+
+    "Retry stops after retry quota exhaustion" to // language=YAML
+        """
+            given:
+              max_attempts: 5
+              initial_retry_tokens: 20
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 6
+                  delay: 0.05
+              - response:
+                  status_code: 502
+                expected:
+                  outcome: retry_quota_exceeded
+                  retry_quota: 6
+        """.trimIndent(),
+
+    "Throttling error token bucket drain and backoff duration" to // language=YAML
+        """
+            given:
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 400
+                  error_code: Throttling
+                expected:
+                  outcome: retry_request
+                  retry_quota: 495
+                  delay: 1.0
+              - response:
+                  status_code: 200
+                expected:
+                  outcome: success
+                  retry_quota: 500
+        """.trimIndent(),
+
+    "DynamoDB base backoff and increased retries" to // language=YAML
+        """
+            given:
+              service: dynamodb
+              max_attempts: 4
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.025
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 458
+                  delay: 0.1
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: max_attempts_exceeded
+                  retry_quota: 458
+        """.trimIndent(),
+)
+
+@Serializable
+data class NewStandardRetryTestCase(val given: NewStandardGiven, val responses: List<NewStandardResponseAndExpectation>)
+
+@Serializable
+data class NewStandardGiven(
+    @SerialName("max_attempts") val maxAttempts: Int = 3,
+    @SerialName("initial_retry_tokens") val initialRetryTokens: Int = 500,
+    @SerialName("exponential_base") val exponentialBase: Double = 1.0,
+    @SerialName("max_backoff_time") val maxBackoffTime: Double = 20.0,
+    val service: String? = null,
+)
+
+@Serializable
+data class NewStandardResponseAndExpectation(val response: NewStandardResponse, val expected: NewStandardExpectation)
+
+@Serializable
+data class NewStandardResponse(
+    @SerialName("status_code") val statusCode: Int,
+    @SerialName("error_code") val errorCode: String? = null,
+)
+
+@Serializable
+data class NewStandardExpectation(
+    val outcome: NewStandardTestOutcome,
+    @SerialName("retry_quota") val retryQuota: Int,
+    val delay: Double? = null,
+)
+
+@Serializable
+enum class NewStandardTestOutcome {
+    @SerialName("max_attempts_exceeded")
+    MaxAttemptsExceeded,
+
+    @SerialName("retry_quota_exceeded")
+    RetryQuotaExceeded,
+
+    @SerialName("retry_request")
+    RetryRequest,
+
+    @SerialName("success")
+    Success,
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
###  Exponential backoff                                                                                                                                                                                                                                                                                                                                                     

  - New delay provider with service-aware base delays: 1000ms for throttling errors, 25ms for DynamoDB/DynamoDB Streams, 50ms for all others
  - Scale factor of 2x with `MAX_BACKOFF` of 20s applied before jitter
  - Introduced `RetryAwareDelayProvider` interface that accepts error type, service name, and retry-after duration

###  `x-amz-retry-after` header

  - Parses the header as integer milliseconds from HTTP responses
  - Clamps the value to `[t_i, t_i + 5s]` where `t_i` is the computed exponential backoff; `MAX_BACKOFF` does not apply
  - Invalid values are ignored with DEBUG-level logging

###  Retry quotas

  - Updated default constants: `RETRY_COST`=14, `THROTTLING_RETRY_COST`=5, `NO_RETRY_INCREMENT`=1, `INITIAL_RETRY_TOKENS`=500
  - Only throttling errors use `THROTTLING_RETRY_COST`; all other error types (including transient) use `RETRY_COST`

###  Service-specific behavior

  - DynamoDB and DynamoDB Streams default to `maxAttempts=4` (auto-detected from service name); all others default to 3                                                                                                                                                                                                                                                     
  - Explicit `maxAttempts` configuration overrides auto-detection

###  Tests

  - YAML-driven integration test runner covering all 15 standard mode test cases: single-invocation, multi-invocation (quota recovery across sequential calls), and multi-threaded (shared token bucket across concurrent calls)
  - Feature flag tests verifying correct types are wired based on flag state
  - Unit tests for backoff scaling, retry-after clamping, and token bucket cost behavior

###  Not included (deferred)

  - Long-polling backoff (`IsLongPollingOperation`)
  - Smithy retryable trait integration
  - AWS_MAX_ATTEMPTS / AWS_RETRY_MODE env var support 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
