### PR TITLE
chore: add test filesystem capabilities

### DIFF
--- a/.changes/50e86c30-b130-4a18-afe6-b57de5017511.json
+++ b/.changes/50e86c30-b130-4a18-afe6-b57de5017511.json
@@ -1,0 +1,5 @@
+{
+    "id": "50e86c30-b130-4a18-afe6-b57de5017511",
+    "type": "feature",
+    "description": "⚠️ **IMPORTANT**: Now writes cached auth files with `600` permissions on POSIX OSes"
+}

--- a/.changes/50e86c30-b130-4a18-afe6-b57de5017511.json
+++ b/.changes/50e86c30-b130-4a18-afe6-b57de5017511.json
@@ -1,5 +1,0 @@
-{
-    "id": "50e86c30-b130-4a18-afe6-b57de5017511",
-    "type": "feature",
-    "description": "⚠️ **IMPORTANT**: Now writes cached auth files with `600` permissions on POSIX OSes"
-}

--- a/runtime/runtime-core/api/runtime-core.api
+++ b/runtime/runtime-core/api/runtime-core.api
@@ -2441,6 +2441,8 @@ public abstract interface class aws/smithy/kotlin/runtime/util/Filesystem {
 public final class aws/smithy/kotlin/runtime/util/Filesystem$Companion {
 	public final fun fromMap (Ljava/util/Map;Ljava/lang/String;)Laws/smithy/kotlin/runtime/util/Filesystem;
 	public static synthetic fun fromMap$default (Laws/smithy/kotlin/runtime/util/Filesystem$Companion;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/util/Filesystem;
+	public final fun fromMapStringTestFile (Ljava/util/Map;Ljava/lang/String;)Laws/smithy/kotlin/runtime/util/Filesystem;
+	public static synthetic fun fromMapStringTestFile$default (Laws/smithy/kotlin/runtime/util/Filesystem$Companion;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/util/Filesystem;
 }
 
 public final class aws/smithy/kotlin/runtime/util/Filesystem$DefaultImpls {
@@ -2485,6 +2487,26 @@ public abstract interface class aws/smithy/kotlin/runtime/util/LazyAsyncValue {
 
 public final class aws/smithy/kotlin/runtime/util/LazyAsyncValueKt {
 	public static final fun asyncLazy (Lkotlin/jvm/functions/Function1;)Laws/smithy/kotlin/runtime/util/LazyAsyncValue;
+}
+
+public final class aws/smithy/kotlin/runtime/util/MapFilesystem : aws/smithy/kotlin/runtime/util/Filesystem {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun atomicMove (Ljava/lang/String;Ljava/lang/String;ZZ)V
+	public fun createDir (Ljava/lang/String;Z)V
+	public fun delete (Ljava/lang/String;Z)V
+	public fun exists (Ljava/lang/String;)Z
+	public fun fileExists (Ljava/lang/String;)Z
+	public fun getFilePathSeparator ()Ljava/lang/String;
+	public final fun getFilePermissions (Ljava/lang/String;)Ljava/lang/String;
+	public fun list (Ljava/lang/String;Z)Ljava/util/Collection;
+	public fun read (Ljava/lang/String;JJZ)[B
+	public fun readFileOrNull (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun readOrNull (Ljava/lang/String;JJZZ)[B
+	public fun size (Ljava/lang/String;Z)J
+	public fun write (Ljava/lang/String;[BLaws/smithy/kotlin/runtime/util/WriteType;ZLjava/lang/String;)V
+	public fun writeFile (Ljava/lang/String;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class aws/smithy/kotlin/runtime/util/OperatingSystem {
@@ -2562,9 +2584,25 @@ public final class aws/smithy/kotlin/runtime/util/SingleFlightGroup {
 	public final fun singleFlight (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class aws/smithy/kotlin/runtime/util/TestFile {
+	public static final field Companion Laws/smithy/kotlin/runtime/util/TestFile$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ([BLjava/lang/String;)V
+	public synthetic fun <init> ([BLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getContents ()[B
+	public final fun getPermissions ()Ljava/lang/String;
+}
+
+public final class aws/smithy/kotlin/runtime/util/TestFile$Companion {
+	public final fun transformMapStringByteArray (Ljava/util/Map;)Ljava/util/Map;
+	public final fun transformMapStringString (Ljava/util/Map;)Ljava/util/Map;
+}
+
 public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider : aws/smithy/kotlin/runtime/util/Filesystem, aws/smithy/kotlin/runtime/util/PlatformProvider {
 	public static final field Companion Laws/smithy/kotlin/runtime/util/TestPlatformProvider$Companion;
 	public fun <init> ()V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/Filesystem;Laws/smithy/kotlin/runtime/util/OperatingSystem;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;)V
 	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun atomicMove (Ljava/lang/String;Ljava/lang/String;ZZ)V
@@ -2575,6 +2613,7 @@ public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider : aws/smi
 	public fun getAllEnvVars ()Ljava/util/Map;
 	public fun getAllProperties ()Ljava/util/Map;
 	public fun getFilePathSeparator ()Ljava/lang/String;
+	public final fun getFs ()Laws/smithy/kotlin/runtime/util/Filesystem;
 	public fun getProperty (Ljava/lang/String;)Ljava/lang/String;
 	public fun getenv (Ljava/lang/String;)Ljava/lang/String;
 	public fun isAndroid ()Z
@@ -2593,6 +2632,8 @@ public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider : aws/smi
 }
 
 public final class aws/smithy/kotlin/runtime/util/TestPlatformProvider$Companion {
+	public final fun of (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;)Laws/smithy/kotlin/runtime/util/TestPlatformProvider;
+	public static synthetic fun of$default (Laws/smithy/kotlin/runtime/util/TestPlatformProvider$Companion;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Laws/smithy/kotlin/runtime/util/OperatingSystem;ILjava/lang/Object;)Laws/smithy/kotlin/runtime/util/TestPlatformProvider;
 }
 
 public final class aws/smithy/kotlin/runtime/util/Uuid {

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Filesystem.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/Filesystem.kt
@@ -5,14 +5,17 @@
 
 package aws.smithy.kotlin.runtime.util
 
+import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.io.IOException
 import kotlinx.io.files.FileNotFoundException
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemPathSeparator
 import okio.Path.Companion.toPath
 import okio.SYSTEM
 import okio.buffer
 import okio.use
+import kotlin.jvm.JvmName
 import okio.FileSystem as OkioFileSystem
 
 /**
@@ -60,7 +63,7 @@ public interface Filesystem {
      * @param data the bytes to write
      * @param writeType the write strategy: [WriteType.OVERWRITE] to replace file contents,
      * [WriteType.APPEND] to add to the end, or [WriteType.OFFSET] to write at a specific byte position
-     * @param mustExist if true, throws [aws.smithy.kotlin.runtime.io.IOException] when the file does not exist
+     * @param mustExist if true, throws [IOException] when the file does not exist
      * @param permissions optional POSIX file permissions as an octal string to apply when the file is created
      * (e.g., `"600"` for owner read/write only). Ignored if the file already exists or the platform does not
      * support POSIX permissions (e.g., Windows).
@@ -73,7 +76,7 @@ public interface Filesystem {
      * @param source fully qualified path of the file to move
      * @param destination fully qualified path of the target location
      * @param mustExist if true, throws [FileNotFoundException] when [source] does not exist
-     * @param overwrite if false, throws [aws.smithy.kotlin.runtime.io.IOException] when [destination] already exists
+     * @param overwrite if false, throws [IOException] when [destination] already exists
      */
     public fun atomicMove(source: String, destination: String, mustExist: Boolean = true, overwrite: Boolean = false) {
         if (!exists(source) && mustExist) {
@@ -123,7 +126,7 @@ public interface Filesystem {
      * @param path fully qualified path of the file
      * @param mustExist if true, throws [FileNotFoundException] when [path] does not exist
      * @return the file size in bytes
-     * @throws [aws.smithy.kotlin.runtime.io.IOException] if the size cannot be determined
+     * @throws [IOException] if the size cannot be determined
      */
     public fun size(path: String, mustExist: Boolean = true): Long {
         if (!exists(path) && mustExist) {
@@ -201,7 +204,20 @@ public interface Filesystem {
         /**
          * Construct a fake filesystem from a mapping of paths to contents
          */
-        public fun fromMap(data: Map<String, ByteArray>, filePathSeparator: String = "/"): Filesystem = MapFilesystem(data.toMutableMap(), filePathSeparator)
+        // TODO deprecate
+        public fun fromMap(data: Map<String, ByteArray>, filePathSeparator: String = "/"): Filesystem = MapFilesystem(
+            TestFile.transformMap(data).toMutableMap(),
+            filePathSeparator,
+        )
+
+        /**
+         * Construct a fake filesystem from a mapping of paths to contents
+         */
+        @JvmName("fromMapStringTestFile")
+        public fun fromMap(data: Map<String, TestFile>, filePathSeparator: String = "/"): Filesystem = MapFilesystem(
+            data.toMutableMap(),
+            filePathSeparator,
+        )
     }
 }
 
@@ -225,14 +241,14 @@ public sealed class WriteType {
     public data class OFFSET(public val offset: Long) : WriteType()
 }
 
-internal class MapFilesystem(
-    private val memFs: MutableMap<String, ByteArray>,
-    override val filePathSeparator: String,
+@InternalApi
+public class MapFilesystem(
+    private val memFs: MutableMap<String, TestFile> = mutableMapOf(),
+    override val filePathSeparator: String = SystemPathSeparator.toString(),
 ) : Filesystem {
-    override suspend fun readFileOrNull(path: String): ByteArray? = memFs[path]
-    override suspend fun writeFile(path: String, data: ByteArray) {
-        memFs[path] = data
-    }
+    override suspend fun readFileOrNull(path: String): ByteArray? = memFs[path]?.contents
+    override suspend fun writeFile(path: String, data: ByteArray): Unit = write(path, data, WriteType.OVERWRITE)
+
     override fun fileExists(path: String): Boolean = memFs[path] != null
     override fun write(
         path: String,
@@ -244,16 +260,24 @@ internal class MapFilesystem(
         if (memFs[path] == null && mustExist) {
             throw FileNotFoundException("$path does not exist and mustExist is set to true")
         }
-        when (writeType) {
+
+        val existing = memFs[path] ?: TestFile(byteArrayOf())
+
+        val newData = when (writeType) {
             is WriteType.OFFSET -> {
-                val existing = memFs[path] ?: ByteArray(0)
-                val end = (writeType.offset.toInt() + data.size)
-                val result = existing.copyOf(newSize = maxOf(existing.size, end))
+                val end = writeType.offset.toInt() + data.size
+                val result = existing.contents.copyOf(newSize = maxOf(existing.contents.size, end))
                 data.copyInto(result, destinationOffset = writeType.offset.toInt())
-                memFs[path] = result
+                result
             }
-            is WriteType.APPEND -> memFs[path] = memFs[path]?.let { it + data } ?: data
-            is WriteType.OVERWRITE -> memFs[path] = data
+            is WriteType.APPEND -> existing.contents + data
+            is WriteType.OVERWRITE -> data
         }
+
+        val newPermissions = permissions ?: existing.permissions
+        memFs[path] = TestFile(newData, newPermissions)
     }
+
+    @InternalApi
+    public fun getFilePermissions(path: String): String = memFs.getValue(path).permissions ?: ""
 }

--- a/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/TestPlatformProvider.kt
+++ b/runtime/runtime-core/common/src/aws/smithy/kotlin/runtime/util/TestPlatformProvider.kt
@@ -6,6 +6,7 @@
 package aws.smithy.kotlin.runtime.util
 
 import aws.smithy.kotlin.runtime.InternalApi
+import kotlin.jvm.JvmName
 
 /**
  * An implementation of [PlatformProvider] meant for testing
@@ -15,15 +16,35 @@ import aws.smithy.kotlin.runtime.InternalApi
  * @param os Operating system info to emulate
  */
 @InternalApi
-public class TestPlatformProvider(
+public class TestPlatformProvider
+private constructor(
     env: Map<String, String> = emptyMap(),
     private val props: Map<String, String> = emptyMap(),
-    private val fs: Map<String, String> = emptyMap(),
+    public val fs: Filesystem = MapFilesystem(),
     private val os: OperatingSystem = OperatingSystem(OsFamily.Linux, "test"),
 ) : PlatformProvider,
-    Filesystem by Filesystem.fromMap(fs.mapValues { it.value.encodeToByteArray() }) {
+    Filesystem by fs {
 
-    public companion object;
+    // TODO deprecate
+    public constructor() : this(emptyMap(), emptyMap(), MapFilesystem(), OperatingSystem(OsFamily.Linux, "test"))
+
+    // TODO deprecate
+    public constructor(
+        env: Map<String, String> = emptyMap(),
+        props: Map<String, String> = emptyMap(),
+        fs: Map<String, String> = emptyMap(),
+        os: OperatingSystem = OperatingSystem(OsFamily.Linux, "test"),
+    ) : this(env, props, MapFilesystem(TestFile.transformMap(fs).toMutableMap()), os)
+
+    @InternalApi
+    public companion object {
+        public fun of(
+            env: Map<String, String> = emptyMap(),
+            props: Map<String, String> = emptyMap(),
+            fs: Map<String, TestFile> = emptyMap(),
+            os: OperatingSystem = OperatingSystem(OsFamily.Linux, "test"),
+        ): TestPlatformProvider = TestPlatformProvider(env, props, MapFilesystem(fs.toMutableMap()), os)
+    }
 
     // ensure HOME directory is set for path normalization. this is mostly for AWS config loader behavior
     private val env = if (env.containsKey("HOME")) env else env.toMutableMap().apply { put("HOME", "/users/test") }
@@ -43,4 +64,22 @@ public class TestPlatformProvider(
     override fun getProperty(key: String): String? = props[key]
     override fun getAllEnvVars(): Map<String, String> = env
     override fun getenv(key: String): String? = env[key]
+}
+
+@InternalApi
+public class TestFile(public val contents: ByteArray, public val permissions: String? = null) {
+    @InternalApi
+    public companion object {
+        @JvmName("transformMapStringByteArray")
+        public fun transformMap(
+            pathsToContents: Map<String, ByteArray>,
+        ): Map<String, TestFile> = pathsToContents.mapValues { (_, contents) -> TestFile(contents) }
+
+        @JvmName("transformMapStringString")
+        public fun transformMap(
+            pathsToContents: Map<String, String>,
+        ): Map<String, TestFile> = pathsToContents.mapValues { (_, contents) -> TestFile(contents) }
+    }
+
+    public constructor(contents: String, permissions: String? = null) : this(contents.encodeToByteArray(), permissions)
 }


### PR DESCRIPTION
## Description of changes

This change adds some new capabilities to `TestPlatformProvider` to facilitate verifying permissions on files in unit tests.

**Downstream PR**: https://github.com/aws/aws-sdk-kotlin/pull/1877

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
