### PR TITLE
fix: erase empty file if setting permissions fails

### DIFF
--- a/.changes/669afdfa-3db5-4436-b029-e46bc508aa18.json
+++ b/.changes/669afdfa-3db5-4436-b029-e46bc508aa18.json
@@ -1,0 +1,5 @@
+{
+    "id": "669afdfa-3db5-4436-b029-e46bc508aa18",
+    "type": "bugfix",
+    "description": "Erase empty file if setting permissions fails"
+}

--- a/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderJVM.kt
+++ b/runtime/runtime-core/jvm/src/aws/smithy/kotlin/runtime/util/SystemDefaultProviderJVM.kt
@@ -65,7 +65,18 @@ internal actual object SystemDefaultProvider : PlatformProvider {
 
         if (creating && permissions != null && osInfo().family != OsFamily.Windows) {
             file.createNewFile()
-            Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString(permissions.toPermissionString()))
+
+            try {
+                Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString(permissions.toPermissionString()))
+            } catch (permissionsException: Throwable) {
+                try {
+                    file.delete()
+                } catch (deleteException: Throwable) {
+                    permissionsException.addSuppressed(deleteException)
+                }
+
+                throw permissionsException
+            }
         }
 
         when (writeType) {


### PR DESCRIPTION
## Description of changes

When we create a new file but _fail_ to set its permissions, we should delete the empty file (if we can) before throwing the error to the caller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
